### PR TITLE
fixing binder

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,4 @@
-git+git://github.com/jacobjma/abTEM@master#egg=abTEM
+git+https://github.com/jacobjma/abTEM@master#egg=abTEM
 bqplot
 bqplot-image-gl
 


### PR DESCRIPTION
Binder recipe doesn't build currently. This seems to fix it, not sure if you want to point at your repository or the abTEM version.
```
git+https://github.com/abTEM/abTEM@master#egg=abTEM
```