### PR TITLE
Attempt 2: TypeError fix [iam.py]

### DIFF
--- a/abtem/potentials/iam.py
+++ b/abtem/potentials/iam.py
@@ -1392,7 +1392,7 @@ class CrystalPotential(_PotentialBuilder):
                 else:
                     seeds = None
 
-                array.itemset(i, (potential_unit, self.seeds[start:stop]))
+                array.itemset(i, (potential_unit, self.seeds))
 
         return (array,)
 


### PR DESCRIPTION
Fixes a TypeError that occurs when calling CrystalPotential, with the default seeds parameter.

In this updated commit, it is done by simply removing the slicing in line 1395.

This is attempt 2, because my commits on the first pull request got messy. Sorry!

Issue link:
https://github.com/abTEM/abTEM/issues/108