### PR TITLE
Fixing assert with cupy backend and changing package requirements for optional dependency "docs"

### DIFF
--- a/abtem/transform.py
+++ b/abtem/transform.py
@@ -348,7 +348,8 @@ class ArrayObjectTransform(
             assert isinstance(new_array, tuple)
             return self._pack_multiple_outputs(array_object, new_array)
         else:
-            assert isinstance(new_array, np.ndarray)
+            xp = get_array_module(new_array)
+            assert isinstance(new_array, xp.ndarray)
             return self._pack_single_output(array_object, new_array)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,8 +55,6 @@ testing =
 docs =
     jupyter-book
     sphinx_autodoc_typehints
-    pydata-sphinx-theme
-    sphinx-book-theme
 
 gpu =
     cupy

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,8 +55,8 @@ testing =
 docs =
     jupyter-book
     sphinx_autodoc_typehints
-    pydata-sphinx-theme<=0.8.99
-    sphinx-book-theme==0.3.3
+    pydata-sphinx-theme
+    sphinx-book-theme
 
 gpu =
     cupy


### PR DESCRIPTION
Hi @jacobjma and @TomaSusi!

I have started to play around with abTEM in more detail this week and ran into two issues, which I believe are fixed by the two changes I propose here. They are really small, so I am not sure if it is even worth to create a PR, but I thought it is maybe a chance to try out collaborating on *ab*TEM.

The issues I aim to fix with these changes are the following:

1. When installing the development dependencies using `pip install -e .[extra,dev,testing,docs]`, pip failed to satisfy all dependencies and I could not install the documentation related dependencies. Removing packages `pydata-sphinx-theme` and `sphinx-book-theme` from `setup.cfg` in accordance with the commit https://github.com/abTEM/doc/commit/418d36f353173bfe76132024ee28663de6d643d3 in the *ab*TEM doc repo solved the issue for me. I tested that I can successfully build the documentation from the *ab*TEM doc repo using `jb build .`.

2. When using a GPU device with the most recent commits in the `main` branch, I run into the error
``` bash
Traceback (most recent call last):
  File "/cfs/klemming/projects/supr/eelsetal/projects/2024_vortex_test/fpms.py", line 79, in <module>
    measurements_phonon = probe.scan(potential_phonon, scan=scan, detectors=detectors).to_zarr('measurement.zarr')
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cfs/klemming/projects/supr/eelsetal/python_venvs/abtem/lib/python3.11/site-packages/abtem/array.py", line 181, in to_zarr
    output = dask.compute(computables, **kwargs)[0]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cfs/klemming/projects/supr/eelsetal/python_venvs/abtem/lib/python3.11/site-packages/dask/base.py", line 660, in compute
    results = schedule(dsk, keys, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cfs/klemming/projects/supr/eelsetal/python_venvs/abtem/lib/python3.11/site-packages/abtem/waves.py", line 1714, in _build_waves
    waves = waves.apply_transform(waves_builder.aperture)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cfs/klemming/projects/supr/eelsetal/python_venvs/abtem/lib/python3.11/site-packages/abtem/array.py", line 1455, in apply_transform
    eager_outputs = transform._apply(self)
                    ^^^^^^^^^^^^^^^^^^^^^^
  File "/cfs/klemming/projects/supr/eelsetal/python_venvs/abtem/lib/python3.11/site-packages/abtem/transform.py", line 351, in _apply
    assert isinstance(new_array, np.ndarray)
AssertionError
```
The second commit aims to fix this error by asserting that `new_array` is an instance of xp.ndarray, where xp is either numpy or cupy and determined on the fly as in other parts of the abtem code.

Looking forward to your comments and to see if these modifications are in line with your ideas/goals.