### PR TITLE
3d plots for atoms and potentials

### DIFF
--- a/abtem/__init__.py
+++ b/abtem/__init__.py
@@ -26,7 +26,7 @@ from abtem.potentials.iam import CrystalPotential, Potential, PotentialArray
 from abtem.prism.s_matrix import SMatrix, SMatrixArray
 from abtem.scan import CustomScan, GridScan, LineScan
 from abtem.transfer import CTF, Aperture, SpatialEnvelope, TemporalEnvelope
-from abtem.visualize.visualizations import show_atoms
+from abtem.visualize.visualizations import show_atoms, show_atoms3d
 from abtem.waves import PlaneWave, Probe, Waves
 
 __all__ = [
@@ -65,6 +65,7 @@ __all__ = [
     "TemporalEnvelope",
     "SpatialEnvelope",
     "show_atoms",
+    "show_atoms3d",
     "Waves",
     "Probe",
     "PlaneWave",

--- a/abtem/visualize/__init__.py
+++ b/abtem/visualize/__init__.py
@@ -1,4 +1,5 @@
 from abtem.visualize.visualizations import (
     Visualization,
     show_atoms,
+    show_atoms3d,
 )


### PR DESCRIPTION
I was repeatedly running into some issues with `ase.build.surface` and `abtem.orthogonalize_cell` when trying to look down unusual axes (GaAs along the 14,2,1 was where the problem started for me, but that's ancillary to the topic of this PR)

Ultimately, the problem was a user error, but diagnosing it was devilishly difficult with the default 2d projection plots. Additionally, there were some missing features in `abtem.show_atoms`, such as the inability to set `plane` to off-plane viewing directions.

Since I needed 2D and 3D plots for my own work, I tried my hand at a generic `abtem version`.  some examples can be seen below:
```
ruby = ase.io.read("ruby.cif")* [9,11,4]
abtem.show_atoms(ruby, merge=False, plane = "xy")
abtem.show_atoms(ruby, merge=False, plane = (10,15))
abtem.show_atoms3d(ruby)
```

![image](https://github.com/user-attachments/assets/cb2e9e82-4d69-4977-9a4c-590b46f98010)

This PR definitely still needs some TLC, but I was far enough long it seemed worth sharing in case others have feedback.

I also want to add a 3d isosurface plot for potentials, and (maybe?) a pyvista plotting tool for both, as the graphics are considerably nicer looking and it's possible to quickly plot true ionospheres instead of scatterplot markers.

Let me know what you think, open to suggestions