### PR TITLE
Numpy 2.X does consider empty array as false.

### DIFF
--- a/abtem/visualize/artists.py
+++ b/abtem/visualize/artists.py
@@ -501,7 +501,7 @@ class ImageArtist(Artist2D):
         self.set_xlabel(xlabel)
         self.set_ylabel(ylabel)
 
-        if caxes:
+        if caxes is not None and len(caxes):
             cbar_label = measurement._scale_axis_from_metadata().format_label()
             self.set_cbars(caxes=caxes, label=cbar_label)
 


### PR DESCRIPTION
I got an error when showing a simulated image like this:
```
measurement = exit_wave.apply_ctf(ctf).intensity()
measurement.show(cmap='gray')
```

Apparently, an object can be ``None``, or a list of colorbar axes, or a numpy array of colorbar axes.  But checking for the object's truth value to detect a non-empty list/array does not work when it is a numpy array.

```
File ~/simulations/Silicon_Moire/src/abtem/abtem/measurements.py:1302, in _BaseMeasurement2D.show(self, ax, cbar, cmap, vmin, vmax, power, common_color_scale, explode, overlay, figsize, title, units, interact, display, **kwargs)
   1227 def show(
   1228     self,

[ ... ]

File ~/simulations/Silicon_Moire/src/abtem/abtem/visualize/artists.py:504, in ImageArtist.__init__(self, ax, measurement, caxes, cmap, vmin, vmax, power, logscale, origin, units, **kwargs)
    501 self.set_xlabel(xlabel)
    502 self.set_ylabel(ylabel)
--> 504 if caxes:
    505     cbar_label = measurement._scale_axis_from_metadata().format_label()
    506     self.set_cbars(caxes=caxes, label=cbar_label)

ValueError: The truth value of an empty array is ambiguous. Use `array.size > 0` to check that an array is not empty.
```

