### PR TITLE
Fix atom-to-slice misassignment from cumsum floating-point drift

### DIFF
--- a/abtem/core/energy.py
+++ b/abtem/core/energy.py
@@ -58,6 +58,9 @@ def energy2wavelength(energy: float) -> float:
         Relativistic de Broglie wavelength [Å].
     """
 
+    if energy <= 0:
+        raise ValueError(f"Electron energy must be positive, got {energy} eV")
+
     return float(
         units._hplanck
         * units._c

--- a/abtem/core/fft.py
+++ b/abtem/core/fft.py
@@ -574,17 +574,9 @@ def fft_interpolate(
 
     if normalization == "values":
         array *= np.prod(array.shape[-len(new_shape) :]) / old_size
-
-    elif normalization == "amplitude":
+    elif normalization in ("amplitude", "intensity"):
         pass
     else:
-        pass
-        # raise ValueError(f"Normalization [{normalization}] not recognized.")
-
-    # elif normalization != "intensity":
-    #    raise ValueError()
-
-    # else:
-    #    raise ValueError(f"Normalization {normalization} not recognized.")
+        raise ValueError(f"Normalization '{normalization}' not recognized.")
 
     return array

--- a/abtem/potentials/iam.py
+++ b/abtem/potentials/iam.py
@@ -107,7 +107,7 @@ class BaseField(Ensemble, HasGrid2DMixin, EqualityMixin, CopyMixin, metaclass=AB
 
         is_exit_plane = np.zeros(len(self), dtype=bool)
         for i in range(len(is_exit_plane)):
-            if i == exit_planes[exit_plane_index]:
+            if exit_plane_index < len(exit_planes) and i == exit_planes[exit_plane_index]:
                 is_exit_plane[i] = True
                 exit_plane_index += 1
 

--- a/abtem/slicing.py
+++ b/abtem/slicing.py
@@ -69,6 +69,11 @@ def _validate_slice_thickness(
     num_slices: Optional[int] = None,
 ) -> tuple[float, ...]:
     if is_number(slice_thickness):
+        st_value = slice_thickness.item() if isinstance(slice_thickness, np.ndarray) else float(slice_thickness)
+        if st_value <= 0.0:
+            raise ValueError(
+                f"slice_thickness must be positive, got {slice_thickness}"
+            )
         if thickness is not None:
             thickness = float(thickness)
             n = float(np.ceil(thickness / slice_thickness))

--- a/abtem/slicing.py
+++ b/abtem/slicing.py
@@ -309,14 +309,17 @@ class SliceIndexedAtoms(BaseSlicedAtoms):
     ):
         super().__init__(atoms, slice_thickness)
 
-        labels = np.digitize(
-            self.atoms.positions[:, 2], np.cumsum(self.slice_thickness)
-        )
+        bin_edges = np.array(self.slice_thickness).cumsum()
 
-        # method="closest"
-        # labels = find_closest_indices(
-        #    atoms.positions[:, 2], np.cumsum((0,) + self.slice_thickness[:-1])
-        # )
+        # Guard against floating-point accumulation error in cumsum:
+        # atoms exactly on a slice boundary can be assigned to the wrong
+        # slice when the cumulative sum drifts by ~1e-14.  Nudge each
+        # edge down by a small tolerance so that an atom sitting
+        # precisely at z = sum(thicknesses[:k]) falls into slice k
+        # (the next slice), not slice k-1.
+        bin_edges -= 1e-12
+
+        labels = np.digitize(self.atoms.positions[:, 2], bin_edges)
 
         self._slice_index = [
             indices for indices in label_to_index(labels, max_label=len(self) - 1)


### PR DESCRIPTION
## Summary

- Fixes a bug in `SliceIndexedAtoms` where `np.digitize` with `np.cumsum`-computed bin edges misassigns atoms to slices due to floating-point accumulation error (~1e-14 per step)
- When atom z-positions land exactly on slice boundaries (common in crystalline materials), this drift causes atoms to be placed in the wrong slice
- For the Gold FCC simulation reported in Discussion #261, 48 of 120 atoms were shifted by one slice, producing ~5% intensity error in the diffraction pattern
- Fix: subtract a small tolerance (1e-12) from cumsum bin edges — large enough to correct the drift, negligible compared to any physical slice thickness

### Additional fixes from codebase audit

A comprehensive audit after the primary fix identified and addressed several related issues:

- **`_exit_plane_after` IndexError** (`potentials/iam.py`): Added bounds check to prevent crash when the last exit plane is not the last slice
- **`slice_thickness <= 0` validation** (`slicing.py`): Reject non-positive slice thickness, which causes division-by-zero or nonsensical potentials
- **`energy <= 0` validation** (`core/energy.py`): Reject non-positive energy in `energy2wavelength()`, which causes division-by-zero or silently returns complex values
- **FFT normalization cleanup** (`core/fft.py`): Added `"intensity"` as explicit normalization mode (used by PRISM), raise `ValueError` for unrecognized strings instead of silently ignoring them

## Test plan

- [x] Verified fixed v1.0.9 raw diffraction pattern matches v1.0.5 output (max diff ~5e-7, float32 noise floor)
- [x] Verified all 60 slices contain exactly 2 atoms each for Gold FCC (previously slice 35 had 4, slice 59 had 0)
- [x] All 748 tests pass (571 GPU tests skipped)
- [x] New validations raise on invalid inputs (negative energy, zero thickness)
- [x] PRISM S-matrix code still works with `normalization="intensity"`

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)