### PR TITLE
Fix bugs, unsafe patterns, and dead code found in codebase audit

### DIFF
--- a/abtem/core/axes.py
+++ b/abtem/core/axes.py
@@ -133,16 +133,20 @@ class AxisMetadata:
     def coordinates(self, n: int) -> tuple:
         return tuple(np.arange(n))
 
-    def format_type(self):
+    def format_type(self) -> str:
+        """Return the axis type name (the class name)."""
         return self.__class__.__name__
 
-    def format_label(self, units: Optional[str] = None):
+    def format_label(self, units: Optional[str] = None) -> str:
+        """Return a formatted label string, optionally with units."""
         return format_label(self, units=units)
 
     def format_title(self, *args: Any, **kwargs: Any) -> str:
+        """Return a formatted title string for display."""
         return f"{self.label}"
 
-    def item_metadata(self, item, metadata=None):
+    def item_metadata(self, item, metadata=None) -> dict:
+        """Return metadata associated with a specific item along this axis."""
         return {}
 
     def to_ordinal_axis(self, n):
@@ -162,10 +166,12 @@ class AxisMetadata:
         arr = da.from_array(arr, chunks=1)
         return arr
 
-    def copy(self):
+    def copy(self) -> AxisMetadata:
+        """Return a deep copy of this axis metadata."""
         return copy(self)
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
+        """Serialize this axis metadata to a dictionary."""
         d = dataclasses.asdict(self)
         for key, value in d.items():
             if isinstance(value, np.ndarray):
@@ -175,6 +181,7 @@ class AxisMetadata:
         return d
 
     def concatenate(self, other: AxisMetadata) -> AxisMetadata:
+        """Concatenate this axis metadata with another compatible axis metadata."""
         if not self._concatenate:
             raise RuntimeError()
 
@@ -184,11 +191,13 @@ class AxisMetadata:
         return self
 
     @staticmethod
-    def from_dict(d):
+    def from_dict(d) -> AxisMetadata:
+        """Reconstruct an AxisMetadata instance from a dictionary."""
         cls = globals()[d["type"]]
         return cls(**{key: value for key, value in d.items() if key != "type"})
 
-    def limits(self, n=None):
+    def limits(self, n=None) -> tuple:
+        """Return the (min, max) coordinate limits for this axis."""
         coordinates = self.coordinates(n)
         min_limit = coordinates[0]
         max_limit = coordinates[-1]

--- a/abtem/core/energy.py
+++ b/abtem/core/energy.py
@@ -196,8 +196,8 @@ class Accelerator(EqualityMixin, CopyMixin):
         """
         if (
             (self.energy is not None)
-            & (other.energy is not None)
-            & (self.energy != other.energy)
+            and (other.energy is not None)
+            and (self.energy != other.energy)
         ):
             raise RuntimeError("Inconsistent energies")
 

--- a/abtem/core/grid.py
+++ b/abtem/core/grid.py
@@ -373,13 +373,13 @@ class Grid(CopyMixin, EqualityMixin):
         if self.extent is not None and other.extent is not None:
             if not np.all(np.isclose(self.extent, other.extent)):
                 raise RuntimeError(
-                    "Inconsistent grid extent ({self.extent} != {other.extent})"
+                    f"Inconsistent grid extent ({self.extent} != {other.extent})"
                 )
 
         if self.gpts is not None and other.gpts is not None:
             if not np.all(self.gpts == other.gpts):
                 raise RuntimeError(
-                    "Inconsistent grid gpts ({self.gpts} != {other.gpts})"
+                    f"Inconsistent grid gpts ({self.gpts} != {other.gpts})"
                 )
 
     def round_to_power(

--- a/abtem/detectors.py
+++ b/abtem/detectors.py
@@ -595,6 +595,10 @@ class AnnularDetector(_AbstractRadialDetector):
 
     @property
     def radial_sampling(self) -> float:
+        if self._outer is None:
+            raise RuntimeError(
+                "radial_sampling is not defined when outer angle is None"
+            )
         return self._outer - self._inner
 
     @property

--- a/abtem/inelastic/core_loss.py
+++ b/abtem/inelastic/core_loss.py
@@ -59,6 +59,8 @@ azimuthal_letter = {value: key for key, value in azimuthal_number.items()}
 
 
 def config_str_to_config_tuples(config_str):
+    """Parse an electron configuration string (e.g. "1s2 2s2 2p6") into a list of
+    (n, l, occupancy) tuples."""
     config_tuples = []
     for subshell_string in config_str.split(" "):
         config_tuples.append(
@@ -72,6 +74,8 @@ def config_str_to_config_tuples(config_str):
 
 
 def config_tuples_to_config_str(config_tuples):
+    """Convert a list of (n, l, occupancy) tuples back to an electron configuration
+    string (e.g. "1s2 2s2 2p6")."""
     config_str = []
     for n, ell, occ in config_tuples:
         config_str.append(str(n) + azimuthal_letter[ell] + str(occ))
@@ -79,6 +83,8 @@ def config_tuples_to_config_str(config_tuples):
 
 
 def remove_electron_from_config_str(config_str, n, ell):
+    """Remove one electron from the (n, l) subshell in the given configuration string
+    and return the updated configuration string."""
     config_tuples = []
     for shell in config_str_to_config_tuples(config_str):
         if shell[:2] == (n, ell):
@@ -89,6 +95,8 @@ def remove_electron_from_config_str(config_str, n, ell):
 
 
 def check_valid_quantum_number(Z, n, ell):
+    """Validate that the quantum numbers (n, l) correspond to an occupied subshell
+    for element with atomic number Z. Raises RuntimeError if invalid."""
     symbol = chemical_symbols[Z]
     config_tuple = config_str_to_config_tuples(electron_configurations[symbol])
 

--- a/abtem/inelastic/phonons.py
+++ b/abtem/inelastic/phonons.py
@@ -52,7 +52,7 @@ def _safe_read_atoms(calculator, clean: bool = True) -> Atoms:
 
     if clean:
         atoms.constraints = None
-        atoms.calc = True
+        atoms.calc = None
 
     return atoms
 

--- a/abtem/inelastic/plasmons.py
+++ b/abtem/inelastic/plasmons.py
@@ -571,41 +571,6 @@ class MonteCarloPlasmons:
         azimuthal_angles = list(itertools.chain(*azimuthal_angles))
         weights = list(itertools.chain(*weights))
 
-        # depths = tuple(
-        #     depths
-        #     for n in self._num_excitations
-        #     for depths in draw_scattering_depths(
-        #         mean_free_path=self._mean_free_path,
-        #         num_depths=n,
-        #         max_depth=depth,
-        #         num_samples=self.num_samples,
-        #         rng=rng,
-        #     )
-        # )
-        #
-        # radial_angles = tuple(
-        #     tuple(
-        #         draw_radial_scattering_angle(
-        #             self._critical_angle, self.characteristic_angle(energy), rng=rng
-        #         )
-        #         for _ in range(n)
-        #     )
-        #     for n in self._num_excitations
-        #     for _ in range(self.num_samples)
-        # )
-        #
-        # azimuthal_angles = tuple(
-        #     tuple(draw_azimuthal_angle(rng=rng) for _ in range(n))
-        #     for n in self._num_excitations
-        #     for _ in range(self.num_samples)
-        # )
-        #
-        # weights = tuple(
-        #     excitations_weights(n, depth, self._mean_free_path)
-        #     for n in self._num_excitations
-        #     for _ in range(self.num_samples)
-        # )
-
         return PlasmonScatteringEvents(
             depths,
             radial_angles,

--- a/abtem/mcf.py
+++ b/abtem/mcf.py
@@ -177,7 +177,10 @@ class DiagonalMCF(ArrayWaveTransform, HasAcceleratorMixin):
         E = self._evaluate_flat_cropped_mcf(waves)
 
         if max(self.eigenvectors) + 1 >= E.shape[0]:
-            raise RuntimeError()
+            raise RuntimeError(
+                f"Requested eigenvector index {max(self.eigenvectors)} exceeds "
+                f"available dimensions ({E.shape[0]})"
+            )
 
         values, vectors = eigsh(E, k=max(self.eigenvectors) + 1)
         order = np.argsort(-values)

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -878,48 +878,6 @@ class MeasurementsEnsemble(BaseMeasurements):
 
         return visualization
 
-    # def show(
-    #     self,
-    #     ax: Axes = None,
-    #     common_scale: bool = True,
-    #     explode: bool | Sequence[int] = None,
-    #     overlay: bool | Sequence[int] = None,
-    #     figsize: tuple[int, int] = None,
-    #     title: str = None,
-    #     units: str = None,
-    #     legend: bool = False,
-    #     interact: bool = False,
-    #     display: bool = True,
-    #     **kwargs,
-    # ):
-    #     # if not interact:
-    #     #     self.compute()
-    #
-    #     visualization = VisualizationLines(
-    #         array=self.array,
-    #         coordinate_axes=self.ensemble_axes_metadata[-1:],
-    #         scale_axis=self._scale_axis_from_metadata(),
-    #         ensemble_axes=self.ensemble_axes_metadata[:-1],
-    #         ax=ax,
-    #         common_scale=common_scale,
-    #         explode=explode,
-    #         overlay=overlay,
-    #         figsize=figsize,
-    #         interact=interact,
-    #         title=title,
-    #         **kwargs,
-    #     )
-    #
-    #     if not display and not interact:
-    #         plt.close()
-    #
-    #     if interact and display:
-    #         from IPython.display import display as ipython_display
-    #
-    #         ipython_display(visualization.layout_widgets())
-    #
-    #     return visualization
-
 
 class _BaseMeasurement2D(BaseMeasurements):
     _base_dims = 2

--- a/abtem/multislice.py
+++ b/abtem/multislice.py
@@ -276,7 +276,11 @@ def allocate_measurement(
     shape = detector._out_shape(waves)[0]
     #
     if extra_ensemble_axes_shape is not None:
-        assert len(extra_ensemble_axes_shape) == len(extra_ensemble_axes_shape)
+        if len(extra_ensemble_axes_shape) != len(extra_ensemble_axes_metadata):
+            raise ValueError(
+                f"extra_ensemble_axes_shape length ({len(extra_ensemble_axes_shape)}) "
+                f"!= extra_ensemble_axes_metadata length ({len(extra_ensemble_axes_metadata)})"
+            )
         shape = extra_ensemble_axes_shape + shape
         axes_metadata = extra_ensemble_axes_metadata + axes_metadata
 

--- a/abtem/noise.py
+++ b/abtem/noise.py
@@ -263,48 +263,6 @@ def _apply_displacement_field(
     return warped.reshape(image.shape)
 
 
-# def apply_scan_noise(
-#     measurement: np.ndarray,
-#     dwell_time: float,
-#     flyback_time: float,
-#     max_frequency: float,
-#     rms_power: float,
-#     num_components: int = 200,
-# ):
-#     """
-#     Add scan noise to a measurement.
-
-#     Parameters
-#     ----------
-#     measurement: Measurement object or 2d array
-#         The measurement to add noise to.
-#     dwell_time: float
-#         Dwell time on a single pixel in s.
-#     flyback_time: float
-#         Flyback time for the scanning probe at the end of each scan line in s.
-#     max_frequency: float
-#         Maximum noise frequency in 1 / s.
-#     rms_power: float
-#         Root-mean-square power of the distortion in unit of percent.
-#     num_components: int, optional
-#         Number of frequency components. More components will be more 'white' but will
-#         take longer.
-
-#     Returns
-#     -------
-#     measurement: Measurement object
-#         The noisy measurement.
-#     """
-
-#     time = _pixel_times(dwell_time, flyback_time, array.T.shape)
-#     displacement_x, displacement_y = _make_displacement_field(
-#         time, max_frequency, num_components, rms_power
-#     )
-
-#     array = _apply_displacement_field(array.T, displacement_x, displacement_y)
-#     return array.T
-
-
 class ScanNoiseTransform(EnsembleTransform):
     def __init__(
         self,

--- a/abtem/reconstruct.py
+++ b/abtem/reconstruct.py
@@ -881,42 +881,6 @@ class RegularizedPtychographicOperator(AbstractPtychographicOperator):
 
         return objects, probes, position
 
-    """
-    @staticmethod
-    def _position_correction(objects: np.ndarray,
-                             probes: np.ndarray,
-                             position:np.ndarray,
-                             exit_wave: np.ndarray,
-                             modified_exit_wave: np.ndarray,
-                             diffraction_pattern:np.ndarray,
-                             sobel: Callable,
-                             position_step_size: float = 1.0,
-                             xp=np,
-                             **kwargs):
-
-        object_dx                  = sobel(objects,axis=0,mode='wrap')
-        object_dy                  = sobel(objects,axis=1,mode='wrap')
-
-        object_indices             = _wrapped_indices_2D_window(position,probes.shape,objects.shape)
-        d_exit_wave_fft_dx         = xp.fft.fft2(object_dx[object_indices]*probes)
-        d_exit_wave_fft_dy         = xp.fft.fft2(object_dy[object_indices]*probes)
-
-        exit_wave_fft              = xp.fft.fft2(exit_wave)
-        estimated_intensity        = xp.abs(exit_wave_fft)**2
-        intensity                  = diffraction_pattern**2
-        difference_intensity       = (intensity - estimated_intensity).ravel()
-
-        exit_wave_fft_conj         = xp.conj(exit_wave_fft)
-
-        partial_intensity_dx       = 2*xp.real(d_exit_wave_fft_dx*exit_wave_fft_conj).ravel()
-        partial_intensity_dy       = 2*xp.real(d_exit_wave_fft_dy*exit_wave_fft_conj).ravel()
-
-        coefficients_matrix        = xp.column_stack((partial_intensity_dx,partial_intensity_dy))
-        displacements              = xp.linalg.lstsq(coefficients_matrix,difference_intensity,rcond=None)[0]
-
-        return position - position_step_size*displacements
-    """
-
     @staticmethod
     def _position_correction(
         objects: np.ndarray,

--- a/abtem/transfer.py
+++ b/abtem/transfer.py
@@ -801,7 +801,11 @@ class RadialPhasePlate(BaseAperture):
         alpha_normed[alpha > max_alpha] = max_alpha
         alpha_normed[alpha < max_alpha] = alpha[alpha < max_alpha]
         alpha_normed[alpha_normed < min_alpha] = min_alpha
-        alpha_normed = (alpha_normed - alpha_normed.min()) / np.ptp(alpha_normed)
+        ptp = alpha_normed.max() - alpha_normed.min()
+        if ptp == 0:
+            alpha_normed = xp.zeros_like(alpha_normed)
+        else:
+            alpha_normed = (alpha_normed - alpha_normed.min()) / ptp
 
         phase_shift = xp.sin(alpha_normed * np.pi * (self.num_flips + 1)) < 0.0
         phase_shift = xp.exp(1.0j * self.phase_shift * phase_shift)

--- a/abtem/visualize/widgets.py
+++ b/abtem/visualize/widgets.py
@@ -79,12 +79,9 @@ def slider_from_axes_metadata(
         if default_value is None:
             default_value = 0
 
-        # print(values, default_value)
-        # print(int(np.argmin(np.abs(values - default_value))))
-
         try:
             index = int(np.argmin(np.abs(values - default_value)))
-        except:
+        except Exception:
             index = 0
 
         slider = widgets.SelectionSlider(


### PR DESCRIPTION
## Summary

- **Fix 4 critical bugs**: missing f-string prefixes in grid error messages, tautological assertion in `multislice.py` that always passed, bitwise `&` used as logical `and` in `energy.py`, and `atoms.calc = True` instead of `None` in `phonons.py`
- **Fix 4 safety issues**: bare `except:` catching KeyboardInterrupt, division-by-zero from deprecated `np.ptp()`, `None` arithmetic crash in `AnnularDetector.radial_sampling`, and empty `RuntimeError()` message
- **Remove ~150 lines of dead code**: commented-out functions/methods in `noise.py`, `measurements.py`, `reconstruct.py`, and `plasmons.py`
- **Add docstrings**: to `AxisMetadata` methods in `axes.py` and electron configuration utilities in `core_loss.py`

## Test plan

- [x] Full test suite (including GPU) passes (1332, 2 skipped, 0 failed)
- [x] Verify grid error messages now show actual extent/gpts values
- [x] Verify `AnnularDetector(inner=10).radial_sampling` gives clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)