### PR TITLE
Feature: Lorentzian, Voigtian, and pseudo-Voigtian distributions and filters for finite source size modeling

### DIFF
--- a/abtem/distributions.py
+++ b/abtem/distributions.py
@@ -385,6 +385,185 @@ def gaussian(
     return MultidimensionalDistribution(distributions=distributions)
 
 
+def lorentzian(
+    half_width: float | tuple[float, ...],
+    num_samples: int | tuple[int, ...],
+    dimension: int = 1,
+    center: float | tuple[float, ...] = 0.0,
+    ensemble_mean: bool | tuple[bool, ...] = True,
+    sampling_limit: float | tuple[float, ...] = 10.0,
+    normalize: str = "intensity",
+) -> MultidimensionalDistribution:
+    """
+    Return a distribution with values weighted according to a (multidimensional)
+    Lorentzian (Cauchy) distribution. The values are evenly spaced within a given
+    truncation of the distribution. As an example, this distribution may be used for
+    simulating focal spread due to an energy-loss spectrum with Lorentzian tails.
+
+    Parameters
+    ----------
+    half_width : float or tuple of float
+        The half-width at half-maximum (HWHM) of the distribution. The half-widths
+        may be given for each axis as a tuple, or as a single number, in which case
+        it is equal for all axes.
+    num_samples : int or tuple of int
+        Number of evenly spaced samples. The number of samples may be given for each
+        axis as a tuple, or as a single number, in which case it is equal for all axes.
+    dimension : int, optional
+        Number of dimensions of the distribution.
+    center : float or tuple of float
+        The center of the distribution (default is 0.0). The center may be given for
+        each axis as a tuple, or as a single number, in which case it is equal for
+        all axes.
+    ensemble_mean : bool or tuple of bool, optional
+        If True, the mean of the ensemble of measurements defined by the distribution
+        is calculated, otherwise the full ensemble is kept. Default is True.
+    sampling_limit : float or tuple of float, optional
+        Truncate the distribution at this many half-widths (default is 10.0). The
+        Lorentzian has heavier tails than the Gaussian, so a larger truncation is
+        recommended.
+    normalize : str, optional
+        Specifies whether to normalize the 'intensity' (default) or 'amplitude'.
+    """
+    center = number_to_tuple(center, dimension)
+    half_width = number_to_tuple(half_width, dimension)
+    ensemble_mean = number_to_tuple(ensemble_mean, dimension)
+    sampling_limit = number_to_tuple(sampling_limit, dimension)
+    num_samples = number_to_tuple(num_samples, dimension)
+
+    distributions: list[BaseDistribution] = []
+    for i in range(dimension):
+        values = np.linspace(
+            -half_width[i] * sampling_limit[i] + center[i],
+            half_width[i] * sampling_limit[i] + center[i],
+            num_samples[i],
+        )
+
+        weights = 1.0 / (1.0 + ((values - center[i]) / half_width[i]) ** 2)
+
+        if normalize == "intensity":
+            weights /= np.sqrt((weights**2).sum())
+        elif normalize == "amplitude":
+            weights /= weights.sum()
+        else:
+            raise RuntimeError(f"Unknown normalization method: {normalize}")
+
+        distributions.append(
+            DistributionFromValues(
+                values=values, weights=weights, ensemble_mean=ensemble_mean[i]
+            )
+        )
+
+    return MultidimensionalDistribution(distributions=distributions)
+
+
+def voigt(
+    gaussian_sigma: float | tuple[float, ...],
+    lorentzian_gamma: float | tuple[float, ...],
+    num_samples: int | tuple[int, ...],
+    dimension: int = 1,
+    center: float | tuple[float, ...] = 0.0,
+    ensemble_mean: bool | tuple[bool, ...] = True,
+    sampling_limit: float | tuple[float, ...] = 5.0,
+    normalize: str = "intensity",
+) -> MultidimensionalDistribution:
+    """
+    Return a distribution with values weighted according to a (multidimensional)
+    Voigt distribution, which is the convolution of a Gaussian and a Lorentzian.
+    The values are evenly spaced within a given truncation of the distribution.
+    As an example, this distribution may be used for simulating focal spread due
+    to an energy-loss spectrum with both Gaussian and Lorentzian contributions.
+
+    Parameters
+    ----------
+    gaussian_sigma : float or tuple of float
+        The standard deviation (σ) of the Gaussian component. The standard deviations
+        may be given for each axis as a tuple, or as a single number, in which case
+        it is equal for all axes.
+    lorentzian_gamma : float or tuple of float
+        The half-width at half-maximum (HWHM, γ) of the Lorentzian component. The
+        half-widths may be given for each axis as a tuple, or as a single number,
+        in which case it is equal for all axes.
+    num_samples : int or tuple of int
+        Number of evenly spaced samples. The number of samples may be given for each
+        axis as a tuple, or as a single number, in which case it is equal for all axes.
+    dimension : int, optional
+        Number of dimensions of the distribution.
+    center : float or tuple of float
+        The center of the distribution (default is 0.0). The center may be given for
+        each axis as a tuple, or as a single number, in which case it is equal for
+        all axes.
+    ensemble_mean : bool or tuple of bool, optional
+        If True, the mean of the ensemble of measurements defined by the distribution
+        is calculated, otherwise the full ensemble is kept. Default is True.
+    sampling_limit : float or tuple of float, optional
+        Truncate the distribution at this many Voigt half-widths (default is 5.0).
+        The Voigt HWHM is estimated using the Thompson et al. (1987) approximation.
+    normalize : str, optional
+        Specifies whether to normalize the 'intensity' (default) or 'amplitude'.
+    """
+    from scipy.special import wofz
+
+    center = number_to_tuple(center, dimension)
+    gaussian_sigma = number_to_tuple(gaussian_sigma, dimension)
+    lorentzian_gamma = number_to_tuple(lorentzian_gamma, dimension)
+    ensemble_mean = number_to_tuple(ensemble_mean, dimension)
+    sampling_limit = number_to_tuple(sampling_limit, dimension)
+    num_samples = number_to_tuple(num_samples, dimension)
+
+    distributions: list[BaseDistribution] = []
+    for i in range(dimension):
+        sigma = gaussian_sigma[i]
+        gamma = lorentzian_gamma[i]
+
+        if sigma == 0.0 and gamma == 0.0:
+            raise ValueError(
+                "At least one of gaussian_sigma or lorentzian_gamma must be non-zero."
+            )
+
+        # Voigt HWHM estimate via Thompson et al. (1987) for the sampling range
+        fG = 2.0 * sigma * np.sqrt(2.0 * np.log(2.0))  # Gaussian FWHM
+        fL = 2.0 * gamma  # Lorentzian FWHM
+        f5 = (
+            fG**5
+            + 2.69269 * fG**4 * fL
+            + 2.42843 * fG**3 * fL**2
+            + 4.47163 * fG**2 * fL**3
+            + 0.07842 * fG * fL**4
+            + fL**5
+        )
+        voigt_hwhm = f5 ** (1.0 / 5.0) / 2.0
+
+        values = np.linspace(
+            -voigt_hwhm * sampling_limit[i] + center[i],
+            voigt_hwhm * sampling_limit[i] + center[i],
+            num_samples[i],
+        )
+
+        if sigma == 0.0:
+            weights = 1.0 / (1.0 + ((values - center[i]) / gamma) ** 2)
+        elif gamma == 0.0:
+            weights = np.exp(-0.5 * (values - center[i]) ** 2 / sigma**2)
+        else:
+            z = ((values - center[i]) + 1j * gamma) / (sigma * np.sqrt(2.0))
+            weights = np.real(wofz(z))
+
+        if normalize == "intensity":
+            weights /= np.sqrt((weights**2).sum())
+        elif normalize == "amplitude":
+            weights /= weights.sum()
+        else:
+            raise RuntimeError(f"Unknown normalization method: {normalize}")
+
+        distributions.append(
+            DistributionFromValues(
+                values=values, weights=weights, ensemble_mean=ensemble_mean[i]
+            )
+        )
+
+    return MultidimensionalDistribution(distributions=distributions)
+
+
 @overload
 def validate_distribution(
     distribution: BaseDistribution | tuple | list | np.ndarray,

--- a/abtem/distributions.py
+++ b/abtem/distributions.py
@@ -486,7 +486,7 @@ def lorentzian(
     return MultidimensionalDistribution(distributions=distributions)
 
 
-def voigt(
+def voigtian(
     gaussian_sigma: float | tuple[float, ...],
     lorentzian_gamma: float | tuple[float, ...],
     num_samples: int | tuple[int, ...],
@@ -498,7 +498,7 @@ def voigt(
 ) -> MultidimensionalDistribution:
     """
     Return a distribution with values weighted according to a (multidimensional)
-    Voigt distribution, which is the convolution of a Gaussian and a Lorentzian.
+    Voigtian distribution, which is the convolution of a Gaussian and a Lorentzian.
     The values are evenly spaced within a given truncation of the distribution.
     As an example, this distribution may be used for simulating focal spread due
     to an energy-loss spectrum with both Gaussian and Lorentzian contributions.
@@ -549,14 +549,9 @@ def voigt(
     (``scipy.special.wofz``). The degenerate limits σ → 0 (pure Lorentzian)
     and γ → 0 (pure Gaussian) are handled analytically.
 
-    The Voigt source-size model is described in [1]_.
-
-    References
-    ----------
-    .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence function
-       in scanning transmission electron microscopy and spectroscopy",
-       *Ultramicroscopy* **146**, 6–16 (2014).
-       https://doi.org/10.1016/j.ultramic.2014.04.008
+    Note that Nguyen et al. (2014) proposed a pseudo-Voigt (weighted sum of
+    Gaussian and Lorentzian) rather than the true convolution implemented here;
+    see :func:`pseudo_voigtian` for that model.
     """
     from scipy.special import wofz
 
@@ -603,6 +598,140 @@ def voigt(
         else:
             z = ((values - center[i]) + 1j * gamma) / (sigma * np.sqrt(2.0))
             weights = np.real(wofz(z))
+
+        if normalize == "intensity":
+            weights /= np.sqrt((weights**2).sum())
+        elif normalize == "amplitude":
+            weights /= weights.sum()
+        else:
+            raise RuntimeError(f"Unknown normalization method: {normalize}")
+
+        distributions.append(
+            DistributionFromValues(
+                values=values, weights=weights, ensemble_mean=ensemble_mean[i]
+            )
+        )
+
+    return MultidimensionalDistribution(distributions=distributions)
+
+
+def pseudo_voigtian(
+    gaussian_sigma: float | tuple[float, ...],
+    lorentzian_gamma: float | tuple[float, ...],
+    eta: float | tuple[float, ...],
+    num_samples: int | tuple[int, ...],
+    dimension: int = 1,
+    center: float | tuple[float, ...] = 0.0,
+    ensemble_mean: bool | tuple[bool, ...] = True,
+    sampling_limit: float | tuple[float, ...] = 10.0,
+    normalize: str = "intensity",
+) -> MultidimensionalDistribution:
+    """
+    Return a distribution with values weighted according to a (multidimensional)
+    pseudo-Voigtian distribution, which is a weighted linear sum of a Gaussian and
+    a Lorentzian (not their convolution). The values are evenly spaced within a
+    given truncation of the distribution.
+
+    The pseudo-Voigt model was proposed by Nguyen et al. (2014) to describe the
+    spatial coherence function in STEM. See :func:`voigtian` for the true
+    convolution (exact Voigt profile).
+
+    Parameters
+    ----------
+    gaussian_sigma : float or tuple of float
+        The standard deviation (σ) of the Gaussian component. May be given for
+        each axis as a tuple, or as a single number equal for all axes.
+    lorentzian_gamma : float or tuple of float
+        The half-width at half-maximum (HWHM, γ) of the Lorentzian component.
+        May be given for each axis as a tuple, or as a single number equal for
+        all axes.
+    eta : float or tuple of float
+        The Lorentzian mixing fraction η ∈ [0, 1]. η = 0 gives a pure Gaussian;
+        η = 1 gives a pure Lorentzian. May be given for each axis as a tuple,
+        or as a single number equal for all axes.
+    num_samples : int or tuple of int
+        Number of evenly spaced samples. May be given for each axis as a tuple,
+        or as a single number equal for all axes.
+    dimension : int, optional
+        Number of dimensions of the distribution.
+    center : float or tuple of float
+        The center of the distribution (default is 0.0). May be given for each
+        axis as a tuple, or as a single number equal for all axes.
+    ensemble_mean : bool or tuple of bool, optional
+        If True, the mean of the ensemble of measurements defined by the
+        distribution is calculated, otherwise the full ensemble is kept.
+        Default is True.
+    sampling_limit : float or tuple of float, optional
+        Truncate the distribution at this many widths (default is 10.0). The
+        effective width is max(σ, γ), so the range is sampling_limit·max(σ, γ)
+        on each side of the center.
+    normalize : str, optional
+        Specifies whether to normalize the 'intensity' (default) or 'amplitude'.
+
+    Notes
+    -----
+    The pseudo-Voigt profile is
+
+        PV(x) = (1 - η) · G(x; σ) + η · L(x; γ)
+
+    where G and L are un-normalized Gaussian and Lorentzian profiles evaluated
+    on the same grid, and the result is normalized before use.
+
+    Width parameterization:
+
+    * ``gaussian_sigma`` (σ): standard deviation; FWHM_G = 2√(2 ln 2)·σ ≈ 2.3548·σ.
+    * ``lorentzian_gamma`` (γ): HWHM; FWHM_L = 2γ.
+
+    For the same FWHM, γ = FWHM / 2 whereas σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
+
+    References
+    ----------
+    .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence function
+       in scanning transmission electron microscopy and spectroscopy",
+       *Ultramicroscopy* **146**, 6–16 (2014).
+       https://doi.org/10.1016/j.ultramic.2014.04.008
+    """
+    center = number_to_tuple(center, dimension)
+    gaussian_sigma = number_to_tuple(gaussian_sigma, dimension)
+    lorentzian_gamma = number_to_tuple(lorentzian_gamma, dimension)
+    eta = number_to_tuple(eta, dimension)
+    ensemble_mean = number_to_tuple(ensemble_mean, dimension)
+    sampling_limit = number_to_tuple(sampling_limit, dimension)
+    num_samples = number_to_tuple(num_samples, dimension)
+
+    distributions: list[BaseDistribution] = []
+    for i in range(dimension):
+        sigma = gaussian_sigma[i]
+        gamma = lorentzian_gamma[i]
+        eta_i = eta[i]
+
+        hw = max(sigma, gamma)
+        if hw == 0.0:
+            raise ValueError(
+                "At least one of gaussian_sigma or lorentzian_gamma must be non-zero."
+            )
+
+        values = np.linspace(
+            -hw * sampling_limit[i] + center[i],
+            hw * sampling_limit[i] + center[i],
+            num_samples[i],
+        )
+
+        x = values - center[i]
+
+        if sigma == 0.0:
+            g_weights = np.zeros(num_samples[i])
+            g_weights[num_samples[i] // 2] = 1.0
+        else:
+            g_weights = np.exp(-0.5 * x**2 / sigma**2)
+
+        if gamma == 0.0:
+            l_weights = np.zeros(num_samples[i])
+            l_weights[num_samples[i] // 2] = 1.0
+        else:
+            l_weights = 1.0 / (1.0 + (x / gamma) ** 2)
+
+        weights = (1.0 - eta_i) * g_weights + eta_i * l_weights
 
         if normalize == "intensity":
             weights /= np.sqrt((weights**2).sum())

--- a/abtem/distributions.py
+++ b/abtem/distributions.py
@@ -352,6 +352,16 @@ def gaussian(
         Truncate the distribution at this many standard deviations (default is 3.0).
     normalize : str, optional
         Specifies whether to normalize the 'intensity' (default) or 'amplitude'.
+
+    Notes
+    -----
+    The Gaussian distribution is parameterized by its standard deviation σ
+    (``standard_deviation``). The corresponding full-width at half-maximum is
+    FWHM_G = 2√(2 ln 2)·σ ≈ 2.3548·σ.
+
+    Note that the Lorentzian and Voigt distributions use the half-width at
+    half-maximum (HWHM) γ as their width parameter, so for the same FWHM one
+    needs γ = FWHM / 2 but σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
     """
     center = number_to_tuple(center, dimension)
     standard_deviation = number_to_tuple(standard_deviation, dimension)
@@ -424,6 +434,25 @@ def lorentzian(
         recommended.
     normalize : str, optional
         Specifies whether to normalize the 'intensity' (default) or 'amplitude'.
+
+    Notes
+    -----
+    The Lorentzian distribution is parameterized by its half-width at half-maximum
+    (HWHM) γ (``half_width``). The corresponding full-width at half-maximum is
+    FWHM_L = 2γ.
+
+    Note that the Gaussian distribution uses the standard deviation σ as its width
+    parameter. For the same FWHM one needs γ = FWHM / 2 but
+    σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
+
+    The Lorentzian source-size model is described in [1]_.
+
+    References
+    ----------
+    .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence function
+       in scanning transmission electron microscopy and spectroscopy",
+       *Ultramicroscopy* **146**, 6–16 (2014).
+       https://doi.org/10.1016/j.ultramic.2014.04.008
     """
     center = number_to_tuple(center, dimension)
     half_width = number_to_tuple(half_width, dimension)
@@ -501,6 +530,33 @@ def voigt(
         The Voigt HWHM is estimated using the Thompson et al. (1987) approximation.
     normalize : str, optional
         Specifies whether to normalize the 'intensity' (default) or 'amplitude'.
+
+    Notes
+    -----
+    The Voigt profile is the convolution of a Gaussian and a Lorentzian, with two
+    independent width parameters:
+
+    * ``gaussian_sigma`` (σ): standard deviation of the Gaussian component;
+      FWHM_G = 2√(2 ln 2)·σ ≈ 2.3548·σ.
+    * ``lorentzian_gamma`` (γ): half-width at half-maximum (HWHM) of the
+      Lorentzian component; FWHM_L = 2γ.
+
+    Because the two components use different parameterizations, σ and γ are
+    *not* directly comparable: for the same FWHM one needs γ = FWHM / 2 but
+    σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
+
+    The profile is computed exactly via the Faddeeva function
+    (``scipy.special.wofz``). The degenerate limits σ → 0 (pure Lorentzian)
+    and γ → 0 (pure Gaussian) are handled analytically.
+
+    The Voigt source-size model is described in [1]_.
+
+    References
+    ----------
+    .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence function
+       in scanning transmission electron microscopy and spectroscopy",
+       *Ultramicroscopy* **146**, 6–16 (2014).
+       https://doi.org/10.1016/j.ultramic.2014.04.008
     """
     from scipy.special import wofz
 

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -41,7 +41,13 @@ from abtem.core.axes import (
     ScaleAxis,
     ScanAxis,
 )
-from abtem.core.backend import asnumpy, cp, get_array_module, get_ndimage_module
+from abtem.core.backend import (
+    asnumpy,
+    cp,
+    get_array_module,
+    get_ndimage_module,
+    get_scipy_module,
+)
 from abtem.core.complex import abs2
 from abtem.core.energy import energy2wavelength
 from abtem.core.fft import fft_crop, fft_interpolate
@@ -1236,11 +1242,12 @@ class _BaseMeasurement2D(BaseMeasurements):
         else:
             # Use FFT-based convolution: cost is independent of kernel size,
             # which matters because the heavy-tailed Lorentzian kernel can
-            # easily be comparable in size to the image itself.
+            # easily be comparable in size to the image itself. The helper
+            # dispatches to scipy.signal or cupyx.scipy.signal based on the
+            # array's backend.
             array = _apply_convolve_2d_on_axes(
-                np.asarray(self.array), kernel_2d, axes=axes, mode=mode, cval=cval
+                self.array, kernel_2d, axes=axes, mode=mode, cval=cval
             )
-            array = xp.asarray(array)
 
         kwargs = self._copy_kwargs(exclude=("array",))
         kwargs["array"] = array
@@ -2553,17 +2560,19 @@ def _lorentzian_kernel_2d(
 def _apply_convolve_2d_on_axes(array, kernel_2d, axes, mode, cval=0.0):
     """Apply a 2-D convolution on a specified pair of axes of an n-D array.
 
-    Uses FFT-based convolution (``scipy.signal.fftconvolve``) so the cost is
-    O(N log N) per spatial slice — independent of kernel size. The heavy tails
-    of the Lorentzian and Voigtian kernels can make them comparable in size to
-    the image itself, which would be prohibitively slow with direct
-    convolution. The image is first padded according to ``mode`` so that the
-    valid-mode convolution returns the same shape as the input.
+    Uses FFT-based convolution (``scipy.signal.fftconvolve`` on CPU,
+    ``cupyx.scipy.signal.fftconvolve`` on GPU) so the cost is O(N log N) per
+    spatial slice — independent of kernel size. The heavy tails of the
+    Lorentzian and Voigtian kernels can make them comparable in size to the
+    image itself, which would be prohibitively slow with direct convolution.
+    The image is first padded according to ``mode`` so that the valid-mode
+    convolution returns the same shape as the input.
 
     The kernel is broadcast to ``array.ndim`` with size-1 dimensions on all
     axes other than ``axes``. Suitable for ``dask.array.map_overlap``.
     """
-    import scipy.signal
+    xp = get_array_module(array)
+    scipy_signal = get_scipy_module(array).signal
 
     kh, kw = kernel_2d.shape
 
@@ -2582,20 +2591,20 @@ def _apply_convolve_2d_on_axes(array, kernel_2d, axes, mode, cval=0.0):
     pad_widths[axes[1]] = (pw, pw)
 
     if mode == "wrap":
-        padded = np.pad(array, pad_widths, mode="wrap")
+        padded = xp.pad(array, pad_widths, mode="wrap")
     elif mode == "reflect":
-        padded = np.pad(array, pad_widths, mode="reflect")
+        padded = xp.pad(array, pad_widths, mode="reflect")
     elif mode == "constant":
-        padded = np.pad(array, pad_widths, mode="constant", constant_values=cval)
+        padded = xp.pad(array, pad_widths, mode="constant", constant_values=cval)
     else:
         raise ValueError(f"Unknown convolution mode: {mode!r}")
 
     shape = [1] * array.ndim
     shape[axes[0]] = kh
     shape[axes[1]] = kw
-    kernel_nd = kernel_2d.reshape(shape)
+    kernel_nd = xp.asarray(kernel_2d).reshape(shape)
 
-    result = scipy.signal.fftconvolve(padded, kernel_nd, mode="valid", axes=axes)
+    result = scipy_signal.fftconvolve(padded, kernel_nd, mode="valid", axes=axes)
     return result.astype(array.dtype, copy=False)
     return array
 
@@ -2651,9 +2660,8 @@ def _lorentzian_source_size(
         )
     else:
         array = _apply_convolve_2d_on_axes(
-            np.asarray(measurements.array), kernel_2d, axes=axes, mode="wrap"
+            measurements.array, kernel_2d, axes=axes, mode="wrap"
         )
-        array = xp.asarray(array)
 
     kwargs = measurements._copy_kwargs(exclude=("array",))
     return measurements.__class__(array, **kwargs)

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -1153,8 +1153,15 @@ class _BaseMeasurement2D(BaseMeasurements):
         """
         Apply a 2D Lorentzian (Cauchy) filter to measurements.
 
-        The filter is applied separately along each axis (separable convolution),
-        which is consistent with how :meth:`gaussian_filter` works.
+        The filter convolves the image with the **true** 2-D Lorentzian profile
+
+            L(x, y) = 1 / (1 + (x/γ_x)² + (y/γ_y)²)
+
+        which is **not** separable into a product of 1-D Lorentzians (unlike a
+        Gaussian). A separable implementation would produce a cross-shaped
+        impulse response — several times brighter along the x and y axes than
+        along the diagonal at the same radius — which manifests as visible
+        halos/lines around sharp features.
 
         Parameters
         ----------
@@ -1162,7 +1169,8 @@ class _BaseMeasurement2D(BaseMeasurements):
             Half-width at half-maximum (HWHM) of the Lorentzian kernel in the ``x``
             and ``y``-direction given in physical units (Å for real-space images,
             1/Å for diffraction patterns). If given as a single number, the
-            half-width is equal for both axes.
+            half-width is equal for both axes (isotropic kernel); otherwise the
+            kernel is elliptical.
         truncate : float, optional
             Truncate the kernel at this many half-widths (default is 10.0). The
             Lorentzian has heavier tails than the Gaussian, so a larger truncation
@@ -1203,30 +1211,36 @@ class _BaseMeasurement2D(BaseMeasurements):
 
         hw_pixels = tuple(hw / d for hw, d in zip(half_width, self.sampling))
 
-        n_ensemble = len(self.shape) - 2
-        kernels = [None] * n_ensemble + [
-            _lorentzian_kernel_1d(hw, truncate) for hw in hw_pixels
-        ]
+        # Two spatial axes are the trailing dims; build a true 2-D kernel.
+        axes = (self.array.ndim - 2, self.array.ndim - 1)
+        kernel_2d = _lorentzian_kernel_2d(hw_pixels, truncate)
 
         if self.is_lazy:
-            radii = [len(k) // 2 if k is not None else 0 for k in kernels]
-            depth = tuple(min(r, n) for r, n in zip(radii, self.shape))
+            depth = [0] * self.array.ndim
+            depth[axes[0]] = min(kernel_2d.shape[0] // 2, self.shape[axes[0]])
+            depth[axes[1]] = min(kernel_2d.shape[1] // 2, self.shape[axes[1]])
 
             array = da.map_overlap(
-                functools.partial(_apply_convolve1d, kernels=kernels, mode=mode, cval=cval),
+                functools.partial(
+                    _apply_convolve_2d_on_axes,
+                    kernel_2d=kernel_2d,
+                    axes=axes,
+                    mode=mode,
+                    cval=cval,
+                ),
                 self.array,
-                depth=depth,
+                depth=tuple(depth),
                 boundary=boundary,
                 meta=xp.array((), dtype=xp.float32),
             )
         else:
-            ndimage = get_ndimage_module(self.array)
-            array = self.array
-            for axis, kernel in enumerate(kernels):
-                if kernel is not None:
-                    array = ndimage.convolve1d(
-                        array, xp.asarray(kernel), axis=axis, mode=mode, cval=cval
-                    )
+            # Use FFT-based convolution: cost is independent of kernel size,
+            # which matters because the heavy-tailed Lorentzian kernel can
+            # easily be comparable in size to the image itself.
+            array = _apply_convolve_2d_on_axes(
+                np.asarray(self.array), kernel_2d, axes=axes, mode=mode, cval=cval
+            )
+            array = xp.asarray(array)
 
         kwargs = self._copy_kwargs(exclude=("array",))
         kwargs["array"] = array
@@ -1236,16 +1250,19 @@ class _BaseMeasurement2D(BaseMeasurements):
         self,
         gaussian_sigma: float | tuple[float, float],
         lorentzian_gamma: float | tuple[float, float],
-        truncate: float = 5.0,
+        truncate: float = 10.0,
         boundary: str = "periodic",
         cval: float = 0.0,
     ):
         """
-        Apply a 2D Voigt filter to measurements.
+        Apply a 2D Voigtian filter to measurements.
 
         The Voigt profile is the convolution of a Gaussian and a Lorentzian.
-        The filter is applied separately along each axis (separable convolution),
-        which is consistent with how :meth:`gaussian_filter` works.
+        Exploiting the associativity of convolution, the filter is implemented
+        as :meth:`gaussian_filter` followed by :meth:`lorentzian_filter`, which
+        uses the true 2-D (non-separable) Lorentzian kernel and therefore
+        avoids the cross-shaped artefacts a naively separable Voigt filter
+        would produce.
 
         Parameters
         ----------
@@ -1257,8 +1274,9 @@ class _BaseMeasurement2D(BaseMeasurements):
             Half-width at half-maximum (HWHM, γ) of the Lorentzian component in
             physical units. If given as a single number it is equal for both axes.
         truncate : float, optional
-            Truncate the kernel at this many Voigt half-widths (default is 5.0).
-            The Voigt HWHM is estimated via the Thompson et al. (1987) approximation.
+            Truncate the Lorentzian component at this many half-widths
+            (default is 10.0). The Gaussian component uses the SciPy default
+            (4·σ).
         boundary : {'periodic', 'reflect', 'constant'}
             How the image is extended beyond its boundary (default is 'periodic').
         cval : float, optional
@@ -1282,54 +1300,11 @@ class _BaseMeasurement2D(BaseMeasurements):
         *not* directly comparable: for the same FWHM, γ = FWHM / 2 whereas
         σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
         """
-        xp = get_array_module(self.array)
-
-        if boundary == "periodic":
-            mode = "wrap"
-        elif boundary in ("reflect", "constant"):
-            mode = boundary
-        else:
-            raise ValueError(
-                f"boundary must be 'periodic', 'reflect', or 'constant', got {boundary!r}"
-            )
-
-        if np.isscalar(gaussian_sigma):
-            gaussian_sigma = (gaussian_sigma,) * 2
-        if np.isscalar(lorentzian_gamma):
-            lorentzian_gamma = (lorentzian_gamma,) * 2
-
-        sigma_pixels = tuple(s / d for s, d in zip(gaussian_sigma, self.sampling))
-        gamma_pixels = tuple(g / d for g, d in zip(lorentzian_gamma, self.sampling))
-
-        n_ensemble = len(self.shape) - 2
-        kernels = [None] * n_ensemble + [
-            _voigt_kernel_1d(s, g, truncate)
-            for s, g in zip(sigma_pixels, gamma_pixels)
-        ]
-
-        if self.is_lazy:
-            radii = [len(k) // 2 if k is not None else 0 for k in kernels]
-            depth = tuple(min(r, n) for r, n in zip(radii, self.shape))
-
-            array = da.map_overlap(
-                functools.partial(_apply_convolve1d, kernels=kernels, mode=mode, cval=cval),
-                self.array,
-                depth=depth,
-                boundary=boundary,
-                meta=xp.array((), dtype=xp.float32),
-            )
-        else:
-            ndimage = get_ndimage_module(self.array)
-            array = self.array
-            for axis, kernel in enumerate(kernels):
-                if kernel is not None:
-                    array = ndimage.convolve1d(
-                        array, xp.asarray(kernel), axis=axis, mode=mode, cval=cval
-                    )
-
-        kwargs = self._copy_kwargs(exclude=("array",))
-        kwargs["array"] = array
-        return self.__class__(**kwargs)
+        return self.gaussian_filter(
+            gaussian_sigma, boundary=boundary, cval=cval
+        ).lorentzian_filter(
+            lorentzian_gamma, truncate=truncate, boundary=boundary, cval=cval
+        )
 
     def pseudo_voigtian_filter(
         self,
@@ -1345,8 +1320,11 @@ class _BaseMeasurement2D(BaseMeasurements):
 
         The pseudo-Voigt profile is a weighted linear sum of a Gaussian and a
         Lorentzian — PV = (1-η)·G + η·L — as proposed by Nguyen et al. (2014).
-        The filter is applied separately along each axis (separable convolution),
-        consistent with how :meth:`gaussian_filter` works.
+        Exploiting the linearity of convolution, the filter is implemented as
+        the linear combination of :meth:`gaussian_filter` and
+        :meth:`lorentzian_filter`, which uses the true 2-D (non-separable)
+        Lorentzian kernel and therefore avoids the cross-shaped artefacts a
+        naively separable filter would produce.
 
         Parameters
         ----------
@@ -1362,8 +1340,8 @@ class _BaseMeasurement2D(BaseMeasurements):
             (equivalent to :meth:`gaussian_filter`); η = 1 gives a pure
             Lorentzian (equivalent to :meth:`lorentzian_filter`).
         truncate : float, optional
-            Truncate the kernel at this many effective half-widths (default 10.0).
-            The effective half-width is max(σ, γ).
+            Truncate the Lorentzian component at this many half-widths
+            (default 10.0). The Gaussian component uses the SciPy default (4·σ).
         boundary : {'periodic', 'reflect', 'constant'}
             How the image is extended beyond its boundary (default is 'periodic').
         cval : float, optional
@@ -1383,53 +1361,19 @@ class _BaseMeasurement2D(BaseMeasurements):
 
         For the same FWHM, γ = FWHM / 2 whereas σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
         """
-        xp = get_array_module(self.array)
-
-        if boundary == "periodic":
-            mode = "wrap"
-        elif boundary in ("reflect", "constant"):
-            mode = boundary
-        else:
-            raise ValueError(
-                f"boundary must be 'periodic', 'reflect', or 'constant', got {boundary!r}"
+        if eta == 0.0:
+            return self.gaussian_filter(gaussian_sigma, boundary=boundary, cval=cval)
+        if eta == 1.0:
+            return self.lorentzian_filter(
+                lorentzian_gamma, truncate=truncate, boundary=boundary, cval=cval
             )
 
-        if np.isscalar(gaussian_sigma):
-            gaussian_sigma = (gaussian_sigma,) * 2
-        if np.isscalar(lorentzian_gamma):
-            lorentzian_gamma = (lorentzian_gamma,) * 2
-
-        sigma_pixels = tuple(s / d for s, d in zip(gaussian_sigma, self.sampling))
-        gamma_pixels = tuple(g / d for g, d in zip(lorentzian_gamma, self.sampling))
-
-        n_ensemble = len(self.shape) - 2
-        kernels = [None] * n_ensemble + [
-            _pseudo_voigt_kernel_1d(s, g, eta, truncate)
-            for s, g in zip(sigma_pixels, gamma_pixels)
-        ]
-
-        if self.is_lazy:
-            radii = [len(k) // 2 if k is not None else 0 for k in kernels]
-            depth = tuple(min(r, n) for r, n in zip(radii, self.shape))
-
-            array = da.map_overlap(
-                functools.partial(_apply_convolve1d, kernels=kernels, mode=mode, cval=cval),
-                self.array,
-                depth=depth,
-                boundary=boundary,
-                meta=xp.array((), dtype=xp.float32),
-            )
-        else:
-            ndimage = get_ndimage_module(self.array)
-            array = self.array
-            for axis, kernel in enumerate(kernels):
-                if kernel is not None:
-                    array = ndimage.convolve1d(
-                        array, xp.asarray(kernel), axis=axis, mode=mode, cval=cval
-                    )
-
+        g = self.gaussian_filter(gaussian_sigma, boundary=boundary, cval=cval)
+        l = self.lorentzian_filter(
+            lorentzian_gamma, truncate=truncate, boundary=boundary, cval=cval
+        )
         kwargs = self._copy_kwargs(exclude=("array",))
-        kwargs["array"] = array
+        kwargs["array"] = (1.0 - eta) * g.array + eta * l.array
         return self.__class__(**kwargs)
 
     def interpolate_line_at_position(
@@ -2558,128 +2502,101 @@ def _fourier_space_bilinear_nodes_and_weight(
 _LORENTZIAN_SAFE_HW = 1.0 / np.sqrt(np.finfo(np.float64).max)  # ≈ 7.5e-155
 
 
-def _lorentzian_kernel_1d(half_width_pixels: float, truncate: float = 10.0) -> np.ndarray:
-    """Build a normalized 1-D Lorentzian (Cauchy) convolution kernel in pixel units.
-
-    When ``half_width_pixels`` is zero or so small that the filter is effectively a
-    unit impulse (kernel narrower than the arithmetic precision allows), a delta
-    kernel is returned — consistent with ``gaussian_filter`` at sigma=0.
-    """
-    if half_width_pixels < _LORENTZIAN_SAFE_HW:
-        return np.array([1.0], dtype=np.float32)
-    radius = int(np.ceil(truncate * half_width_pixels))
-    x = np.arange(-radius, radius + 1, dtype=np.float64)
-    kernel = 1.0 / (1.0 + (x / half_width_pixels) ** 2)
-    return (kernel / kernel.sum()).astype(np.float32)
-
-
-def _voigt_kernel_1d(
-    sigma_pixels: float,
-    gamma_pixels: float,
-    truncate: float = 5.0,
-) -> np.ndarray:
-    """Build a normalized 1-D Voigt convolution kernel in pixel units.
-
-    Uses the exact Voigt profile (Faddeeva function) when both components are
-    non-zero, falls back to pure Gaussian / Lorentzian for degenerate cases, and
-    returns a unit impulse when both are zero (leaving the data unchanged).
-    """
-    from scipy.special import wofz
-
-    # Clamp values below the safe threshold to zero to avoid overflow
-    if sigma_pixels < _LORENTZIAN_SAFE_HW:
-        sigma_pixels = 0.0
-    if gamma_pixels < _LORENTZIAN_SAFE_HW:
-        gamma_pixels = 0.0
-
-    if sigma_pixels == 0.0 and gamma_pixels == 0.0:
-        return np.array([1.0], dtype=np.float32)
-
-    fG = 2.0 * sigma_pixels * np.sqrt(2.0 * np.log(2.0))
-    fL = 2.0 * gamma_pixels
-    if sigma_pixels == 0.0:
-        voigt_hwhm = gamma_pixels
-    elif gamma_pixels == 0.0:
-        voigt_hwhm = fG / 2.0
-    else:
-        f5 = (
-            fG**5
-            + 2.69269 * fG**4 * fL
-            + 2.42843 * fG**3 * fL**2
-            + 4.47163 * fG**2 * fL**3
-            + 0.07842 * fG * fL**4
-            + fL**5
-        )
-        voigt_hwhm = f5 ** (1.0 / 5.0) / 2.0
-
-    radius = int(np.ceil(truncate * voigt_hwhm))
-    x = np.arange(-radius, radius + 1, dtype=np.float64)
-
-    if sigma_pixels == 0.0:
-        kernel = 1.0 / (1.0 + (x / gamma_pixels) ** 2)
-    elif gamma_pixels == 0.0:
-        kernel = np.exp(-0.5 * x**2 / sigma_pixels**2)
-    else:
-        z = (x + 1j * gamma_pixels) / (sigma_pixels * np.sqrt(2.0))
-        kernel = np.real(wofz(z))
-
-    return (kernel / kernel.sum()).astype(np.float32)
-
-
-def _pseudo_voigt_kernel_1d(
-    sigma_pixels: float,
-    gamma_pixels: float,
-    eta: float,
+def _lorentzian_kernel_2d(
+    hw_pixels: tuple[float, float],
     truncate: float = 10.0,
 ) -> np.ndarray:
-    """Build a normalized 1-D pseudo-Voigt convolution kernel in pixel units.
+    """Build a normalized 2-D Lorentzian (Cauchy) convolution kernel in pixel units.
 
-    The kernel is the weighted sum (1-eta)*G + eta*L evaluated on a shared grid,
-    where G is a Gaussian and L is a Lorentzian. Returns a delta kernel when both
-    sigma_pixels and gamma_pixels are effectively zero.
+    The kernel is the **true** 2-D Lorentzian profile
+
+        L(x, y) = 1 / (1 + (x/γ_x)² + (y/γ_y)²)
+
+    which is **not** separable into a product of 1-D Lorentzians. Filtering with
+    a separable Lorentzian (outer product of two 1-D kernels) produces a
+    non-rotationally-symmetric impulse response that is several times brighter
+    along the axes than along the diagonal at the same radius, manifesting as
+    cross-shaped halos around sharp features. This 2-D kernel avoids that
+    artefact (it is elliptical when γ_x ≠ γ_y, isotropic when γ_x = γ_y).
+
+    Parameters
+    ----------
+    hw_pixels : tuple of two float
+        Half-width at half-maximum along each axis (axis 0, axis 1) in pixel
+        units. An axis with HWHM below ``_LORENTZIAN_SAFE_HW`` is treated as
+        zero and contributes a delta along that axis.
+    truncate : float
+        Truncate the kernel at this many half-widths along each axis.
     """
-    if sigma_pixels < _LORENTZIAN_SAFE_HW:
-        sigma_pixels = 0.0
-    if gamma_pixels < _LORENTZIAN_SAFE_HW:
-        gamma_pixels = 0.0
+    hw0, hw1 = hw_pixels
 
-    hw = max(sigma_pixels, gamma_pixels)
-    if hw == 0.0:
-        return np.array([1.0], dtype=np.float32)
+    zero0 = hw0 < _LORENTZIAN_SAFE_HW
+    zero1 = hw1 < _LORENTZIAN_SAFE_HW
 
-    radius = int(np.ceil(truncate * hw))
-    x = np.arange(-radius, radius + 1, dtype=np.float64)
+    if zero0 and zero1:
+        return np.array([[1.0]], dtype=np.float32)
 
-    if sigma_pixels > 0.0:
-        g = np.exp(-0.5 * (x / sigma_pixels) ** 2)
-    else:
-        g = np.zeros(len(x))
-        g[radius] = 1.0  # delta at center
+    radius0 = 0 if zero0 else int(np.ceil(truncate * hw0))
+    radius1 = 0 if zero1 else int(np.ceil(truncate * hw1))
+    y = np.arange(-radius0, radius0 + 1, dtype=np.float64)[:, None]
+    x = np.arange(-radius1, radius1 + 1, dtype=np.float64)[None, :]
 
-    if gamma_pixels > 0.0:
-        l = 1.0 / (1.0 + (x / gamma_pixels) ** 2)
-    else:
-        l = np.zeros(len(x))
-        l[radius] = 1.0  # delta at center
-
-    kernel = (1.0 - eta) * g + eta * l
+    denom = np.broadcast_to(np.ones(()), (y.shape[0], x.shape[1])).copy()
+    if not zero0:
+        denom = denom + (y / hw0) ** 2
+    if not zero1:
+        denom = denom + (x / hw1) ** 2
+    kernel = 1.0 / denom
     return (kernel / kernel.sum()).astype(np.float32)
 
 
-def _apply_convolve1d(array, kernels, mode, cval=0.0):
-    """Apply 1-D convolutions along each axis using ``scipy.ndimage.convolve1d``.
+def _apply_convolve_2d_on_axes(array, kernel_2d, axes, mode, cval=0.0):
+    """Apply a 2-D convolution on a specified pair of axes of an n-D array.
 
-    Used as the callable passed to ``dask.array.map_overlap`` so that it
-    always runs on CPU (NumPy) chunks.  ``kernels`` is a list aligned with
-    ``array.ndim``; ``None`` entries skip the corresponding axis.
+    Uses FFT-based convolution (``scipy.signal.fftconvolve``) so the cost is
+    O(N log N) per spatial slice — independent of kernel size. The heavy tails
+    of the Lorentzian and Voigtian kernels can make them comparable in size to
+    the image itself, which would be prohibitively slow with direct
+    convolution. The image is first padded according to ``mode`` so that the
+    valid-mode convolution returns the same shape as the input.
+
+    The kernel is broadcast to ``array.ndim`` with size-1 dimensions on all
+    axes other than ``axes``. Suitable for ``dask.array.map_overlap``.
     """
-    import scipy.ndimage
+    import scipy.signal
 
-    for axis, kernel in enumerate(kernels):
-        if kernel is not None:
-            array = scipy.ndimage.convolve1d(
-                array, kernel, axis=axis, mode=mode, cval=cval
-            )
+    kh, kw = kernel_2d.shape
+
+    # Delta kernel → no-op shortcut.
+    if kh == 1 and kw == 1:
+        return (array * float(kernel_2d[0, 0])).astype(array.dtype, copy=False)
+
+    # Kernels from _lorentzian_kernel_2d always have odd sizes; `valid`-mode
+    # convolution on a (kh//2, kw//2)-padded array then returns the original
+    # shape exactly.
+    ph = kh // 2
+    pw = kw // 2
+
+    pad_widths = [(0, 0)] * array.ndim
+    pad_widths[axes[0]] = (ph, ph)
+    pad_widths[axes[1]] = (pw, pw)
+
+    if mode == "wrap":
+        padded = np.pad(array, pad_widths, mode="wrap")
+    elif mode == "reflect":
+        padded = np.pad(array, pad_widths, mode="reflect")
+    elif mode == "constant":
+        padded = np.pad(array, pad_widths, mode="constant", constant_values=cval)
+    else:
+        raise ValueError(f"Unknown convolution mode: {mode!r}")
+
+    shape = [1] * array.ndim
+    shape[axes[0]] = kh
+    shape[axes[1]] = kw
+    kernel_nd = kernel_2d.reshape(shape)
+
+    result = scipy.signal.fftconvolve(padded, kernel_nd, mode="valid", axes=axes)
+    return result.astype(array.dtype, copy=False)
     return array
 
 
@@ -2688,7 +2605,15 @@ def _lorentzian_source_size(
     half_width: float | tuple[float, float],
     truncate: float = 10.0,
 ):
-    if len(_scan_axes(measurements)) < 2:
+    """Apply a true 2-D Lorentzian convolution across the two scan axes.
+
+    Mirrors :func:`_gaussian_source_size` but uses the non-separable 2-D
+    Lorentzian kernel from :func:`_lorentzian_kernel_2d`, avoiding the
+    cross-shaped artefacts that a separable 1-D × 1-D Lorentzian would
+    produce around sharp features.
+    """
+    scan_axes = _scan_axes(measurements)
+    if len(scan_axes) < 2:
         raise RuntimeError(
             "Lorentzian source size not implemented for diffraction patterns with less"
             " than two scan axes."
@@ -2699,41 +2624,36 @@ def _lorentzian_source_size(
 
     xp = get_array_module(measurements.array)
 
-    ensemble_axes = tuple(range(len(measurements.ensemble_shape)))
-    kernels = []
-    depth = []
-    i = 0
-    for axis, n in zip(ensemble_axes, measurements.ensemble_shape):
-        if axis in _scan_axes(measurements):
-            scan_sampling = _scan_sampling(measurements)[i]
-            hw_pix = half_width[i] / scan_sampling
-            kernel = _lorentzian_kernel_1d(hw_pix, truncate)
-            kernels.append(kernel)
-            depth.append(min(len(kernel) // 2, n))
-            i += 1
-        else:
-            kernels.append(None)
-            depth.append(0)
+    scan_sampling = _scan_sampling(measurements)
+    hw_pixels = (
+        half_width[0] / scan_sampling[0],
+        half_width[1] / scan_sampling[1],
+    )
+    kernel_2d = _lorentzian_kernel_2d(hw_pixels, truncate)
 
-    # Two trailing measurement axes — never filtered
-    kernels += [None, None]
-    depth += [0, 0]
+    axes = (scan_axes[0], scan_axes[1])
 
     if measurements.is_lazy:
+        depth = [0] * measurements.array.ndim
+        depth[axes[0]] = min(kernel_2d.shape[0] // 2, measurements.shape[axes[0]])
+        depth[axes[1]] = min(kernel_2d.shape[1] // 2, measurements.shape[axes[1]])
+
         array = measurements.array.map_overlap(
-            functools.partial(_apply_convolve1d, kernels=kernels, mode="wrap"),
+            functools.partial(
+                _apply_convolve_2d_on_axes,
+                kernel_2d=kernel_2d,
+                axes=axes,
+                mode="wrap",
+            ),
             depth=tuple(depth),
             boundary="periodic",
             meta=xp.array((), dtype=xp.float32),
         )
     else:
-        ndimage = get_ndimage_module(measurements._array)
-        array = measurements.array
-        for axis, kernel in enumerate(kernels):
-            if kernel is not None:
-                array = ndimage.convolve1d(
-                    array, xp.asarray(kernel), axis=axis, mode="wrap"
-                )
+        array = _apply_convolve_2d_on_axes(
+            np.asarray(measurements.array), kernel_2d, axes=axes, mode="wrap"
+        )
+        array = xp.asarray(array)
 
     kwargs = measurements._copy_kwargs(exclude=("array",))
     return measurements.__class__(array, **kwargs)
@@ -2743,59 +2663,22 @@ def _voigtian_source_size(
     measurements,
     gaussian_sigma: float | tuple[float, float],
     lorentzian_gamma: float | tuple[float, float],
-    truncate: float = 5.0,
+    truncate: float = 10.0,
 ):
+    """Apply a Voigtian source-size convolution via Gaussian then Lorentzian.
+
+    Exploits the associativity of convolution: convolving with a Voigt profile
+    (Gaussian ∗ Lorentzian) is equivalent to convolving sequentially with a
+    Gaussian and then with a Lorentzian. The Lorentzian step uses the true
+    2-D non-separable kernel.
+    """
     if len(_scan_axes(measurements)) < 2:
         raise RuntimeError(
-            "Voigt source size not implemented for diffraction patterns with less"
+            "Voigtian source size not implemented for diffraction patterns with less"
             " than two scan axes."
         )
-
-    if np.isscalar(gaussian_sigma):
-        gaussian_sigma = (gaussian_sigma,) * 2
-    if np.isscalar(lorentzian_gamma):
-        lorentzian_gamma = (lorentzian_gamma,) * 2
-
-    xp = get_array_module(measurements.array)
-
-    ensemble_axes = tuple(range(len(measurements.ensemble_shape)))
-    kernels = []
-    depth = []
-    i = 0
-    for axis, n in zip(ensemble_axes, measurements.ensemble_shape):
-        if axis in _scan_axes(measurements):
-            scan_sampling = _scan_sampling(measurements)[i]
-            sigma_pix = gaussian_sigma[i] / scan_sampling
-            gamma_pix = lorentzian_gamma[i] / scan_sampling
-            kernel = _voigt_kernel_1d(sigma_pix, gamma_pix, truncate)
-            kernels.append(kernel)
-            depth.append(min(len(kernel) // 2, n))
-            i += 1
-        else:
-            kernels.append(None)
-            depth.append(0)
-
-    kernels += [None, None]
-    depth += [0, 0]
-
-    if measurements.is_lazy:
-        array = measurements.array.map_overlap(
-            functools.partial(_apply_convolve1d, kernels=kernels, mode="wrap"),
-            depth=tuple(depth),
-            boundary="periodic",
-            meta=xp.array((), dtype=xp.float32),
-        )
-    else:
-        ndimage = get_ndimage_module(measurements._array)
-        array = measurements.array
-        for axis, kernel in enumerate(kernels):
-            if kernel is not None:
-                array = ndimage.convolve1d(
-                    array, xp.asarray(kernel), axis=axis, mode="wrap"
-                )
-
-    kwargs = measurements._copy_kwargs(exclude=("array",))
-    return measurements.__class__(array, **kwargs)
+    g = _gaussian_source_size(measurements, gaussian_sigma)
+    return _lorentzian_source_size(g, lorentzian_gamma, truncate)
 
 
 def _pseudo_voigtian_source_size(
@@ -2805,57 +2688,29 @@ def _pseudo_voigtian_source_size(
     eta: float,
     truncate: float = 10.0,
 ):
+    """Apply a pseudo-Voigtian source-size convolution via a linear combination.
+
+    Exploits the linearity of convolution: PV = (1−η)·G + η·L, so the
+    pseudo-Voigt-filtered image is the same weighted combination of the
+    Gaussian- and Lorentzian-filtered images. Each component is computed
+    with its proper (separable Gaussian / true-2-D Lorentzian) kernel.
+    """
     if len(_scan_axes(measurements)) < 2:
         raise RuntimeError(
             "Pseudo-Voigtian source size not implemented for diffraction patterns"
             " with less than two scan axes."
         )
+    if eta == 0.0:
+        return _gaussian_source_size(measurements, gaussian_sigma)
+    if eta == 1.0:
+        return _lorentzian_source_size(measurements, lorentzian_gamma, truncate)
 
-    if np.isscalar(gaussian_sigma):
-        gaussian_sigma = (gaussian_sigma,) * 2
-    if np.isscalar(lorentzian_gamma):
-        lorentzian_gamma = (lorentzian_gamma,) * 2
-
-    xp = get_array_module(measurements.array)
-
-    ensemble_axes = tuple(range(len(measurements.ensemble_shape)))
-    kernels = []
-    depth = []
-    i = 0
-    for axis, n in zip(ensemble_axes, measurements.ensemble_shape):
-        if axis in _scan_axes(measurements):
-            scan_sampling = _scan_sampling(measurements)[i]
-            sigma_pix = gaussian_sigma[i] / scan_sampling
-            gamma_pix = lorentzian_gamma[i] / scan_sampling
-            kernel = _pseudo_voigt_kernel_1d(sigma_pix, gamma_pix, eta, truncate)
-            kernels.append(kernel)
-            depth.append(min(len(kernel) // 2, n))
-            i += 1
-        else:
-            kernels.append(None)
-            depth.append(0)
-
-    kernels += [None, None]
-    depth += [0, 0]
-
-    if measurements.is_lazy:
-        array = measurements.array.map_overlap(
-            functools.partial(_apply_convolve1d, kernels=kernels, mode="wrap"),
-            depth=tuple(depth),
-            boundary="periodic",
-            meta=xp.array((), dtype=xp.float32),
-        )
-    else:
-        ndimage = get_ndimage_module(measurements._array)
-        array = measurements.array
-        for axis, kernel in enumerate(kernels):
-            if kernel is not None:
-                array = ndimage.convolve1d(
-                    array, xp.asarray(kernel), axis=axis, mode="wrap"
-                )
-
+    g = _gaussian_source_size(measurements, gaussian_sigma)
+    l = _lorentzian_source_size(measurements, lorentzian_gamma, truncate)
     kwargs = measurements._copy_kwargs(exclude=("array",))
-    return measurements.__class__(array, **kwargs)
+    return measurements.__class__(
+        (1.0 - eta) * g.array + eta * l.array, **kwargs
+    )
 
 
 def _gaussian_source_size(measurements, sigma: float | tuple[float, float]):
@@ -3614,7 +3469,7 @@ class DiffractionPatterns(_BaseMeasurement2D):
         self,
         gaussian_sigma: float | tuple[float, float],
         lorentzian_gamma: float | tuple[float, float],
-        truncate: float = 5.0,
+        truncate: float = 10.0,
     ) -> DiffractionPatterns:
         """
         Simulate the effect of a finite source size on diffraction pattern(s) using a
@@ -3634,7 +3489,8 @@ class DiffractionPatterns(_BaseMeasurement2D):
             Half-width at half-maximum (HWHM, γ) of the Lorentzian component [Å].
             If given as a single number it is equal for both axes.
         truncate : float, optional
-            Truncate the kernel at this many Voigt half-widths (default is 5.0).
+            Truncate the Lorentzian component at this many half-widths
+            (default 10.0). The Gaussian component uses the SciPy default (4·σ).
 
         Returns
         -------
@@ -4718,7 +4574,7 @@ class PolarMeasurements(BaseMeasurements):
         self,
         gaussian_sigma: float | tuple[float, float],
         lorentzian_gamma: float | tuple[float, float],
-        truncate: float = 5.0,
+        truncate: float = 10.0,
     ) -> PolarMeasurements:
         """
         Simulate the effect of a finite source size on polar measurement(s) using a
@@ -4736,7 +4592,8 @@ class PolarMeasurements(BaseMeasurements):
             Half-width at half-maximum (HWHM, γ) of the Lorentzian component [Å].
             If given as a single number it is equal for both axes.
         truncate : float, optional
-            Truncate the kernel at this many Voigt half-widths (default is 5.0).
+            Truncate the Lorentzian component at this many half-widths
+            (default 10.0). The Gaussian component uses the SciPy default (4·σ).
 
         Returns
         -------

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -2614,9 +2614,12 @@ def _apply_convolve_2d_on_axes(array, kernel_2d, axes, mode, cval=0.0):
 
     # Convolve over all axes (no ``axes=`` kwarg). The size-1 dims of the
     # kernel make the FFT along non-target axes a length-1 no-op, so the
-    # result is identical to passing ``axes=axes`` — but we stay compatible
-    # with CuPy versions whose cupyx.scipy.signal.fftconvolve predates the
-    # ``axes`` parameter.
+    # result is numerically identical to passing ``axes=axes`` — verified
+    # against scipy.signal.fftconvolve with explicit axes. We do not depend
+    # on the kwarg purely for code simplicity; ``axes=`` has actually been
+    # available in cupyx.scipy.signal.fftconvolve since the first version
+    # that shipped fftconvolve (CuPy 9.0, April 2021), which is also the
+    # effective minimum CuPy version for any GPU code in this module.
     #
     # cupyx.scipy.signal.fftconvolve internally uses cupyx.jit.rawkernel,
     # which raises a FutureWarning ("cupyx.jit.rawkernel is experimental ...").

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -1186,15 +1186,6 @@ class _BaseMeasurement2D(BaseMeasurements):
         Note that :meth:`gaussian_filter` uses the standard deviation σ as its
         width parameter. For the same FWHM one needs γ = FWHM / 2 whereas
         σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
-
-        The Lorentzian source-size model is described in [1]_.
-
-        References
-        ----------
-        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
-           function in scanning transmission electron microscopy and spectroscopy",
-           *Ultramicroscopy* **146**, 6–16 (2014).
-           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         xp = get_array_module(self.array)
 
@@ -1290,15 +1281,6 @@ class _BaseMeasurement2D(BaseMeasurements):
         Because the two components use different parameterizations, σ and γ are
         *not* directly comparable: for the same FWHM, γ = FWHM / 2 whereas
         σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
-
-        The Voigt source-size model is described in [1]_.
-
-        References
-        ----------
-        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
-           function in scanning transmission electron microscopy and spectroscopy",
-           *Ultramicroscopy* **146**, 6–16 (2014).
-           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         xp = get_array_module(self.array)
 
@@ -3424,15 +3406,6 @@ class DiffractionPatterns(_BaseMeasurement2D):
         The Lorentzian kernel is parameterized by its HWHM γ (``half_width``),
         with FWHM_L = 2γ. This differs from :meth:`gaussian_source_size`,
         which uses the standard deviation σ (FWHM_G ≈ 2.3548·σ).
-
-        The Lorentzian source-size model is described in [1]_.
-
-        References
-        ----------
-        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
-           function in scanning transmission electron microscopy and spectroscopy",
-           *Ultramicroscopy* **146**, 6–16 (2014).
-           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         return _lorentzian_source_size(self, half_width, truncate)
 
@@ -3477,15 +3450,6 @@ class DiffractionPatterns(_BaseMeasurement2D):
           FWHM_L = 2γ.
 
         For the same FWHM, γ = FWHM / 2 but σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
-
-        The Voigt source-size model is described in [1]_.
-
-        References
-        ----------
-        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
-           function in scanning transmission electron microscopy and spectroscopy",
-           *Ultramicroscopy* **146**, 6–16 (2014).
-           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         return _voigtian_source_size(self, gaussian_sigma, lorentzian_gamma, truncate)
 
@@ -4501,15 +4465,6 @@ class PolarMeasurements(BaseMeasurements):
         The Lorentzian kernel is parameterized by its HWHM γ (``half_width``),
         with FWHM_L = 2γ. This differs from :meth:`gaussian_source_size`,
         which uses the standard deviation σ (FWHM_G ≈ 2.3548·σ).
-
-        The Lorentzian source-size model is described in [1]_.
-
-        References
-        ----------
-        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
-           function in scanning transmission electron microscopy and spectroscopy",
-           *Ultramicroscopy* **146**, 6–16 (2014).
-           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         return _lorentzian_source_size(self, half_width, truncate)
 
@@ -4552,15 +4507,6 @@ class PolarMeasurements(BaseMeasurements):
           FWHM_L = 2γ.
 
         For the same FWHM, γ = FWHM / 2 but σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
-
-        The Voigt source-size model is described in [1]_.
-
-        References
-        ----------
-        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
-           function in scanning transmission electron microscopy and spectroscopy",
-           *Ultramicroscopy* **146**, 6–16 (2014).
-           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         return _voigtian_source_size(self, gaussian_sigma, lorentzian_gamma, truncate)
 

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -1331,6 +1331,107 @@ class _BaseMeasurement2D(BaseMeasurements):
         kwargs["array"] = array
         return self.__class__(**kwargs)
 
+    def pseudo_voigtian_filter(
+        self,
+        gaussian_sigma: float | tuple[float, float],
+        lorentzian_gamma: float | tuple[float, float],
+        eta: float,
+        truncate: float = 10.0,
+        boundary: str = "periodic",
+        cval: float = 0.0,
+    ):
+        """
+        Apply a 2D pseudo-Voigtian filter to measurements.
+
+        The pseudo-Voigt profile is a weighted linear sum of a Gaussian and a
+        Lorentzian — PV = (1-η)·G + η·L — as proposed by Nguyen et al. (2014).
+        The filter is applied separately along each axis (separable convolution),
+        consistent with how :meth:`gaussian_filter` works.
+
+        Parameters
+        ----------
+        gaussian_sigma : float or two float
+            Standard deviation (σ) of the Gaussian component in physical units
+            (Å for real-space images, 1/Å for diffraction patterns). If given
+            as a single number it is equal for both axes.
+        lorentzian_gamma : float or two float
+            Half-width at half-maximum (HWHM, γ) of the Lorentzian component in
+            physical units. If given as a single number it is equal for both axes.
+        eta : float
+            Lorentzian mixing fraction η ∈ [0, 1]. η = 0 gives a pure Gaussian
+            (equivalent to :meth:`gaussian_filter`); η = 1 gives a pure
+            Lorentzian (equivalent to :meth:`lorentzian_filter`).
+        truncate : float, optional
+            Truncate the kernel at this many effective half-widths (default 10.0).
+            The effective half-width is max(σ, γ).
+        boundary : {'periodic', 'reflect', 'constant'}
+            How the image is extended beyond its boundary (default is 'periodic').
+        cval : float, optional
+            Constant value used when ``boundary`` is ``'constant'`` (default 0.0).
+
+        Returns
+        -------
+        filtered : same type as input
+            The filtered measurement(s).
+
+        Notes
+        -----
+        Width parameterization:
+
+        * ``gaussian_sigma`` (σ): standard deviation; FWHM_G = 2√(2 ln 2)·σ ≈ 2.3548·σ.
+        * ``lorentzian_gamma`` (γ): HWHM; FWHM_L = 2γ.
+
+        For the same FWHM, γ = FWHM / 2 whereas σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
+        """
+        xp = get_array_module(self.array)
+
+        if boundary == "periodic":
+            mode = "wrap"
+        elif boundary in ("reflect", "constant"):
+            mode = boundary
+        else:
+            raise ValueError(
+                f"boundary must be 'periodic', 'reflect', or 'constant', got {boundary!r}"
+            )
+
+        if np.isscalar(gaussian_sigma):
+            gaussian_sigma = (gaussian_sigma,) * 2
+        if np.isscalar(lorentzian_gamma):
+            lorentzian_gamma = (lorentzian_gamma,) * 2
+
+        sigma_pixels = tuple(s / d for s, d in zip(gaussian_sigma, self.sampling))
+        gamma_pixels = tuple(g / d for g, d in zip(lorentzian_gamma, self.sampling))
+
+        n_ensemble = len(self.shape) - 2
+        kernels = [None] * n_ensemble + [
+            _pseudo_voigt_kernel_1d(s, g, eta, truncate)
+            for s, g in zip(sigma_pixels, gamma_pixels)
+        ]
+
+        if self.is_lazy:
+            radii = [len(k) // 2 if k is not None else 0 for k in kernels]
+            depth = tuple(min(r, n) for r, n in zip(radii, self.shape))
+
+            array = da.map_overlap(
+                functools.partial(_apply_convolve1d, kernels=kernels, mode=mode, cval=cval),
+                self.array,
+                depth=depth,
+                boundary=boundary,
+                meta=xp.array((), dtype=xp.float32),
+            )
+        else:
+            ndimage = get_ndimage_module(self.array)
+            array = self.array
+            for axis, kernel in enumerate(kernels):
+                if kernel is not None:
+                    array = ndimage.convolve1d(
+                        array, xp.asarray(kernel), axis=axis, mode=mode, cval=cval
+                    )
+
+        kwargs = self._copy_kwargs(exclude=("array",))
+        kwargs["array"] = array
+        return self.__class__(**kwargs)
+
     def interpolate_line_at_position(
         self,
         center: tuple[float, float] | Atom,
@@ -2525,6 +2626,46 @@ def _voigt_kernel_1d(
     return (kernel / kernel.sum()).astype(np.float32)
 
 
+def _pseudo_voigt_kernel_1d(
+    sigma_pixels: float,
+    gamma_pixels: float,
+    eta: float,
+    truncate: float = 10.0,
+) -> np.ndarray:
+    """Build a normalized 1-D pseudo-Voigt convolution kernel in pixel units.
+
+    The kernel is the weighted sum (1-eta)*G + eta*L evaluated on a shared grid,
+    where G is a Gaussian and L is a Lorentzian. Returns a delta kernel when both
+    sigma_pixels and gamma_pixels are effectively zero.
+    """
+    if sigma_pixels < _LORENTZIAN_SAFE_HW:
+        sigma_pixels = 0.0
+    if gamma_pixels < _LORENTZIAN_SAFE_HW:
+        gamma_pixels = 0.0
+
+    hw = max(sigma_pixels, gamma_pixels)
+    if hw == 0.0:
+        return np.array([1.0], dtype=np.float32)
+
+    radius = int(np.ceil(truncate * hw))
+    x = np.arange(-radius, radius + 1, dtype=np.float64)
+
+    if sigma_pixels > 0.0:
+        g = np.exp(-0.5 * (x / sigma_pixels) ** 2)
+    else:
+        g = np.zeros(len(x))
+        g[radius] = 1.0  # delta at center
+
+    if gamma_pixels > 0.0:
+        l = 1.0 / (1.0 + (x / gamma_pixels) ** 2)
+    else:
+        l = np.zeros(len(x))
+        l[radius] = 1.0  # delta at center
+
+    kernel = (1.0 - eta) * g + eta * l
+    return (kernel / kernel.sum()).astype(np.float32)
+
+
 def _apply_convolve1d(array, kernels, mode, cval=0.0):
     """Apply 1-D convolutions along each axis using ``scipy.ndimage.convolve1d``.
 
@@ -2627,6 +2768,66 @@ def _voigtian_source_size(
             sigma_pix = gaussian_sigma[i] / scan_sampling
             gamma_pix = lorentzian_gamma[i] / scan_sampling
             kernel = _voigt_kernel_1d(sigma_pix, gamma_pix, truncate)
+            kernels.append(kernel)
+            depth.append(min(len(kernel) // 2, n))
+            i += 1
+        else:
+            kernels.append(None)
+            depth.append(0)
+
+    kernels += [None, None]
+    depth += [0, 0]
+
+    if measurements.is_lazy:
+        array = measurements.array.map_overlap(
+            functools.partial(_apply_convolve1d, kernels=kernels, mode="wrap"),
+            depth=tuple(depth),
+            boundary="periodic",
+            meta=xp.array((), dtype=xp.float32),
+        )
+    else:
+        ndimage = get_ndimage_module(measurements._array)
+        array = measurements.array
+        for axis, kernel in enumerate(kernels):
+            if kernel is not None:
+                array = ndimage.convolve1d(
+                    array, xp.asarray(kernel), axis=axis, mode="wrap"
+                )
+
+    kwargs = measurements._copy_kwargs(exclude=("array",))
+    return measurements.__class__(array, **kwargs)
+
+
+def _pseudo_voigtian_source_size(
+    measurements,
+    gaussian_sigma: float | tuple[float, float],
+    lorentzian_gamma: float | tuple[float, float],
+    eta: float,
+    truncate: float = 10.0,
+):
+    if len(_scan_axes(measurements)) < 2:
+        raise RuntimeError(
+            "Pseudo-Voigtian source size not implemented for diffraction patterns"
+            " with less than two scan axes."
+        )
+
+    if np.isscalar(gaussian_sigma):
+        gaussian_sigma = (gaussian_sigma,) * 2
+    if np.isscalar(lorentzian_gamma):
+        lorentzian_gamma = (lorentzian_gamma,) * 2
+
+    xp = get_array_module(measurements.array)
+
+    ensemble_axes = tuple(range(len(measurements.ensemble_shape)))
+    kernels = []
+    depth = []
+    i = 0
+    for axis, n in zip(ensemble_axes, measurements.ensemble_shape):
+        if axis in _scan_axes(measurements):
+            scan_sampling = _scan_sampling(measurements)[i]
+            sigma_pix = gaussian_sigma[i] / scan_sampling
+            gamma_pix = lorentzian_gamma[i] / scan_sampling
+            kernel = _pseudo_voigt_kernel_1d(sigma_pix, gamma_pix, eta, truncate)
             kernels.append(kernel)
             depth.append(min(len(kernel) // 2, n))
             i += 1
@@ -3452,6 +3653,51 @@ class DiffractionPatterns(_BaseMeasurement2D):
         For the same FWHM, γ = FWHM / 2 but σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
         """
         return _voigtian_source_size(self, gaussian_sigma, lorentzian_gamma, truncate)
+
+    def pseudo_voigtian_source_size(
+        self,
+        gaussian_sigma: float | tuple[float, float],
+        lorentzian_gamma: float | tuple[float, float],
+        eta: float,
+        truncate: float = 10.0,
+    ) -> DiffractionPatterns:
+        """
+        Simulate the effect of a finite source size on diffraction pattern(s) using a
+        pseudo-Voigtian filter (weighted sum of Gaussian and Lorentzian).
+
+        The filter mixes intensities across scan axes (not within each diffraction
+        pattern) and requires two linear scan axes. Applying this filter before
+        integrating gives the same result as integrating first and then applying a
+        :meth:`pseudo_voigtian_filter` to the resulting images.
+
+        Parameters
+        ----------
+        gaussian_sigma : float or two float
+            Standard deviation (σ) of the Gaussian component [Å]. If given as a
+            single number it is equal for both axes.
+        lorentzian_gamma : float or two float
+            Half-width at half-maximum (HWHM, γ) of the Lorentzian component [Å].
+            If given as a single number it is equal for both axes.
+        eta : float
+            Lorentzian mixing fraction η ∈ [0, 1]. η = 0 gives a pure Gaussian;
+            η = 1 gives a pure Lorentzian.
+        truncate : float, optional
+            Truncate the kernel at this many effective half-widths (default 10.0).
+
+        Returns
+        -------
+        filtered_diffraction_patterns : DiffractionPatterns
+            The filtered diffraction pattern(s).
+
+        Notes
+        -----
+        The pseudo-Voigt profile is PV = (1-η)·G + η·L, where G and L are
+        Gaussian and Lorentzian profiles with widths σ and γ respectively. Width
+        parameterization: FWHM_G = 2√(2 ln 2)·σ ≈ 2.3548·σ; FWHM_L = 2γ.
+        """
+        return _pseudo_voigtian_source_size(
+            self, gaussian_sigma, lorentzian_gamma, eta, truncate
+        )
 
     def poisson_noise(
         self,
@@ -4509,6 +4755,49 @@ class PolarMeasurements(BaseMeasurements):
         For the same FWHM, γ = FWHM / 2 but σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
         """
         return _voigtian_source_size(self, gaussian_sigma, lorentzian_gamma, truncate)
+
+    def pseudo_voigtian_source_size(
+        self,
+        gaussian_sigma: float | tuple[float, float],
+        lorentzian_gamma: float | tuple[float, float],
+        eta: float,
+        truncate: float = 10.0,
+    ) -> PolarMeasurements:
+        """
+        Simulate the effect of a finite source size on polar measurement(s) using a
+        pseudo-Voigtian filter (weighted sum of Gaussian and Lorentzian).
+
+        The filter mixes intensities across scan axes (not within each measurement)
+        and requires two linear scan axes.
+
+        Parameters
+        ----------
+        gaussian_sigma : float or two float
+            Standard deviation (σ) of the Gaussian component [Å]. If given as a
+            single number it is equal for both axes.
+        lorentzian_gamma : float or two float
+            Half-width at half-maximum (HWHM, γ) of the Lorentzian component [Å].
+            If given as a single number it is equal for both axes.
+        eta : float
+            Lorentzian mixing fraction η ∈ [0, 1]. η = 0 gives a pure Gaussian;
+            η = 1 gives a pure Lorentzian.
+        truncate : float, optional
+            Truncate the kernel at this many effective half-widths (default 10.0).
+
+        Returns
+        -------
+        filtered_measurements : PolarMeasurements
+            The filtered measurement(s).
+
+        Notes
+        -----
+        The pseudo-Voigt profile is PV = (1-η)·G + η·L, where G and L are
+        Gaussian and Lorentzian profiles with widths σ and γ respectively. Width
+        parameterization: FWHM_G = 2√(2 ln 2)·σ ≈ 2.3548·σ; FWHM_L = 2γ.
+        """
+        return _pseudo_voigtian_source_size(
+            self, gaussian_sigma, lorentzian_gamma, eta, truncate
+        )
 
     def poisson_noise(
         self,

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -2604,7 +2604,20 @@ def _apply_convolve_2d_on_axes(array, kernel_2d, axes, mode, cval=0.0):
     shape[axes[1]] = kw
     kernel_nd = xp.asarray(kernel_2d).reshape(shape)
 
-    result = scipy_signal.fftconvolve(padded, kernel_nd, mode="valid", axes=axes)
+    # cupyx.scipy.signal.fftconvolve internally uses cupyx.jit.rawkernel, which
+    # raises a FutureWarning ("cupyx.jit.rawkernel is experimental ..."). The
+    # warning is purely an upstream API-stability notice we can do nothing
+    # about, but it would fail tests under filterwarnings=error and clutter
+    # library output, so suppress it precisely at the call site.
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"cupyx\.jit\.rawkernel is experimental",
+            category=FutureWarning,
+        )
+        result = scipy_signal.fftconvolve(
+            padded, kernel_nd, mode="valid", axes=axes
+        )
     return result.astype(array.dtype, copy=False)
     return array
 

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import functools
 import itertools
 import warnings
 from abc import ABCMeta, abstractmethod
@@ -1130,6 +1131,171 @@ class _BaseMeasurement2D(BaseMeasurements):
         kwargs["array"] = array
         return self.__class__(**kwargs)
 
+    def lorentzian_filter(
+        self,
+        half_width: float | tuple[float, float],
+        truncate: float = 10.0,
+        boundary: str = "periodic",
+        cval: float = 0.0,
+    ):
+        """
+        Apply a 2D Lorentzian (Cauchy) filter to measurements.
+
+        The filter is applied separately along each axis (separable convolution),
+        which is consistent with how :meth:`gaussian_filter` works.
+
+        Parameters
+        ----------
+        half_width : float or two float
+            Half-width at half-maximum (HWHM) of the Lorentzian kernel in the ``x``
+            and ``y``-direction given in physical units (Å for real-space images,
+            1/Å for diffraction patterns). If given as a single number, the
+            half-width is equal for both axes.
+        truncate : float, optional
+            Truncate the kernel at this many half-widths (default is 10.0). The
+            Lorentzian has heavier tails than the Gaussian, so a larger truncation
+            is recommended.
+        boundary : {'periodic', 'reflect', 'constant'}
+            How the image is extended beyond its boundary (default is 'periodic').
+        cval : float, optional
+            Constant value used when ``boundary`` is ``'constant'`` (default 0.0).
+
+        Returns
+        -------
+        filtered : same type as input
+            The filtered measurement(s).
+        """
+        xp = get_array_module(self.array)
+
+        if boundary == "periodic":
+            mode = "wrap"
+        elif boundary in ("reflect", "constant"):
+            mode = boundary
+        else:
+            raise ValueError(
+                f"boundary must be 'periodic', 'reflect', or 'constant', got {boundary!r}"
+            )
+
+        if np.isscalar(half_width):
+            half_width = (half_width,) * 2
+
+        hw_pixels = tuple(hw / d for hw, d in zip(half_width, self.sampling))
+
+        n_ensemble = len(self.shape) - 2
+        kernels = [None] * n_ensemble + [
+            _lorentzian_kernel_1d(hw, truncate) for hw in hw_pixels
+        ]
+
+        if self.is_lazy:
+            radii = [len(k) // 2 if k is not None else 0 for k in kernels]
+            depth = tuple(min(r, n) for r, n in zip(radii, self.shape))
+
+            array = da.map_overlap(
+                functools.partial(_apply_convolve1d, kernels=kernels, mode=mode, cval=cval),
+                self.array,
+                depth=depth,
+                boundary=boundary,
+                meta=xp.array((), dtype=xp.float32),
+            )
+        else:
+            ndimage = get_ndimage_module(self.array)
+            array = self.array
+            for axis, kernel in enumerate(kernels):
+                if kernel is not None:
+                    array = ndimage.convolve1d(
+                        array, xp.asarray(kernel), axis=axis, mode=mode, cval=cval
+                    )
+
+        kwargs = self._copy_kwargs(exclude=("array",))
+        kwargs["array"] = array
+        return self.__class__(**kwargs)
+
+    def voigtian_filter(
+        self,
+        gaussian_sigma: float | tuple[float, float],
+        lorentzian_gamma: float | tuple[float, float],
+        truncate: float = 5.0,
+        boundary: str = "periodic",
+        cval: float = 0.0,
+    ):
+        """
+        Apply a 2D Voigt filter to measurements.
+
+        The Voigt profile is the convolution of a Gaussian and a Lorentzian.
+        The filter is applied separately along each axis (separable convolution),
+        which is consistent with how :meth:`gaussian_filter` works.
+
+        Parameters
+        ----------
+        gaussian_sigma : float or two float
+            Standard deviation (σ) of the Gaussian component in physical units
+            (Å for real-space images, 1/Å for diffraction patterns). If given
+            as a single number it is equal for both axes.
+        lorentzian_gamma : float or two float
+            Half-width at half-maximum (HWHM, γ) of the Lorentzian component in
+            physical units. If given as a single number it is equal for both axes.
+        truncate : float, optional
+            Truncate the kernel at this many Voigt half-widths (default is 5.0).
+            The Voigt HWHM is estimated via the Thompson et al. (1987) approximation.
+        boundary : {'periodic', 'reflect', 'constant'}
+            How the image is extended beyond its boundary (default is 'periodic').
+        cval : float, optional
+            Constant value used when ``boundary`` is ``'constant'`` (default 0.0).
+
+        Returns
+        -------
+        filtered : same type as input
+            The filtered measurement(s).
+        """
+        xp = get_array_module(self.array)
+
+        if boundary == "periodic":
+            mode = "wrap"
+        elif boundary in ("reflect", "constant"):
+            mode = boundary
+        else:
+            raise ValueError(
+                f"boundary must be 'periodic', 'reflect', or 'constant', got {boundary!r}"
+            )
+
+        if np.isscalar(gaussian_sigma):
+            gaussian_sigma = (gaussian_sigma,) * 2
+        if np.isscalar(lorentzian_gamma):
+            lorentzian_gamma = (lorentzian_gamma,) * 2
+
+        sigma_pixels = tuple(s / d for s, d in zip(gaussian_sigma, self.sampling))
+        gamma_pixels = tuple(g / d for g, d in zip(lorentzian_gamma, self.sampling))
+
+        n_ensemble = len(self.shape) - 2
+        kernels = [None] * n_ensemble + [
+            _voigt_kernel_1d(s, g, truncate)
+            for s, g in zip(sigma_pixels, gamma_pixels)
+        ]
+
+        if self.is_lazy:
+            radii = [len(k) // 2 if k is not None else 0 for k in kernels]
+            depth = tuple(min(r, n) for r, n in zip(radii, self.shape))
+
+            array = da.map_overlap(
+                functools.partial(_apply_convolve1d, kernels=kernels, mode=mode, cval=cval),
+                self.array,
+                depth=depth,
+                boundary=boundary,
+                meta=xp.array((), dtype=xp.float32),
+            )
+        else:
+            ndimage = get_ndimage_module(self.array)
+            array = self.array
+            for axis, kernel in enumerate(kernels):
+                if kernel is not None:
+                    array = ndimage.convolve1d(
+                        array, xp.asarray(kernel), axis=axis, mode=mode, cval=cval
+                    )
+
+        kwargs = self._copy_kwargs(exclude=("array",))
+        kwargs["array"] = array
+        return self.__class__(**kwargs)
+
     def interpolate_line_at_position(
         self,
         center: tuple[float, float] | Atom,
@@ -2250,6 +2416,212 @@ def _fourier_space_bilinear_nodes_and_weight(
     return v, u, vw, uw
 
 
+# Threshold below which (1/hw)^2 would overflow float64.
+# For the Lorentzian kernel the minimum radius is 1, so the maximum operand
+# is x/hw = 1/hw; squaring overflows when hw < 1/sqrt(float_max).
+_LORENTZIAN_SAFE_HW = 1.0 / np.sqrt(np.finfo(np.float64).max)  # ≈ 7.5e-155
+
+
+def _lorentzian_kernel_1d(half_width_pixels: float, truncate: float = 10.0) -> np.ndarray:
+    """Build a normalized 1-D Lorentzian (Cauchy) convolution kernel in pixel units.
+
+    When ``half_width_pixels`` is zero or so small that the filter is effectively a
+    unit impulse (kernel narrower than the arithmetic precision allows), a delta
+    kernel is returned — consistent with ``gaussian_filter`` at sigma=0.
+    """
+    if half_width_pixels < _LORENTZIAN_SAFE_HW:
+        return np.array([1.0], dtype=np.float32)
+    radius = int(np.ceil(truncate * half_width_pixels))
+    x = np.arange(-radius, radius + 1, dtype=np.float64)
+    kernel = 1.0 / (1.0 + (x / half_width_pixels) ** 2)
+    return (kernel / kernel.sum()).astype(np.float32)
+
+
+def _voigt_kernel_1d(
+    sigma_pixels: float,
+    gamma_pixels: float,
+    truncate: float = 5.0,
+) -> np.ndarray:
+    """Build a normalized 1-D Voigt convolution kernel in pixel units.
+
+    Uses the exact Voigt profile (Faddeeva function) when both components are
+    non-zero, falls back to pure Gaussian / Lorentzian for degenerate cases, and
+    returns a unit impulse when both are zero (leaving the data unchanged).
+    """
+    from scipy.special import wofz
+
+    # Clamp values below the safe threshold to zero to avoid overflow
+    if sigma_pixels < _LORENTZIAN_SAFE_HW:
+        sigma_pixels = 0.0
+    if gamma_pixels < _LORENTZIAN_SAFE_HW:
+        gamma_pixels = 0.0
+
+    if sigma_pixels == 0.0 and gamma_pixels == 0.0:
+        return np.array([1.0], dtype=np.float32)
+
+    fG = 2.0 * sigma_pixels * np.sqrt(2.0 * np.log(2.0))
+    fL = 2.0 * gamma_pixels
+    if sigma_pixels == 0.0:
+        voigt_hwhm = gamma_pixels
+    elif gamma_pixels == 0.0:
+        voigt_hwhm = fG / 2.0
+    else:
+        f5 = (
+            fG**5
+            + 2.69269 * fG**4 * fL
+            + 2.42843 * fG**3 * fL**2
+            + 4.47163 * fG**2 * fL**3
+            + 0.07842 * fG * fL**4
+            + fL**5
+        )
+        voigt_hwhm = f5 ** (1.0 / 5.0) / 2.0
+
+    radius = int(np.ceil(truncate * voigt_hwhm))
+    x = np.arange(-radius, radius + 1, dtype=np.float64)
+
+    if sigma_pixels == 0.0:
+        kernel = 1.0 / (1.0 + (x / gamma_pixels) ** 2)
+    elif gamma_pixels == 0.0:
+        kernel = np.exp(-0.5 * x**2 / sigma_pixels**2)
+    else:
+        z = (x + 1j * gamma_pixels) / (sigma_pixels * np.sqrt(2.0))
+        kernel = np.real(wofz(z))
+
+    return (kernel / kernel.sum()).astype(np.float32)
+
+
+def _apply_convolve1d(array, kernels, mode, cval=0.0):
+    """Apply 1-D convolutions along each axis using ``scipy.ndimage.convolve1d``.
+
+    Used as the callable passed to ``dask.array.map_overlap`` so that it
+    always runs on CPU (NumPy) chunks.  ``kernels`` is a list aligned with
+    ``array.ndim``; ``None`` entries skip the corresponding axis.
+    """
+    import scipy.ndimage
+
+    for axis, kernel in enumerate(kernels):
+        if kernel is not None:
+            array = scipy.ndimage.convolve1d(
+                array, kernel, axis=axis, mode=mode, cval=cval
+            )
+    return array
+
+
+def _lorentzian_source_size(
+    measurements,
+    half_width: float | tuple[float, float],
+    truncate: float = 10.0,
+):
+    if len(_scan_axes(measurements)) < 2:
+        raise RuntimeError(
+            "Lorentzian source size not implemented for diffraction patterns with less"
+            " than two scan axes."
+        )
+
+    if np.isscalar(half_width):
+        half_width = (half_width,) * 2
+
+    xp = get_array_module(measurements.array)
+
+    ensemble_axes = tuple(range(len(measurements.ensemble_shape)))
+    kernels = []
+    depth = []
+    i = 0
+    for axis, n in zip(ensemble_axes, measurements.ensemble_shape):
+        if axis in _scan_axes(measurements):
+            scan_sampling = _scan_sampling(measurements)[i]
+            hw_pix = half_width[i] / scan_sampling
+            kernel = _lorentzian_kernel_1d(hw_pix, truncate)
+            kernels.append(kernel)
+            depth.append(min(len(kernel) // 2, n))
+            i += 1
+        else:
+            kernels.append(None)
+            depth.append(0)
+
+    # Two trailing measurement axes — never filtered
+    kernels += [None, None]
+    depth += [0, 0]
+
+    if measurements.is_lazy:
+        array = measurements.array.map_overlap(
+            functools.partial(_apply_convolve1d, kernels=kernels, mode="wrap"),
+            depth=tuple(depth),
+            boundary="periodic",
+            meta=xp.array((), dtype=xp.float32),
+        )
+    else:
+        ndimage = get_ndimage_module(measurements._array)
+        array = measurements.array
+        for axis, kernel in enumerate(kernels):
+            if kernel is not None:
+                array = ndimage.convolve1d(
+                    array, xp.asarray(kernel), axis=axis, mode="wrap"
+                )
+
+    kwargs = measurements._copy_kwargs(exclude=("array",))
+    return measurements.__class__(array, **kwargs)
+
+
+def _voigtian_source_size(
+    measurements,
+    gaussian_sigma: float | tuple[float, float],
+    lorentzian_gamma: float | tuple[float, float],
+    truncate: float = 5.0,
+):
+    if len(_scan_axes(measurements)) < 2:
+        raise RuntimeError(
+            "Voigt source size not implemented for diffraction patterns with less"
+            " than two scan axes."
+        )
+
+    if np.isscalar(gaussian_sigma):
+        gaussian_sigma = (gaussian_sigma,) * 2
+    if np.isscalar(lorentzian_gamma):
+        lorentzian_gamma = (lorentzian_gamma,) * 2
+
+    xp = get_array_module(measurements.array)
+
+    ensemble_axes = tuple(range(len(measurements.ensemble_shape)))
+    kernels = []
+    depth = []
+    i = 0
+    for axis, n in zip(ensemble_axes, measurements.ensemble_shape):
+        if axis in _scan_axes(measurements):
+            scan_sampling = _scan_sampling(measurements)[i]
+            sigma_pix = gaussian_sigma[i] / scan_sampling
+            gamma_pix = lorentzian_gamma[i] / scan_sampling
+            kernel = _voigt_kernel_1d(sigma_pix, gamma_pix, truncate)
+            kernels.append(kernel)
+            depth.append(min(len(kernel) // 2, n))
+            i += 1
+        else:
+            kernels.append(None)
+            depth.append(0)
+
+    kernels += [None, None]
+    depth += [0, 0]
+
+    if measurements.is_lazy:
+        array = measurements.array.map_overlap(
+            functools.partial(_apply_convolve1d, kernels=kernels, mode="wrap"),
+            depth=tuple(depth),
+            boundary="periodic",
+            meta=xp.array((), dtype=xp.float32),
+        )
+    else:
+        ndimage = get_ndimage_module(measurements._array)
+        array = measurements.array
+        for axis, kernel in enumerate(kernels):
+            if kernel is not None:
+                array = ndimage.convolve1d(
+                    array, xp.asarray(kernel), axis=axis, mode="wrap"
+                )
+
+    kwargs = measurements._copy_kwargs(exclude=("array",))
+    return measurements.__class__(array, **kwargs)
+
+
 def _gaussian_source_size(measurements, sigma: float | tuple[float, float]):
     if len(_scan_axes(measurements)) < 2:
         raise RuntimeError(
@@ -2965,6 +3337,69 @@ class DiffractionPatterns(_BaseMeasurement2D):
         """
 
         return _gaussian_source_size(self, sigma)
+
+    def lorentzian_source_size(
+        self,
+        half_width: float | tuple[float, float],
+        truncate: float = 10.0,
+    ) -> DiffractionPatterns:
+        """
+        Simulate the effect of a finite source size on diffraction pattern(s) using a
+        Lorentzian (Cauchy) filter.
+
+        The filter mixes intensities across scan axes (not within each diffraction
+        pattern) and requires two linear scan axes. Applying this filter before
+        integrating gives the same result as integrating first and then applying a
+        :meth:`lorentzian_filter` to the resulting images.
+
+        Parameters
+        ----------
+        half_width : float or two float
+            Half-width at half-maximum (HWHM) of the Lorentzian kernel in the ``x``
+            and ``y``-direction [Å]. If given as a single number it is equal for
+            both axes.
+        truncate : float, optional
+            Truncate the kernel at this many half-widths (default is 10.0).
+
+        Returns
+        -------
+        filtered_diffraction_patterns : DiffractionPatterns
+            The filtered diffraction pattern(s).
+        """
+        return _lorentzian_source_size(self, half_width, truncate)
+
+    def voigtian_source_size(
+        self,
+        gaussian_sigma: float | tuple[float, float],
+        lorentzian_gamma: float | tuple[float, float],
+        truncate: float = 5.0,
+    ) -> DiffractionPatterns:
+        """
+        Simulate the effect of a finite source size on diffraction pattern(s) using a
+        Voigt filter (convolution of Gaussian and Lorentzian).
+
+        The filter mixes intensities across scan axes (not within each diffraction
+        pattern) and requires two linear scan axes. Applying this filter before
+        integrating gives the same result as integrating first and then applying a
+        :meth:`voigtian_filter` to the resulting images.
+
+        Parameters
+        ----------
+        gaussian_sigma : float or two float
+            Standard deviation (σ) of the Gaussian component [Å]. If given as a
+            single number it is equal for both axes.
+        lorentzian_gamma : float or two float
+            Half-width at half-maximum (HWHM, γ) of the Lorentzian component [Å].
+            If given as a single number it is equal for both axes.
+        truncate : float, optional
+            Truncate the kernel at this many Voigt half-widths (default is 5.0).
+
+        Returns
+        -------
+        filtered_diffraction_patterns : DiffractionPatterns
+            The filtered diffraction pattern(s).
+        """
+        return _voigtian_source_size(self, gaussian_sigma, lorentzian_gamma, truncate)
 
     def poisson_noise(
         self,
@@ -3946,6 +4381,65 @@ class PolarMeasurements(BaseMeasurements):
         """
 
         return _gaussian_source_size(self, sigma)
+
+    def lorentzian_source_size(
+        self,
+        half_width: float | tuple[float, float],
+        truncate: float = 10.0,
+    ) -> PolarMeasurements:
+        """
+        Simulate the effect of a finite source size on polar measurement(s) using a
+        Lorentzian (Cauchy) filter.
+
+        The filter mixes intensities across scan axes (not within each measurement)
+        and requires two linear scan axes.
+
+        Parameters
+        ----------
+        half_width : float or two float
+            Half-width at half-maximum (HWHM) of the Lorentzian kernel in the ``x``
+            and ``y``-direction [Å]. If given as a single number it is equal for
+            both axes.
+        truncate : float, optional
+            Truncate the kernel at this many half-widths (default is 10.0).
+
+        Returns
+        -------
+        filtered_measurements : PolarMeasurements
+            The filtered measurement(s).
+        """
+        return _lorentzian_source_size(self, half_width, truncate)
+
+    def voigtian_source_size(
+        self,
+        gaussian_sigma: float | tuple[float, float],
+        lorentzian_gamma: float | tuple[float, float],
+        truncate: float = 5.0,
+    ) -> PolarMeasurements:
+        """
+        Simulate the effect of a finite source size on polar measurement(s) using a
+        Voigt filter (convolution of Gaussian and Lorentzian).
+
+        The filter mixes intensities across scan axes (not within each measurement)
+        and requires two linear scan axes.
+
+        Parameters
+        ----------
+        gaussian_sigma : float or two float
+            Standard deviation (σ) of the Gaussian component [Å]. If given as a
+            single number it is equal for both axes.
+        lorentzian_gamma : float or two float
+            Half-width at half-maximum (HWHM, γ) of the Lorentzian component [Å].
+            If given as a single number it is equal for both axes.
+        truncate : float, optional
+            Truncate the kernel at this many Voigt half-widths (default is 5.0).
+
+        Returns
+        -------
+        filtered_measurements : PolarMeasurements
+            The filtered measurement(s).
+        """
+        return _voigtian_source_size(self, gaussian_sigma, lorentzian_gamma, truncate)
 
     def poisson_noise(
         self,

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -2615,26 +2615,16 @@ def _apply_convolve_2d_on_axes(array, kernel_2d, axes, mode, cval=0.0):
     # Convolve over all axes (no ``axes=`` kwarg). The size-1 dims of the
     # kernel make the FFT along non-target axes a length-1 no-op, so the
     # result is numerically identical to passing ``axes=axes`` — verified
-    # against scipy.signal.fftconvolve with explicit axes. We do not depend
-    # on the kwarg purely for code simplicity; ``axes=`` has actually been
-    # available in cupyx.scipy.signal.fftconvolve since the first version
-    # that shipped fftconvolve (CuPy 9.0, April 2021), which is also the
-    # effective minimum CuPy version for any GPU code in this module.
+    # against scipy.signal.fftconvolve with explicit axes.
     #
     # cupyx.scipy.signal.fftconvolve internally uses cupyx.jit.rawkernel,
-    # which raises a FutureWarning ("cupyx.jit.rawkernel is experimental ...").
-    # This is purely an upstream API-stability notice we cannot fix, but it
-    # would fail tests under filterwarnings=error and clutter library output,
-    # so suppress it precisely here. The filter is message- *and*
-    # category-matched: if CuPy changes the warning text, the category, or
-    # the fftconvolve interface itself, our GPU tests will catch the change.
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=r"cupyx\.jit\.rawkernel is experimental",
-            category=FutureWarning,
-        )
-        result = scipy_signal.fftconvolve(padded, kernel_nd, mode="valid")
+    # which emits a FutureWarning at import / decorator-application time
+    # ("cupyx.jit.rawkernel is experimental ..."). That warning is purely
+    # an upstream API-stability notice, so it is silenced project-wide via
+    # the ``filterwarnings`` block in pyproject.toml. If CuPy changes the
+    # warning text, the category, or the fftconvolve interface itself, the
+    # filter stops matching and the GPU tests catch the change.
+    result = scipy_signal.fftconvolve(padded, kernel_nd, mode="valid")
     return result.astype(array.dtype, copy=False)
     return array
 

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -1065,8 +1065,10 @@ class _BaseMeasurement2D(BaseMeasurements):
         Parameters
         ----------
         sigma : float or two float
-            Standard deviation for the Gaussian kernel in the `x` and `y`-direction. If
-            given as a single number, the standard deviation is equal for both axes.
+            Standard deviation for the Gaussian kernel in the `x` and `y`-direction
+            given in physical units (Å for real-space images, 1/Å for diffraction
+            patterns). If given as a single number, the standard deviation is equal
+            for both axes.
 
         boundary : {'periodic', 'reflect', 'constant'}
             The boundary parameter determines how the images are extended beyond their
@@ -1091,6 +1093,16 @@ class _BaseMeasurement2D(BaseMeasurements):
         -------
         filtered_images : Images
             The filtered image(s).
+
+        Notes
+        -----
+        The Gaussian kernel is parameterized by its standard deviation σ
+        (``sigma``). The corresponding full-width at half-maximum is
+        FWHM_G = 2√(2 ln 2)·σ ≈ 2.3548·σ.
+
+        The Lorentzian and Voigtian filters use the half-width at half-maximum
+        (HWHM) γ as their width parameter: for the same FWHM, γ = FWHM / 2
+        whereas σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
         """
         xp = get_array_module(self.array)
         gaussian_filter = get_ndimage_module(self.array).gaussian_filter
@@ -1164,6 +1176,25 @@ class _BaseMeasurement2D(BaseMeasurements):
         -------
         filtered : same type as input
             The filtered measurement(s).
+
+        Notes
+        -----
+        The Lorentzian kernel is parameterized by its half-width at half-maximum
+        (HWHM) γ (``half_width``). The corresponding full-width at half-maximum
+        is FWHM_L = 2γ.
+
+        Note that :meth:`gaussian_filter` uses the standard deviation σ as its
+        width parameter. For the same FWHM one needs γ = FWHM / 2 whereas
+        σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
+
+        The Lorentzian source-size model is described in [1]_.
+
+        References
+        ----------
+        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
+           function in scanning transmission electron microscopy and spectroscopy",
+           *Ultramicroscopy* **146**, 6–16 (2014).
+           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         xp = get_array_module(self.array)
 
@@ -1246,6 +1277,28 @@ class _BaseMeasurement2D(BaseMeasurements):
         -------
         filtered : same type as input
             The filtered measurement(s).
+
+        Notes
+        -----
+        The Voigt kernel has two independent width parameters:
+
+        * ``gaussian_sigma`` (σ): standard deviation of the Gaussian component,
+          FWHM_G = 2√(2 ln 2)·σ ≈ 2.3548·σ.
+        * ``lorentzian_gamma`` (γ): half-width at half-maximum (HWHM) of the
+          Lorentzian component, FWHM_L = 2γ.
+
+        Because the two components use different parameterizations, σ and γ are
+        *not* directly comparable: for the same FWHM, γ = FWHM / 2 whereas
+        σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
+
+        The Voigt source-size model is described in [1]_.
+
+        References
+        ----------
+        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
+           function in scanning transmission electron microscopy and spectroscopy",
+           *Ultramicroscopy* **146**, 6–16 (2014).
+           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         xp = get_array_module(self.array)
 
@@ -3365,6 +3418,21 @@ class DiffractionPatterns(_BaseMeasurement2D):
         -------
         filtered_diffraction_patterns : DiffractionPatterns
             The filtered diffraction pattern(s).
+
+        Notes
+        -----
+        The Lorentzian kernel is parameterized by its HWHM γ (``half_width``),
+        with FWHM_L = 2γ. This differs from :meth:`gaussian_source_size`,
+        which uses the standard deviation σ (FWHM_G ≈ 2.3548·σ).
+
+        The Lorentzian source-size model is described in [1]_.
+
+        References
+        ----------
+        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
+           function in scanning transmission electron microscopy and spectroscopy",
+           *Ultramicroscopy* **146**, 6–16 (2014).
+           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         return _lorentzian_source_size(self, half_width, truncate)
 
@@ -3398,6 +3466,26 @@ class DiffractionPatterns(_BaseMeasurement2D):
         -------
         filtered_diffraction_patterns : DiffractionPatterns
             The filtered diffraction pattern(s).
+
+        Notes
+        -----
+        The Voigt profile combines two width parameters:
+
+        * ``gaussian_sigma`` (σ): standard deviation of the Gaussian component,
+          FWHM_G = 2√(2 ln 2)·σ ≈ 2.3548·σ.
+        * ``lorentzian_gamma`` (γ): HWHM of the Lorentzian component,
+          FWHM_L = 2γ.
+
+        For the same FWHM, γ = FWHM / 2 but σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
+
+        The Voigt source-size model is described in [1]_.
+
+        References
+        ----------
+        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
+           function in scanning transmission electron microscopy and spectroscopy",
+           *Ultramicroscopy* **146**, 6–16 (2014).
+           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         return _voigtian_source_size(self, gaussian_sigma, lorentzian_gamma, truncate)
 
@@ -4407,6 +4495,21 @@ class PolarMeasurements(BaseMeasurements):
         -------
         filtered_measurements : PolarMeasurements
             The filtered measurement(s).
+
+        Notes
+        -----
+        The Lorentzian kernel is parameterized by its HWHM γ (``half_width``),
+        with FWHM_L = 2γ. This differs from :meth:`gaussian_source_size`,
+        which uses the standard deviation σ (FWHM_G ≈ 2.3548·σ).
+
+        The Lorentzian source-size model is described in [1]_.
+
+        References
+        ----------
+        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
+           function in scanning transmission electron microscopy and spectroscopy",
+           *Ultramicroscopy* **146**, 6–16 (2014).
+           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         return _lorentzian_source_size(self, half_width, truncate)
 
@@ -4438,6 +4541,26 @@ class PolarMeasurements(BaseMeasurements):
         -------
         filtered_measurements : PolarMeasurements
             The filtered measurement(s).
+
+        Notes
+        -----
+        The Voigt profile combines two width parameters:
+
+        * ``gaussian_sigma`` (σ): standard deviation of the Gaussian component,
+          FWHM_G = 2√(2 ln 2)·σ ≈ 2.3548·σ.
+        * ``lorentzian_gamma`` (γ): HWHM of the Lorentzian component,
+          FWHM_L = 2γ.
+
+        For the same FWHM, γ = FWHM / 2 but σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
+
+        The Voigt source-size model is described in [1]_.
+
+        References
+        ----------
+        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
+           function in scanning transmission electron microscopy and spectroscopy",
+           *Ultramicroscopy* **146**, 6–16 (2014).
+           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         return _voigtian_source_size(self, gaussian_sigma, lorentzian_gamma, truncate)
 

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -1237,7 +1237,7 @@ class _BaseMeasurement2D(BaseMeasurements):
                 self.array,
                 depth=tuple(depth),
                 boundary=boundary,
-                meta=xp.array((), dtype=xp.float32),
+                meta=xp.array((), dtype=self.array.dtype),
             )
         else:
             # Use FFT-based convolution: cost is independent of kernel size,
@@ -2526,6 +2526,10 @@ def _lorentzian_kernel_2d(
     cross-shaped halos around sharp features. This 2-D kernel avoids that
     artefact (it is elliptical when γ_x ≠ γ_y, isotropic when γ_x = γ_y).
 
+    The returned kernel uses the dtype configured via ``abtem.config['precision']``
+    (``float32`` or ``float64``), so the filter respects the global precision
+    setting.
+
     Parameters
     ----------
     hw_pixels : tuple of two float
@@ -2535,16 +2539,20 @@ def _lorentzian_kernel_2d(
     truncate : float
         Truncate the kernel at this many half-widths along each axis.
     """
+    out_dtype = get_dtype(complex=False)
+
     hw0, hw1 = hw_pixels
 
     zero0 = hw0 < _LORENTZIAN_SAFE_HW
     zero1 = hw1 < _LORENTZIAN_SAFE_HW
 
     if zero0 and zero1:
-        return np.array([[1.0]], dtype=np.float32)
+        return np.array([[1.0]], dtype=out_dtype)
 
     radius0 = 0 if zero0 else int(np.ceil(truncate * hw0))
     radius1 = 0 if zero1 else int(np.ceil(truncate * hw1))
+    # Always compute the kernel in float64 to keep the small-tail values
+    # accurate, then cast down to the configured precision at the end.
     y = np.arange(-radius0, radius0 + 1, dtype=np.float64)[:, None]
     x = np.arange(-radius1, radius1 + 1, dtype=np.float64)[None, :]
 
@@ -2554,7 +2562,7 @@ def _lorentzian_kernel_2d(
     if not zero1:
         denom = denom + (x / hw1) ** 2
     kernel = 1.0 / denom
-    return (kernel / kernel.sum()).astype(np.float32)
+    return (kernel / kernel.sum()).astype(out_dtype)
 
 
 def _apply_convolve_2d_on_axes(array, kernel_2d, axes, mode, cval=0.0):
@@ -2604,20 +2612,26 @@ def _apply_convolve_2d_on_axes(array, kernel_2d, axes, mode, cval=0.0):
     shape[axes[1]] = kw
     kernel_nd = xp.asarray(kernel_2d).reshape(shape)
 
-    # cupyx.scipy.signal.fftconvolve internally uses cupyx.jit.rawkernel, which
-    # raises a FutureWarning ("cupyx.jit.rawkernel is experimental ..."). The
-    # warning is purely an upstream API-stability notice we can do nothing
-    # about, but it would fail tests under filterwarnings=error and clutter
-    # library output, so suppress it precisely at the call site.
+    # Convolve over all axes (no ``axes=`` kwarg). The size-1 dims of the
+    # kernel make the FFT along non-target axes a length-1 no-op, so the
+    # result is identical to passing ``axes=axes`` — but we stay compatible
+    # with CuPy versions whose cupyx.scipy.signal.fftconvolve predates the
+    # ``axes`` parameter.
+    #
+    # cupyx.scipy.signal.fftconvolve internally uses cupyx.jit.rawkernel,
+    # which raises a FutureWarning ("cupyx.jit.rawkernel is experimental ...").
+    # This is purely an upstream API-stability notice we cannot fix, but it
+    # would fail tests under filterwarnings=error and clutter library output,
+    # so suppress it precisely here. The filter is message- *and*
+    # category-matched: if CuPy changes the warning text, the category, or
+    # the fftconvolve interface itself, our GPU tests will catch the change.
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
             message=r"cupyx\.jit\.rawkernel is experimental",
             category=FutureWarning,
         )
-        result = scipy_signal.fftconvolve(
-            padded, kernel_nd, mode="valid", axes=axes
-        )
+        result = scipy_signal.fftconvolve(padded, kernel_nd, mode="valid")
     return result.astype(array.dtype, copy=False)
     return array
 
@@ -2669,7 +2683,7 @@ def _lorentzian_source_size(
             ),
             depth=tuple(depth),
             boundary="periodic",
-            meta=xp.array((), dtype=xp.float32),
+            meta=xp.array((), dtype=measurements.array.dtype),
         )
     else:
         array = _apply_convolve_2d_on_axes(

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -1236,7 +1236,7 @@ class _BaseMeasurement2D(BaseMeasurements):
                 self.array,
                 depth=tuple(depth),
                 boundary=boundary,
-                meta=xp.array((), dtype=xp.float32),
+                meta=xp.array((), dtype=self.array.dtype),
             )
         else:
             # Use FFT-based convolution: cost is independent of kernel size,
@@ -2525,6 +2525,10 @@ def _lorentzian_kernel_2d(
     cross-shaped halos around sharp features. This 2-D kernel avoids that
     artefact (it is elliptical when γ_x ≠ γ_y, isotropic when γ_x = γ_y).
 
+    The returned kernel uses the dtype configured via ``abtem.config['precision']``
+    (``float32`` or ``float64``), so the filter respects the global precision
+    setting.
+
     Parameters
     ----------
     hw_pixels : tuple of two float
@@ -2534,16 +2538,20 @@ def _lorentzian_kernel_2d(
     truncate : float
         Truncate the kernel at this many half-widths along each axis.
     """
+    out_dtype = get_dtype(complex=False)
+
     hw0, hw1 = hw_pixels
 
     zero0 = hw0 < _LORENTZIAN_SAFE_HW
     zero1 = hw1 < _LORENTZIAN_SAFE_HW
 
     if zero0 and zero1:
-        return np.array([[1.0]], dtype=np.float32)
+        return np.array([[1.0]], dtype=out_dtype)
 
     radius0 = 0 if zero0 else int(np.ceil(truncate * hw0))
     radius1 = 0 if zero1 else int(np.ceil(truncate * hw1))
+    # Always compute the kernel in float64 to keep the small-tail values
+    # accurate, then cast down to the configured precision at the end.
     y = np.arange(-radius0, radius0 + 1, dtype=np.float64)[:, None]
     x = np.arange(-radius1, radius1 + 1, dtype=np.float64)[None, :]
 
@@ -2553,7 +2561,7 @@ def _lorentzian_kernel_2d(
     if not zero1:
         denom = denom + (x / hw1) ** 2
     kernel = 1.0 / denom
-    return (kernel / kernel.sum()).astype(np.float32)
+    return (kernel / kernel.sum()).astype(out_dtype)
 
 
 def _apply_convolve_2d_on_axes(array, kernel_2d, axes, mode, cval=0.0):
@@ -2603,20 +2611,26 @@ def _apply_convolve_2d_on_axes(array, kernel_2d, axes, mode, cval=0.0):
     shape[axes[1]] = kw
     kernel_nd = xp.asarray(kernel_2d).reshape(shape)
 
-    # cupyx.scipy.signal.fftconvolve internally uses cupyx.jit.rawkernel, which
-    # raises a FutureWarning ("cupyx.jit.rawkernel is experimental ..."). The
-    # warning is purely an upstream API-stability notice we can do nothing
-    # about, but it would fail tests under filterwarnings=error and clutter
-    # library output, so suppress it precisely at the call site.
+    # Convolve over all axes (no ``axes=`` kwarg). The size-1 dims of the
+    # kernel make the FFT along non-target axes a length-1 no-op, so the
+    # result is identical to passing ``axes=axes`` — but we stay compatible
+    # with CuPy versions whose cupyx.scipy.signal.fftconvolve predates the
+    # ``axes`` parameter.
+    #
+    # cupyx.scipy.signal.fftconvolve internally uses cupyx.jit.rawkernel,
+    # which raises a FutureWarning ("cupyx.jit.rawkernel is experimental ...").
+    # This is purely an upstream API-stability notice we cannot fix, but it
+    # would fail tests under filterwarnings=error and clutter library output,
+    # so suppress it precisely here. The filter is message- *and*
+    # category-matched: if CuPy changes the warning text, the category, or
+    # the fftconvolve interface itself, our GPU tests will catch the change.
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
             message=r"cupyx\.jit\.rawkernel is experimental",
             category=FutureWarning,
         )
-        result = scipy_signal.fftconvolve(
-            padded, kernel_nd, mode="valid", axes=axes
-        )
+        result = scipy_signal.fftconvolve(padded, kernel_nd, mode="valid")
     return result.astype(array.dtype, copy=False)
     return array
 
@@ -2668,7 +2682,7 @@ def _lorentzian_source_size(
             ),
             depth=tuple(depth),
             boundary="periodic",
-            meta=xp.array((), dtype=xp.float32),
+            meta=xp.array((), dtype=measurements.array.dtype),
         )
     else:
         array = _apply_convolve_2d_on_axes(

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -1152,8 +1152,15 @@ class _BaseMeasurement2D(BaseMeasurements):
         """
         Apply a 2D Lorentzian (Cauchy) filter to measurements.
 
-        The filter is applied separately along each axis (separable convolution),
-        which is consistent with how :meth:`gaussian_filter` works.
+        The filter convolves the image with the **true** 2-D Lorentzian profile
+
+            L(x, y) = 1 / (1 + (x/γ_x)² + (y/γ_y)²)
+
+        which is **not** separable into a product of 1-D Lorentzians (unlike a
+        Gaussian). A separable implementation would produce a cross-shaped
+        impulse response — several times brighter along the x and y axes than
+        along the diagonal at the same radius — which manifests as visible
+        halos/lines around sharp features.
 
         Parameters
         ----------
@@ -1161,7 +1168,8 @@ class _BaseMeasurement2D(BaseMeasurements):
             Half-width at half-maximum (HWHM) of the Lorentzian kernel in the ``x``
             and ``y``-direction given in physical units (Å for real-space images,
             1/Å for diffraction patterns). If given as a single number, the
-            half-width is equal for both axes.
+            half-width is equal for both axes (isotropic kernel); otherwise the
+            kernel is elliptical.
         truncate : float, optional
             Truncate the kernel at this many half-widths (default is 10.0). The
             Lorentzian has heavier tails than the Gaussian, so a larger truncation
@@ -1202,30 +1210,36 @@ class _BaseMeasurement2D(BaseMeasurements):
 
         hw_pixels = tuple(hw / d for hw, d in zip(half_width, self.sampling))
 
-        n_ensemble = len(self.shape) - 2
-        kernels = [None] * n_ensemble + [
-            _lorentzian_kernel_1d(hw, truncate) for hw in hw_pixels
-        ]
+        # Two spatial axes are the trailing dims; build a true 2-D kernel.
+        axes = (self.array.ndim - 2, self.array.ndim - 1)
+        kernel_2d = _lorentzian_kernel_2d(hw_pixels, truncate)
 
         if self.is_lazy:
-            radii = [len(k) // 2 if k is not None else 0 for k in kernels]
-            depth = tuple(min(r, n) for r, n in zip(radii, self.shape))
+            depth = [0] * self.array.ndim
+            depth[axes[0]] = min(kernel_2d.shape[0] // 2, self.shape[axes[0]])
+            depth[axes[1]] = min(kernel_2d.shape[1] // 2, self.shape[axes[1]])
 
             array = da.map_overlap(
-                functools.partial(_apply_convolve1d, kernels=kernels, mode=mode, cval=cval),
+                functools.partial(
+                    _apply_convolve_2d_on_axes,
+                    kernel_2d=kernel_2d,
+                    axes=axes,
+                    mode=mode,
+                    cval=cval,
+                ),
                 self.array,
-                depth=depth,
+                depth=tuple(depth),
                 boundary=boundary,
                 meta=xp.array((), dtype=xp.float32),
             )
         else:
-            ndimage = get_ndimage_module(self.array)
-            array = self.array
-            for axis, kernel in enumerate(kernels):
-                if kernel is not None:
-                    array = ndimage.convolve1d(
-                        array, xp.asarray(kernel), axis=axis, mode=mode, cval=cval
-                    )
+            # Use FFT-based convolution: cost is independent of kernel size,
+            # which matters because the heavy-tailed Lorentzian kernel can
+            # easily be comparable in size to the image itself.
+            array = _apply_convolve_2d_on_axes(
+                np.asarray(self.array), kernel_2d, axes=axes, mode=mode, cval=cval
+            )
+            array = xp.asarray(array)
 
         kwargs = self._copy_kwargs(exclude=("array",))
         kwargs["array"] = array
@@ -1235,16 +1249,19 @@ class _BaseMeasurement2D(BaseMeasurements):
         self,
         gaussian_sigma: float | tuple[float, float],
         lorentzian_gamma: float | tuple[float, float],
-        truncate: float = 5.0,
+        truncate: float = 10.0,
         boundary: str = "periodic",
         cval: float = 0.0,
     ):
         """
-        Apply a 2D Voigt filter to measurements.
+        Apply a 2D Voigtian filter to measurements.
 
         The Voigt profile is the convolution of a Gaussian and a Lorentzian.
-        The filter is applied separately along each axis (separable convolution),
-        which is consistent with how :meth:`gaussian_filter` works.
+        Exploiting the associativity of convolution, the filter is implemented
+        as :meth:`gaussian_filter` followed by :meth:`lorentzian_filter`, which
+        uses the true 2-D (non-separable) Lorentzian kernel and therefore
+        avoids the cross-shaped artefacts a naively separable Voigt filter
+        would produce.
 
         Parameters
         ----------
@@ -1256,8 +1273,9 @@ class _BaseMeasurement2D(BaseMeasurements):
             Half-width at half-maximum (HWHM, γ) of the Lorentzian component in
             physical units. If given as a single number it is equal for both axes.
         truncate : float, optional
-            Truncate the kernel at this many Voigt half-widths (default is 5.0).
-            The Voigt HWHM is estimated via the Thompson et al. (1987) approximation.
+            Truncate the Lorentzian component at this many half-widths
+            (default is 10.0). The Gaussian component uses the SciPy default
+            (4·σ).
         boundary : {'periodic', 'reflect', 'constant'}
             How the image is extended beyond its boundary (default is 'periodic').
         cval : float, optional
@@ -1281,54 +1299,11 @@ class _BaseMeasurement2D(BaseMeasurements):
         *not* directly comparable: for the same FWHM, γ = FWHM / 2 whereas
         σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
         """
-        xp = get_array_module(self.array)
-
-        if boundary == "periodic":
-            mode = "wrap"
-        elif boundary in ("reflect", "constant"):
-            mode = boundary
-        else:
-            raise ValueError(
-                f"boundary must be 'periodic', 'reflect', or 'constant', got {boundary!r}"
-            )
-
-        if np.isscalar(gaussian_sigma):
-            gaussian_sigma = (gaussian_sigma,) * 2
-        if np.isscalar(lorentzian_gamma):
-            lorentzian_gamma = (lorentzian_gamma,) * 2
-
-        sigma_pixels = tuple(s / d for s, d in zip(gaussian_sigma, self.sampling))
-        gamma_pixels = tuple(g / d for g, d in zip(lorentzian_gamma, self.sampling))
-
-        n_ensemble = len(self.shape) - 2
-        kernels = [None] * n_ensemble + [
-            _voigt_kernel_1d(s, g, truncate)
-            for s, g in zip(sigma_pixels, gamma_pixels)
-        ]
-
-        if self.is_lazy:
-            radii = [len(k) // 2 if k is not None else 0 for k in kernels]
-            depth = tuple(min(r, n) for r, n in zip(radii, self.shape))
-
-            array = da.map_overlap(
-                functools.partial(_apply_convolve1d, kernels=kernels, mode=mode, cval=cval),
-                self.array,
-                depth=depth,
-                boundary=boundary,
-                meta=xp.array((), dtype=xp.float32),
-            )
-        else:
-            ndimage = get_ndimage_module(self.array)
-            array = self.array
-            for axis, kernel in enumerate(kernels):
-                if kernel is not None:
-                    array = ndimage.convolve1d(
-                        array, xp.asarray(kernel), axis=axis, mode=mode, cval=cval
-                    )
-
-        kwargs = self._copy_kwargs(exclude=("array",))
-        kwargs["array"] = array
-        return self.__class__(**kwargs)
+        return self.gaussian_filter(
+            gaussian_sigma, boundary=boundary, cval=cval
+        ).lorentzian_filter(
+            lorentzian_gamma, truncate=truncate, boundary=boundary, cval=cval
+        )
 
     def pseudo_voigtian_filter(
         self,
@@ -1344,8 +1319,11 @@ class _BaseMeasurement2D(BaseMeasurements):
 
         The pseudo-Voigt profile is a weighted linear sum of a Gaussian and a
         Lorentzian — PV = (1-η)·G + η·L — as proposed by Nguyen et al. (2014).
-        The filter is applied separately along each axis (separable convolution),
-        consistent with how :meth:`gaussian_filter` works.
+        Exploiting the linearity of convolution, the filter is implemented as
+        the linear combination of :meth:`gaussian_filter` and
+        :meth:`lorentzian_filter`, which uses the true 2-D (non-separable)
+        Lorentzian kernel and therefore avoids the cross-shaped artefacts a
+        naively separable filter would produce.
 
         Parameters
         ----------
@@ -1361,8 +1339,8 @@ class _BaseMeasurement2D(BaseMeasurements):
             (equivalent to :meth:`gaussian_filter`); η = 1 gives a pure
             Lorentzian (equivalent to :meth:`lorentzian_filter`).
         truncate : float, optional
-            Truncate the kernel at this many effective half-widths (default 10.0).
-            The effective half-width is max(σ, γ).
+            Truncate the Lorentzian component at this many half-widths
+            (default 10.0). The Gaussian component uses the SciPy default (4·σ).
         boundary : {'periodic', 'reflect', 'constant'}
             How the image is extended beyond its boundary (default is 'periodic').
         cval : float, optional
@@ -1382,53 +1360,19 @@ class _BaseMeasurement2D(BaseMeasurements):
 
         For the same FWHM, γ = FWHM / 2 whereas σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
         """
-        xp = get_array_module(self.array)
-
-        if boundary == "periodic":
-            mode = "wrap"
-        elif boundary in ("reflect", "constant"):
-            mode = boundary
-        else:
-            raise ValueError(
-                f"boundary must be 'periodic', 'reflect', or 'constant', got {boundary!r}"
+        if eta == 0.0:
+            return self.gaussian_filter(gaussian_sigma, boundary=boundary, cval=cval)
+        if eta == 1.0:
+            return self.lorentzian_filter(
+                lorentzian_gamma, truncate=truncate, boundary=boundary, cval=cval
             )
 
-        if np.isscalar(gaussian_sigma):
-            gaussian_sigma = (gaussian_sigma,) * 2
-        if np.isscalar(lorentzian_gamma):
-            lorentzian_gamma = (lorentzian_gamma,) * 2
-
-        sigma_pixels = tuple(s / d for s, d in zip(gaussian_sigma, self.sampling))
-        gamma_pixels = tuple(g / d for g, d in zip(lorentzian_gamma, self.sampling))
-
-        n_ensemble = len(self.shape) - 2
-        kernels = [None] * n_ensemble + [
-            _pseudo_voigt_kernel_1d(s, g, eta, truncate)
-            for s, g in zip(sigma_pixels, gamma_pixels)
-        ]
-
-        if self.is_lazy:
-            radii = [len(k) // 2 if k is not None else 0 for k in kernels]
-            depth = tuple(min(r, n) for r, n in zip(radii, self.shape))
-
-            array = da.map_overlap(
-                functools.partial(_apply_convolve1d, kernels=kernels, mode=mode, cval=cval),
-                self.array,
-                depth=depth,
-                boundary=boundary,
-                meta=xp.array((), dtype=xp.float32),
-            )
-        else:
-            ndimage = get_ndimage_module(self.array)
-            array = self.array
-            for axis, kernel in enumerate(kernels):
-                if kernel is not None:
-                    array = ndimage.convolve1d(
-                        array, xp.asarray(kernel), axis=axis, mode=mode, cval=cval
-                    )
-
+        g = self.gaussian_filter(gaussian_sigma, boundary=boundary, cval=cval)
+        l = self.lorentzian_filter(
+            lorentzian_gamma, truncate=truncate, boundary=boundary, cval=cval
+        )
         kwargs = self._copy_kwargs(exclude=("array",))
-        kwargs["array"] = array
+        kwargs["array"] = (1.0 - eta) * g.array + eta * l.array
         return self.__class__(**kwargs)
 
     def interpolate_line_at_position(
@@ -2557,128 +2501,101 @@ def _fourier_space_bilinear_nodes_and_weight(
 _LORENTZIAN_SAFE_HW = 1.0 / np.sqrt(np.finfo(np.float64).max)  # ≈ 7.5e-155
 
 
-def _lorentzian_kernel_1d(half_width_pixels: float, truncate: float = 10.0) -> np.ndarray:
-    """Build a normalized 1-D Lorentzian (Cauchy) convolution kernel in pixel units.
-
-    When ``half_width_pixels`` is zero or so small that the filter is effectively a
-    unit impulse (kernel narrower than the arithmetic precision allows), a delta
-    kernel is returned — consistent with ``gaussian_filter`` at sigma=0.
-    """
-    if half_width_pixels < _LORENTZIAN_SAFE_HW:
-        return np.array([1.0], dtype=np.float32)
-    radius = int(np.ceil(truncate * half_width_pixels))
-    x = np.arange(-radius, radius + 1, dtype=np.float64)
-    kernel = 1.0 / (1.0 + (x / half_width_pixels) ** 2)
-    return (kernel / kernel.sum()).astype(np.float32)
-
-
-def _voigt_kernel_1d(
-    sigma_pixels: float,
-    gamma_pixels: float,
-    truncate: float = 5.0,
-) -> np.ndarray:
-    """Build a normalized 1-D Voigt convolution kernel in pixel units.
-
-    Uses the exact Voigt profile (Faddeeva function) when both components are
-    non-zero, falls back to pure Gaussian / Lorentzian for degenerate cases, and
-    returns a unit impulse when both are zero (leaving the data unchanged).
-    """
-    from scipy.special import wofz
-
-    # Clamp values below the safe threshold to zero to avoid overflow
-    if sigma_pixels < _LORENTZIAN_SAFE_HW:
-        sigma_pixels = 0.0
-    if gamma_pixels < _LORENTZIAN_SAFE_HW:
-        gamma_pixels = 0.0
-
-    if sigma_pixels == 0.0 and gamma_pixels == 0.0:
-        return np.array([1.0], dtype=np.float32)
-
-    fG = 2.0 * sigma_pixels * np.sqrt(2.0 * np.log(2.0))
-    fL = 2.0 * gamma_pixels
-    if sigma_pixels == 0.0:
-        voigt_hwhm = gamma_pixels
-    elif gamma_pixels == 0.0:
-        voigt_hwhm = fG / 2.0
-    else:
-        f5 = (
-            fG**5
-            + 2.69269 * fG**4 * fL
-            + 2.42843 * fG**3 * fL**2
-            + 4.47163 * fG**2 * fL**3
-            + 0.07842 * fG * fL**4
-            + fL**5
-        )
-        voigt_hwhm = f5 ** (1.0 / 5.0) / 2.0
-
-    radius = int(np.ceil(truncate * voigt_hwhm))
-    x = np.arange(-radius, radius + 1, dtype=np.float64)
-
-    if sigma_pixels == 0.0:
-        kernel = 1.0 / (1.0 + (x / gamma_pixels) ** 2)
-    elif gamma_pixels == 0.0:
-        kernel = np.exp(-0.5 * x**2 / sigma_pixels**2)
-    else:
-        z = (x + 1j * gamma_pixels) / (sigma_pixels * np.sqrt(2.0))
-        kernel = np.real(wofz(z))
-
-    return (kernel / kernel.sum()).astype(np.float32)
-
-
-def _pseudo_voigt_kernel_1d(
-    sigma_pixels: float,
-    gamma_pixels: float,
-    eta: float,
+def _lorentzian_kernel_2d(
+    hw_pixels: tuple[float, float],
     truncate: float = 10.0,
 ) -> np.ndarray:
-    """Build a normalized 1-D pseudo-Voigt convolution kernel in pixel units.
+    """Build a normalized 2-D Lorentzian (Cauchy) convolution kernel in pixel units.
 
-    The kernel is the weighted sum (1-eta)*G + eta*L evaluated on a shared grid,
-    where G is a Gaussian and L is a Lorentzian. Returns a delta kernel when both
-    sigma_pixels and gamma_pixels are effectively zero.
+    The kernel is the **true** 2-D Lorentzian profile
+
+        L(x, y) = 1 / (1 + (x/γ_x)² + (y/γ_y)²)
+
+    which is **not** separable into a product of 1-D Lorentzians. Filtering with
+    a separable Lorentzian (outer product of two 1-D kernels) produces a
+    non-rotationally-symmetric impulse response that is several times brighter
+    along the axes than along the diagonal at the same radius, manifesting as
+    cross-shaped halos around sharp features. This 2-D kernel avoids that
+    artefact (it is elliptical when γ_x ≠ γ_y, isotropic when γ_x = γ_y).
+
+    Parameters
+    ----------
+    hw_pixels : tuple of two float
+        Half-width at half-maximum along each axis (axis 0, axis 1) in pixel
+        units. An axis with HWHM below ``_LORENTZIAN_SAFE_HW`` is treated as
+        zero and contributes a delta along that axis.
+    truncate : float
+        Truncate the kernel at this many half-widths along each axis.
     """
-    if sigma_pixels < _LORENTZIAN_SAFE_HW:
-        sigma_pixels = 0.0
-    if gamma_pixels < _LORENTZIAN_SAFE_HW:
-        gamma_pixels = 0.0
+    hw0, hw1 = hw_pixels
 
-    hw = max(sigma_pixels, gamma_pixels)
-    if hw == 0.0:
-        return np.array([1.0], dtype=np.float32)
+    zero0 = hw0 < _LORENTZIAN_SAFE_HW
+    zero1 = hw1 < _LORENTZIAN_SAFE_HW
 
-    radius = int(np.ceil(truncate * hw))
-    x = np.arange(-radius, radius + 1, dtype=np.float64)
+    if zero0 and zero1:
+        return np.array([[1.0]], dtype=np.float32)
 
-    if sigma_pixels > 0.0:
-        g = np.exp(-0.5 * (x / sigma_pixels) ** 2)
-    else:
-        g = np.zeros(len(x))
-        g[radius] = 1.0  # delta at center
+    radius0 = 0 if zero0 else int(np.ceil(truncate * hw0))
+    radius1 = 0 if zero1 else int(np.ceil(truncate * hw1))
+    y = np.arange(-radius0, radius0 + 1, dtype=np.float64)[:, None]
+    x = np.arange(-radius1, radius1 + 1, dtype=np.float64)[None, :]
 
-    if gamma_pixels > 0.0:
-        l = 1.0 / (1.0 + (x / gamma_pixels) ** 2)
-    else:
-        l = np.zeros(len(x))
-        l[radius] = 1.0  # delta at center
-
-    kernel = (1.0 - eta) * g + eta * l
+    denom = np.broadcast_to(np.ones(()), (y.shape[0], x.shape[1])).copy()
+    if not zero0:
+        denom = denom + (y / hw0) ** 2
+    if not zero1:
+        denom = denom + (x / hw1) ** 2
+    kernel = 1.0 / denom
     return (kernel / kernel.sum()).astype(np.float32)
 
 
-def _apply_convolve1d(array, kernels, mode, cval=0.0):
-    """Apply 1-D convolutions along each axis using ``scipy.ndimage.convolve1d``.
+def _apply_convolve_2d_on_axes(array, kernel_2d, axes, mode, cval=0.0):
+    """Apply a 2-D convolution on a specified pair of axes of an n-D array.
 
-    Used as the callable passed to ``dask.array.map_overlap`` so that it
-    always runs on CPU (NumPy) chunks.  ``kernels`` is a list aligned with
-    ``array.ndim``; ``None`` entries skip the corresponding axis.
+    Uses FFT-based convolution (``scipy.signal.fftconvolve``) so the cost is
+    O(N log N) per spatial slice — independent of kernel size. The heavy tails
+    of the Lorentzian and Voigtian kernels can make them comparable in size to
+    the image itself, which would be prohibitively slow with direct
+    convolution. The image is first padded according to ``mode`` so that the
+    valid-mode convolution returns the same shape as the input.
+
+    The kernel is broadcast to ``array.ndim`` with size-1 dimensions on all
+    axes other than ``axes``. Suitable for ``dask.array.map_overlap``.
     """
-    import scipy.ndimage
+    import scipy.signal
 
-    for axis, kernel in enumerate(kernels):
-        if kernel is not None:
-            array = scipy.ndimage.convolve1d(
-                array, kernel, axis=axis, mode=mode, cval=cval
-            )
+    kh, kw = kernel_2d.shape
+
+    # Delta kernel → no-op shortcut.
+    if kh == 1 and kw == 1:
+        return (array * float(kernel_2d[0, 0])).astype(array.dtype, copy=False)
+
+    # Kernels from _lorentzian_kernel_2d always have odd sizes; `valid`-mode
+    # convolution on a (kh//2, kw//2)-padded array then returns the original
+    # shape exactly.
+    ph = kh // 2
+    pw = kw // 2
+
+    pad_widths = [(0, 0)] * array.ndim
+    pad_widths[axes[0]] = (ph, ph)
+    pad_widths[axes[1]] = (pw, pw)
+
+    if mode == "wrap":
+        padded = np.pad(array, pad_widths, mode="wrap")
+    elif mode == "reflect":
+        padded = np.pad(array, pad_widths, mode="reflect")
+    elif mode == "constant":
+        padded = np.pad(array, pad_widths, mode="constant", constant_values=cval)
+    else:
+        raise ValueError(f"Unknown convolution mode: {mode!r}")
+
+    shape = [1] * array.ndim
+    shape[axes[0]] = kh
+    shape[axes[1]] = kw
+    kernel_nd = kernel_2d.reshape(shape)
+
+    result = scipy.signal.fftconvolve(padded, kernel_nd, mode="valid", axes=axes)
+    return result.astype(array.dtype, copy=False)
     return array
 
 
@@ -2687,7 +2604,15 @@ def _lorentzian_source_size(
     half_width: float | tuple[float, float],
     truncate: float = 10.0,
 ):
-    if len(_scan_axes(measurements)) < 2:
+    """Apply a true 2-D Lorentzian convolution across the two scan axes.
+
+    Mirrors :func:`_gaussian_source_size` but uses the non-separable 2-D
+    Lorentzian kernel from :func:`_lorentzian_kernel_2d`, avoiding the
+    cross-shaped artefacts that a separable 1-D × 1-D Lorentzian would
+    produce around sharp features.
+    """
+    scan_axes = _scan_axes(measurements)
+    if len(scan_axes) < 2:
         raise RuntimeError(
             "Lorentzian source size not implemented for diffraction patterns with less"
             " than two scan axes."
@@ -2698,41 +2623,36 @@ def _lorentzian_source_size(
 
     xp = get_array_module(measurements.array)
 
-    ensemble_axes = tuple(range(len(measurements.ensemble_shape)))
-    kernels = []
-    depth = []
-    i = 0
-    for axis, n in zip(ensemble_axes, measurements.ensemble_shape):
-        if axis in _scan_axes(measurements):
-            scan_sampling = _scan_sampling(measurements)[i]
-            hw_pix = half_width[i] / scan_sampling
-            kernel = _lorentzian_kernel_1d(hw_pix, truncate)
-            kernels.append(kernel)
-            depth.append(min(len(kernel) // 2, n))
-            i += 1
-        else:
-            kernels.append(None)
-            depth.append(0)
+    scan_sampling = _scan_sampling(measurements)
+    hw_pixels = (
+        half_width[0] / scan_sampling[0],
+        half_width[1] / scan_sampling[1],
+    )
+    kernel_2d = _lorentzian_kernel_2d(hw_pixels, truncate)
 
-    # Two trailing measurement axes — never filtered
-    kernels += [None, None]
-    depth += [0, 0]
+    axes = (scan_axes[0], scan_axes[1])
 
     if measurements.is_lazy:
+        depth = [0] * measurements.array.ndim
+        depth[axes[0]] = min(kernel_2d.shape[0] // 2, measurements.shape[axes[0]])
+        depth[axes[1]] = min(kernel_2d.shape[1] // 2, measurements.shape[axes[1]])
+
         array = measurements.array.map_overlap(
-            functools.partial(_apply_convolve1d, kernels=kernels, mode="wrap"),
+            functools.partial(
+                _apply_convolve_2d_on_axes,
+                kernel_2d=kernel_2d,
+                axes=axes,
+                mode="wrap",
+            ),
             depth=tuple(depth),
             boundary="periodic",
             meta=xp.array((), dtype=xp.float32),
         )
     else:
-        ndimage = get_ndimage_module(measurements._array)
-        array = measurements.array
-        for axis, kernel in enumerate(kernels):
-            if kernel is not None:
-                array = ndimage.convolve1d(
-                    array, xp.asarray(kernel), axis=axis, mode="wrap"
-                )
+        array = _apply_convolve_2d_on_axes(
+            np.asarray(measurements.array), kernel_2d, axes=axes, mode="wrap"
+        )
+        array = xp.asarray(array)
 
     kwargs = measurements._copy_kwargs(exclude=("array",))
     return measurements.__class__(array, **kwargs)
@@ -2742,59 +2662,22 @@ def _voigtian_source_size(
     measurements,
     gaussian_sigma: float | tuple[float, float],
     lorentzian_gamma: float | tuple[float, float],
-    truncate: float = 5.0,
+    truncate: float = 10.0,
 ):
+    """Apply a Voigtian source-size convolution via Gaussian then Lorentzian.
+
+    Exploits the associativity of convolution: convolving with a Voigt profile
+    (Gaussian ∗ Lorentzian) is equivalent to convolving sequentially with a
+    Gaussian and then with a Lorentzian. The Lorentzian step uses the true
+    2-D non-separable kernel.
+    """
     if len(_scan_axes(measurements)) < 2:
         raise RuntimeError(
-            "Voigt source size not implemented for diffraction patterns with less"
+            "Voigtian source size not implemented for diffraction patterns with less"
             " than two scan axes."
         )
-
-    if np.isscalar(gaussian_sigma):
-        gaussian_sigma = (gaussian_sigma,) * 2
-    if np.isscalar(lorentzian_gamma):
-        lorentzian_gamma = (lorentzian_gamma,) * 2
-
-    xp = get_array_module(measurements.array)
-
-    ensemble_axes = tuple(range(len(measurements.ensemble_shape)))
-    kernels = []
-    depth = []
-    i = 0
-    for axis, n in zip(ensemble_axes, measurements.ensemble_shape):
-        if axis in _scan_axes(measurements):
-            scan_sampling = _scan_sampling(measurements)[i]
-            sigma_pix = gaussian_sigma[i] / scan_sampling
-            gamma_pix = lorentzian_gamma[i] / scan_sampling
-            kernel = _voigt_kernel_1d(sigma_pix, gamma_pix, truncate)
-            kernels.append(kernel)
-            depth.append(min(len(kernel) // 2, n))
-            i += 1
-        else:
-            kernels.append(None)
-            depth.append(0)
-
-    kernels += [None, None]
-    depth += [0, 0]
-
-    if measurements.is_lazy:
-        array = measurements.array.map_overlap(
-            functools.partial(_apply_convolve1d, kernels=kernels, mode="wrap"),
-            depth=tuple(depth),
-            boundary="periodic",
-            meta=xp.array((), dtype=xp.float32),
-        )
-    else:
-        ndimage = get_ndimage_module(measurements._array)
-        array = measurements.array
-        for axis, kernel in enumerate(kernels):
-            if kernel is not None:
-                array = ndimage.convolve1d(
-                    array, xp.asarray(kernel), axis=axis, mode="wrap"
-                )
-
-    kwargs = measurements._copy_kwargs(exclude=("array",))
-    return measurements.__class__(array, **kwargs)
+    g = _gaussian_source_size(measurements, gaussian_sigma)
+    return _lorentzian_source_size(g, lorentzian_gamma, truncate)
 
 
 def _pseudo_voigtian_source_size(
@@ -2804,57 +2687,29 @@ def _pseudo_voigtian_source_size(
     eta: float,
     truncate: float = 10.0,
 ):
+    """Apply a pseudo-Voigtian source-size convolution via a linear combination.
+
+    Exploits the linearity of convolution: PV = (1−η)·G + η·L, so the
+    pseudo-Voigt-filtered image is the same weighted combination of the
+    Gaussian- and Lorentzian-filtered images. Each component is computed
+    with its proper (separable Gaussian / true-2-D Lorentzian) kernel.
+    """
     if len(_scan_axes(measurements)) < 2:
         raise RuntimeError(
             "Pseudo-Voigtian source size not implemented for diffraction patterns"
             " with less than two scan axes."
         )
+    if eta == 0.0:
+        return _gaussian_source_size(measurements, gaussian_sigma)
+    if eta == 1.0:
+        return _lorentzian_source_size(measurements, lorentzian_gamma, truncate)
 
-    if np.isscalar(gaussian_sigma):
-        gaussian_sigma = (gaussian_sigma,) * 2
-    if np.isscalar(lorentzian_gamma):
-        lorentzian_gamma = (lorentzian_gamma,) * 2
-
-    xp = get_array_module(measurements.array)
-
-    ensemble_axes = tuple(range(len(measurements.ensemble_shape)))
-    kernels = []
-    depth = []
-    i = 0
-    for axis, n in zip(ensemble_axes, measurements.ensemble_shape):
-        if axis in _scan_axes(measurements):
-            scan_sampling = _scan_sampling(measurements)[i]
-            sigma_pix = gaussian_sigma[i] / scan_sampling
-            gamma_pix = lorentzian_gamma[i] / scan_sampling
-            kernel = _pseudo_voigt_kernel_1d(sigma_pix, gamma_pix, eta, truncate)
-            kernels.append(kernel)
-            depth.append(min(len(kernel) // 2, n))
-            i += 1
-        else:
-            kernels.append(None)
-            depth.append(0)
-
-    kernels += [None, None]
-    depth += [0, 0]
-
-    if measurements.is_lazy:
-        array = measurements.array.map_overlap(
-            functools.partial(_apply_convolve1d, kernels=kernels, mode="wrap"),
-            depth=tuple(depth),
-            boundary="periodic",
-            meta=xp.array((), dtype=xp.float32),
-        )
-    else:
-        ndimage = get_ndimage_module(measurements._array)
-        array = measurements.array
-        for axis, kernel in enumerate(kernels):
-            if kernel is not None:
-                array = ndimage.convolve1d(
-                    array, xp.asarray(kernel), axis=axis, mode="wrap"
-                )
-
+    g = _gaussian_source_size(measurements, gaussian_sigma)
+    l = _lorentzian_source_size(measurements, lorentzian_gamma, truncate)
     kwargs = measurements._copy_kwargs(exclude=("array",))
-    return measurements.__class__(array, **kwargs)
+    return measurements.__class__(
+        (1.0 - eta) * g.array + eta * l.array, **kwargs
+    )
 
 
 def _gaussian_source_size(measurements, sigma: float | tuple[float, float]):
@@ -3613,7 +3468,7 @@ class DiffractionPatterns(_BaseMeasurement2D):
         self,
         gaussian_sigma: float | tuple[float, float],
         lorentzian_gamma: float | tuple[float, float],
-        truncate: float = 5.0,
+        truncate: float = 10.0,
     ) -> DiffractionPatterns:
         """
         Simulate the effect of a finite source size on diffraction pattern(s) using a
@@ -3633,7 +3488,8 @@ class DiffractionPatterns(_BaseMeasurement2D):
             Half-width at half-maximum (HWHM, γ) of the Lorentzian component [Å].
             If given as a single number it is equal for both axes.
         truncate : float, optional
-            Truncate the kernel at this many Voigt half-widths (default is 5.0).
+            Truncate the Lorentzian component at this many half-widths
+            (default 10.0). The Gaussian component uses the SciPy default (4·σ).
 
         Returns
         -------
@@ -4713,7 +4569,7 @@ class PolarMeasurements(BaseMeasurements):
         self,
         gaussian_sigma: float | tuple[float, float],
         lorentzian_gamma: float | tuple[float, float],
-        truncate: float = 5.0,
+        truncate: float = 10.0,
     ) -> PolarMeasurements:
         """
         Simulate the effect of a finite source size on polar measurement(s) using a
@@ -4731,7 +4587,8 @@ class PolarMeasurements(BaseMeasurements):
             Half-width at half-maximum (HWHM, γ) of the Lorentzian component [Å].
             If given as a single number it is equal for both axes.
         truncate : float, optional
-            Truncate the kernel at this many Voigt half-widths (default is 5.0).
+            Truncate the Lorentzian component at this many half-widths
+            (default 10.0). The Gaussian component uses the SciPy default (4·σ).
 
         Returns
         -------

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -1330,6 +1330,107 @@ class _BaseMeasurement2D(BaseMeasurements):
         kwargs["array"] = array
         return self.__class__(**kwargs)
 
+    def pseudo_voigtian_filter(
+        self,
+        gaussian_sigma: float | tuple[float, float],
+        lorentzian_gamma: float | tuple[float, float],
+        eta: float,
+        truncate: float = 10.0,
+        boundary: str = "periodic",
+        cval: float = 0.0,
+    ):
+        """
+        Apply a 2D pseudo-Voigtian filter to measurements.
+
+        The pseudo-Voigt profile is a weighted linear sum of a Gaussian and a
+        Lorentzian — PV = (1-η)·G + η·L — as proposed by Nguyen et al. (2014).
+        The filter is applied separately along each axis (separable convolution),
+        consistent with how :meth:`gaussian_filter` works.
+
+        Parameters
+        ----------
+        gaussian_sigma : float or two float
+            Standard deviation (σ) of the Gaussian component in physical units
+            (Å for real-space images, 1/Å for diffraction patterns). If given
+            as a single number it is equal for both axes.
+        lorentzian_gamma : float or two float
+            Half-width at half-maximum (HWHM, γ) of the Lorentzian component in
+            physical units. If given as a single number it is equal for both axes.
+        eta : float
+            Lorentzian mixing fraction η ∈ [0, 1]. η = 0 gives a pure Gaussian
+            (equivalent to :meth:`gaussian_filter`); η = 1 gives a pure
+            Lorentzian (equivalent to :meth:`lorentzian_filter`).
+        truncate : float, optional
+            Truncate the kernel at this many effective half-widths (default 10.0).
+            The effective half-width is max(σ, γ).
+        boundary : {'periodic', 'reflect', 'constant'}
+            How the image is extended beyond its boundary (default is 'periodic').
+        cval : float, optional
+            Constant value used when ``boundary`` is ``'constant'`` (default 0.0).
+
+        Returns
+        -------
+        filtered : same type as input
+            The filtered measurement(s).
+
+        Notes
+        -----
+        Width parameterization:
+
+        * ``gaussian_sigma`` (σ): standard deviation; FWHM_G = 2√(2 ln 2)·σ ≈ 2.3548·σ.
+        * ``lorentzian_gamma`` (γ): HWHM; FWHM_L = 2γ.
+
+        For the same FWHM, γ = FWHM / 2 whereas σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
+        """
+        xp = get_array_module(self.array)
+
+        if boundary == "periodic":
+            mode = "wrap"
+        elif boundary in ("reflect", "constant"):
+            mode = boundary
+        else:
+            raise ValueError(
+                f"boundary must be 'periodic', 'reflect', or 'constant', got {boundary!r}"
+            )
+
+        if np.isscalar(gaussian_sigma):
+            gaussian_sigma = (gaussian_sigma,) * 2
+        if np.isscalar(lorentzian_gamma):
+            lorentzian_gamma = (lorentzian_gamma,) * 2
+
+        sigma_pixels = tuple(s / d for s, d in zip(gaussian_sigma, self.sampling))
+        gamma_pixels = tuple(g / d for g, d in zip(lorentzian_gamma, self.sampling))
+
+        n_ensemble = len(self.shape) - 2
+        kernels = [None] * n_ensemble + [
+            _pseudo_voigt_kernel_1d(s, g, eta, truncate)
+            for s, g in zip(sigma_pixels, gamma_pixels)
+        ]
+
+        if self.is_lazy:
+            radii = [len(k) // 2 if k is not None else 0 for k in kernels]
+            depth = tuple(min(r, n) for r, n in zip(radii, self.shape))
+
+            array = da.map_overlap(
+                functools.partial(_apply_convolve1d, kernels=kernels, mode=mode, cval=cval),
+                self.array,
+                depth=depth,
+                boundary=boundary,
+                meta=xp.array((), dtype=xp.float32),
+            )
+        else:
+            ndimage = get_ndimage_module(self.array)
+            array = self.array
+            for axis, kernel in enumerate(kernels):
+                if kernel is not None:
+                    array = ndimage.convolve1d(
+                        array, xp.asarray(kernel), axis=axis, mode=mode, cval=cval
+                    )
+
+        kwargs = self._copy_kwargs(exclude=("array",))
+        kwargs["array"] = array
+        return self.__class__(**kwargs)
+
     def interpolate_line_at_position(
         self,
         center: tuple[float, float] | Atom,
@@ -2524,6 +2625,46 @@ def _voigt_kernel_1d(
     return (kernel / kernel.sum()).astype(np.float32)
 
 
+def _pseudo_voigt_kernel_1d(
+    sigma_pixels: float,
+    gamma_pixels: float,
+    eta: float,
+    truncate: float = 10.0,
+) -> np.ndarray:
+    """Build a normalized 1-D pseudo-Voigt convolution kernel in pixel units.
+
+    The kernel is the weighted sum (1-eta)*G + eta*L evaluated on a shared grid,
+    where G is a Gaussian and L is a Lorentzian. Returns a delta kernel when both
+    sigma_pixels and gamma_pixels are effectively zero.
+    """
+    if sigma_pixels < _LORENTZIAN_SAFE_HW:
+        sigma_pixels = 0.0
+    if gamma_pixels < _LORENTZIAN_SAFE_HW:
+        gamma_pixels = 0.0
+
+    hw = max(sigma_pixels, gamma_pixels)
+    if hw == 0.0:
+        return np.array([1.0], dtype=np.float32)
+
+    radius = int(np.ceil(truncate * hw))
+    x = np.arange(-radius, radius + 1, dtype=np.float64)
+
+    if sigma_pixels > 0.0:
+        g = np.exp(-0.5 * (x / sigma_pixels) ** 2)
+    else:
+        g = np.zeros(len(x))
+        g[radius] = 1.0  # delta at center
+
+    if gamma_pixels > 0.0:
+        l = 1.0 / (1.0 + (x / gamma_pixels) ** 2)
+    else:
+        l = np.zeros(len(x))
+        l[radius] = 1.0  # delta at center
+
+    kernel = (1.0 - eta) * g + eta * l
+    return (kernel / kernel.sum()).astype(np.float32)
+
+
 def _apply_convolve1d(array, kernels, mode, cval=0.0):
     """Apply 1-D convolutions along each axis using ``scipy.ndimage.convolve1d``.
 
@@ -2626,6 +2767,66 @@ def _voigtian_source_size(
             sigma_pix = gaussian_sigma[i] / scan_sampling
             gamma_pix = lorentzian_gamma[i] / scan_sampling
             kernel = _voigt_kernel_1d(sigma_pix, gamma_pix, truncate)
+            kernels.append(kernel)
+            depth.append(min(len(kernel) // 2, n))
+            i += 1
+        else:
+            kernels.append(None)
+            depth.append(0)
+
+    kernels += [None, None]
+    depth += [0, 0]
+
+    if measurements.is_lazy:
+        array = measurements.array.map_overlap(
+            functools.partial(_apply_convolve1d, kernels=kernels, mode="wrap"),
+            depth=tuple(depth),
+            boundary="periodic",
+            meta=xp.array((), dtype=xp.float32),
+        )
+    else:
+        ndimage = get_ndimage_module(measurements._array)
+        array = measurements.array
+        for axis, kernel in enumerate(kernels):
+            if kernel is not None:
+                array = ndimage.convolve1d(
+                    array, xp.asarray(kernel), axis=axis, mode="wrap"
+                )
+
+    kwargs = measurements._copy_kwargs(exclude=("array",))
+    return measurements.__class__(array, **kwargs)
+
+
+def _pseudo_voigtian_source_size(
+    measurements,
+    gaussian_sigma: float | tuple[float, float],
+    lorentzian_gamma: float | tuple[float, float],
+    eta: float,
+    truncate: float = 10.0,
+):
+    if len(_scan_axes(measurements)) < 2:
+        raise RuntimeError(
+            "Pseudo-Voigtian source size not implemented for diffraction patterns"
+            " with less than two scan axes."
+        )
+
+    if np.isscalar(gaussian_sigma):
+        gaussian_sigma = (gaussian_sigma,) * 2
+    if np.isscalar(lorentzian_gamma):
+        lorentzian_gamma = (lorentzian_gamma,) * 2
+
+    xp = get_array_module(measurements.array)
+
+    ensemble_axes = tuple(range(len(measurements.ensemble_shape)))
+    kernels = []
+    depth = []
+    i = 0
+    for axis, n in zip(ensemble_axes, measurements.ensemble_shape):
+        if axis in _scan_axes(measurements):
+            scan_sampling = _scan_sampling(measurements)[i]
+            sigma_pix = gaussian_sigma[i] / scan_sampling
+            gamma_pix = lorentzian_gamma[i] / scan_sampling
+            kernel = _pseudo_voigt_kernel_1d(sigma_pix, gamma_pix, eta, truncate)
             kernels.append(kernel)
             depth.append(min(len(kernel) // 2, n))
             i += 1
@@ -3451,6 +3652,51 @@ class DiffractionPatterns(_BaseMeasurement2D):
         For the same FWHM, γ = FWHM / 2 but σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
         """
         return _voigtian_source_size(self, gaussian_sigma, lorentzian_gamma, truncate)
+
+    def pseudo_voigtian_source_size(
+        self,
+        gaussian_sigma: float | tuple[float, float],
+        lorentzian_gamma: float | tuple[float, float],
+        eta: float,
+        truncate: float = 10.0,
+    ) -> DiffractionPatterns:
+        """
+        Simulate the effect of a finite source size on diffraction pattern(s) using a
+        pseudo-Voigtian filter (weighted sum of Gaussian and Lorentzian).
+
+        The filter mixes intensities across scan axes (not within each diffraction
+        pattern) and requires two linear scan axes. Applying this filter before
+        integrating gives the same result as integrating first and then applying a
+        :meth:`pseudo_voigtian_filter` to the resulting images.
+
+        Parameters
+        ----------
+        gaussian_sigma : float or two float
+            Standard deviation (σ) of the Gaussian component [Å]. If given as a
+            single number it is equal for both axes.
+        lorentzian_gamma : float or two float
+            Half-width at half-maximum (HWHM, γ) of the Lorentzian component [Å].
+            If given as a single number it is equal for both axes.
+        eta : float
+            Lorentzian mixing fraction η ∈ [0, 1]. η = 0 gives a pure Gaussian;
+            η = 1 gives a pure Lorentzian.
+        truncate : float, optional
+            Truncate the kernel at this many effective half-widths (default 10.0).
+
+        Returns
+        -------
+        filtered_diffraction_patterns : DiffractionPatterns
+            The filtered diffraction pattern(s).
+
+        Notes
+        -----
+        The pseudo-Voigt profile is PV = (1-η)·G + η·L, where G and L are
+        Gaussian and Lorentzian profiles with widths σ and γ respectively. Width
+        parameterization: FWHM_G = 2√(2 ln 2)·σ ≈ 2.3548·σ; FWHM_L = 2γ.
+        """
+        return _pseudo_voigtian_source_size(
+            self, gaussian_sigma, lorentzian_gamma, eta, truncate
+        )
 
     def poisson_noise(
         self,
@@ -4504,6 +4750,49 @@ class PolarMeasurements(BaseMeasurements):
         For the same FWHM, γ = FWHM / 2 but σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
         """
         return _voigtian_source_size(self, gaussian_sigma, lorentzian_gamma, truncate)
+
+    def pseudo_voigtian_source_size(
+        self,
+        gaussian_sigma: float | tuple[float, float],
+        lorentzian_gamma: float | tuple[float, float],
+        eta: float,
+        truncate: float = 10.0,
+    ) -> PolarMeasurements:
+        """
+        Simulate the effect of a finite source size on polar measurement(s) using a
+        pseudo-Voigtian filter (weighted sum of Gaussian and Lorentzian).
+
+        The filter mixes intensities across scan axes (not within each measurement)
+        and requires two linear scan axes.
+
+        Parameters
+        ----------
+        gaussian_sigma : float or two float
+            Standard deviation (σ) of the Gaussian component [Å]. If given as a
+            single number it is equal for both axes.
+        lorentzian_gamma : float or two float
+            Half-width at half-maximum (HWHM, γ) of the Lorentzian component [Å].
+            If given as a single number it is equal for both axes.
+        eta : float
+            Lorentzian mixing fraction η ∈ [0, 1]. η = 0 gives a pure Gaussian;
+            η = 1 gives a pure Lorentzian.
+        truncate : float, optional
+            Truncate the kernel at this many effective half-widths (default 10.0).
+
+        Returns
+        -------
+        filtered_measurements : PolarMeasurements
+            The filtered measurement(s).
+
+        Notes
+        -----
+        The pseudo-Voigt profile is PV = (1-η)·G + η·L, where G and L are
+        Gaussian and Lorentzian profiles with widths σ and γ respectively. Width
+        parameterization: FWHM_G = 2√(2 ln 2)·σ ≈ 2.3548·σ; FWHM_L = 2γ.
+        """
+        return _pseudo_voigtian_source_size(
+            self, gaussian_sigma, lorentzian_gamma, eta, truncate
+        )
 
     def poisson_noise(
         self,

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import functools
 import itertools
 import warnings
 from abc import ABCMeta, abstractmethod
@@ -1129,6 +1130,171 @@ class _BaseMeasurement2D(BaseMeasurements):
         kwargs["array"] = array
         return self.__class__(**kwargs)
 
+    def lorentzian_filter(
+        self,
+        half_width: float | tuple[float, float],
+        truncate: float = 10.0,
+        boundary: str = "periodic",
+        cval: float = 0.0,
+    ):
+        """
+        Apply a 2D Lorentzian (Cauchy) filter to measurements.
+
+        The filter is applied separately along each axis (separable convolution),
+        which is consistent with how :meth:`gaussian_filter` works.
+
+        Parameters
+        ----------
+        half_width : float or two float
+            Half-width at half-maximum (HWHM) of the Lorentzian kernel in the ``x``
+            and ``y``-direction given in physical units (Å for real-space images,
+            1/Å for diffraction patterns). If given as a single number, the
+            half-width is equal for both axes.
+        truncate : float, optional
+            Truncate the kernel at this many half-widths (default is 10.0). The
+            Lorentzian has heavier tails than the Gaussian, so a larger truncation
+            is recommended.
+        boundary : {'periodic', 'reflect', 'constant'}
+            How the image is extended beyond its boundary (default is 'periodic').
+        cval : float, optional
+            Constant value used when ``boundary`` is ``'constant'`` (default 0.0).
+
+        Returns
+        -------
+        filtered : same type as input
+            The filtered measurement(s).
+        """
+        xp = get_array_module(self.array)
+
+        if boundary == "periodic":
+            mode = "wrap"
+        elif boundary in ("reflect", "constant"):
+            mode = boundary
+        else:
+            raise ValueError(
+                f"boundary must be 'periodic', 'reflect', or 'constant', got {boundary!r}"
+            )
+
+        if np.isscalar(half_width):
+            half_width = (half_width,) * 2
+
+        hw_pixels = tuple(hw / d for hw, d in zip(half_width, self.sampling))
+
+        n_ensemble = len(self.shape) - 2
+        kernels = [None] * n_ensemble + [
+            _lorentzian_kernel_1d(hw, truncate) for hw in hw_pixels
+        ]
+
+        if self.is_lazy:
+            radii = [len(k) // 2 if k is not None else 0 for k in kernels]
+            depth = tuple(min(r, n) for r, n in zip(radii, self.shape))
+
+            array = da.map_overlap(
+                functools.partial(_apply_convolve1d, kernels=kernels, mode=mode, cval=cval),
+                self.array,
+                depth=depth,
+                boundary=boundary,
+                meta=xp.array((), dtype=xp.float32),
+            )
+        else:
+            ndimage = get_ndimage_module(self.array)
+            array = self.array
+            for axis, kernel in enumerate(kernels):
+                if kernel is not None:
+                    array = ndimage.convolve1d(
+                        array, xp.asarray(kernel), axis=axis, mode=mode, cval=cval
+                    )
+
+        kwargs = self._copy_kwargs(exclude=("array",))
+        kwargs["array"] = array
+        return self.__class__(**kwargs)
+
+    def voigtian_filter(
+        self,
+        gaussian_sigma: float | tuple[float, float],
+        lorentzian_gamma: float | tuple[float, float],
+        truncate: float = 5.0,
+        boundary: str = "periodic",
+        cval: float = 0.0,
+    ):
+        """
+        Apply a 2D Voigt filter to measurements.
+
+        The Voigt profile is the convolution of a Gaussian and a Lorentzian.
+        The filter is applied separately along each axis (separable convolution),
+        which is consistent with how :meth:`gaussian_filter` works.
+
+        Parameters
+        ----------
+        gaussian_sigma : float or two float
+            Standard deviation (σ) of the Gaussian component in physical units
+            (Å for real-space images, 1/Å for diffraction patterns). If given
+            as a single number it is equal for both axes.
+        lorentzian_gamma : float or two float
+            Half-width at half-maximum (HWHM, γ) of the Lorentzian component in
+            physical units. If given as a single number it is equal for both axes.
+        truncate : float, optional
+            Truncate the kernel at this many Voigt half-widths (default is 5.0).
+            The Voigt HWHM is estimated via the Thompson et al. (1987) approximation.
+        boundary : {'periodic', 'reflect', 'constant'}
+            How the image is extended beyond its boundary (default is 'periodic').
+        cval : float, optional
+            Constant value used when ``boundary`` is ``'constant'`` (default 0.0).
+
+        Returns
+        -------
+        filtered : same type as input
+            The filtered measurement(s).
+        """
+        xp = get_array_module(self.array)
+
+        if boundary == "periodic":
+            mode = "wrap"
+        elif boundary in ("reflect", "constant"):
+            mode = boundary
+        else:
+            raise ValueError(
+                f"boundary must be 'periodic', 'reflect', or 'constant', got {boundary!r}"
+            )
+
+        if np.isscalar(gaussian_sigma):
+            gaussian_sigma = (gaussian_sigma,) * 2
+        if np.isscalar(lorentzian_gamma):
+            lorentzian_gamma = (lorentzian_gamma,) * 2
+
+        sigma_pixels = tuple(s / d for s, d in zip(gaussian_sigma, self.sampling))
+        gamma_pixels = tuple(g / d for g, d in zip(lorentzian_gamma, self.sampling))
+
+        n_ensemble = len(self.shape) - 2
+        kernels = [None] * n_ensemble + [
+            _voigt_kernel_1d(s, g, truncate)
+            for s, g in zip(sigma_pixels, gamma_pixels)
+        ]
+
+        if self.is_lazy:
+            radii = [len(k) // 2 if k is not None else 0 for k in kernels]
+            depth = tuple(min(r, n) for r, n in zip(radii, self.shape))
+
+            array = da.map_overlap(
+                functools.partial(_apply_convolve1d, kernels=kernels, mode=mode, cval=cval),
+                self.array,
+                depth=depth,
+                boundary=boundary,
+                meta=xp.array((), dtype=xp.float32),
+            )
+        else:
+            ndimage = get_ndimage_module(self.array)
+            array = self.array
+            for axis, kernel in enumerate(kernels):
+                if kernel is not None:
+                    array = ndimage.convolve1d(
+                        array, xp.asarray(kernel), axis=axis, mode=mode, cval=cval
+                    )
+
+        kwargs = self._copy_kwargs(exclude=("array",))
+        kwargs["array"] = array
+        return self.__class__(**kwargs)
+
     def interpolate_line_at_position(
         self,
         center: tuple[float, float] | Atom,
@@ -2249,6 +2415,212 @@ def _fourier_space_bilinear_nodes_and_weight(
     return v, u, vw, uw
 
 
+# Threshold below which (1/hw)^2 would overflow float64.
+# For the Lorentzian kernel the minimum radius is 1, so the maximum operand
+# is x/hw = 1/hw; squaring overflows when hw < 1/sqrt(float_max).
+_LORENTZIAN_SAFE_HW = 1.0 / np.sqrt(np.finfo(np.float64).max)  # ≈ 7.5e-155
+
+
+def _lorentzian_kernel_1d(half_width_pixels: float, truncate: float = 10.0) -> np.ndarray:
+    """Build a normalized 1-D Lorentzian (Cauchy) convolution kernel in pixel units.
+
+    When ``half_width_pixels`` is zero or so small that the filter is effectively a
+    unit impulse (kernel narrower than the arithmetic precision allows), a delta
+    kernel is returned — consistent with ``gaussian_filter`` at sigma=0.
+    """
+    if half_width_pixels < _LORENTZIAN_SAFE_HW:
+        return np.array([1.0], dtype=np.float32)
+    radius = int(np.ceil(truncate * half_width_pixels))
+    x = np.arange(-radius, radius + 1, dtype=np.float64)
+    kernel = 1.0 / (1.0 + (x / half_width_pixels) ** 2)
+    return (kernel / kernel.sum()).astype(np.float32)
+
+
+def _voigt_kernel_1d(
+    sigma_pixels: float,
+    gamma_pixels: float,
+    truncate: float = 5.0,
+) -> np.ndarray:
+    """Build a normalized 1-D Voigt convolution kernel in pixel units.
+
+    Uses the exact Voigt profile (Faddeeva function) when both components are
+    non-zero, falls back to pure Gaussian / Lorentzian for degenerate cases, and
+    returns a unit impulse when both are zero (leaving the data unchanged).
+    """
+    from scipy.special import wofz
+
+    # Clamp values below the safe threshold to zero to avoid overflow
+    if sigma_pixels < _LORENTZIAN_SAFE_HW:
+        sigma_pixels = 0.0
+    if gamma_pixels < _LORENTZIAN_SAFE_HW:
+        gamma_pixels = 0.0
+
+    if sigma_pixels == 0.0 and gamma_pixels == 0.0:
+        return np.array([1.0], dtype=np.float32)
+
+    fG = 2.0 * sigma_pixels * np.sqrt(2.0 * np.log(2.0))
+    fL = 2.0 * gamma_pixels
+    if sigma_pixels == 0.0:
+        voigt_hwhm = gamma_pixels
+    elif gamma_pixels == 0.0:
+        voigt_hwhm = fG / 2.0
+    else:
+        f5 = (
+            fG**5
+            + 2.69269 * fG**4 * fL
+            + 2.42843 * fG**3 * fL**2
+            + 4.47163 * fG**2 * fL**3
+            + 0.07842 * fG * fL**4
+            + fL**5
+        )
+        voigt_hwhm = f5 ** (1.0 / 5.0) / 2.0
+
+    radius = int(np.ceil(truncate * voigt_hwhm))
+    x = np.arange(-radius, radius + 1, dtype=np.float64)
+
+    if sigma_pixels == 0.0:
+        kernel = 1.0 / (1.0 + (x / gamma_pixels) ** 2)
+    elif gamma_pixels == 0.0:
+        kernel = np.exp(-0.5 * x**2 / sigma_pixels**2)
+    else:
+        z = (x + 1j * gamma_pixels) / (sigma_pixels * np.sqrt(2.0))
+        kernel = np.real(wofz(z))
+
+    return (kernel / kernel.sum()).astype(np.float32)
+
+
+def _apply_convolve1d(array, kernels, mode, cval=0.0):
+    """Apply 1-D convolutions along each axis using ``scipy.ndimage.convolve1d``.
+
+    Used as the callable passed to ``dask.array.map_overlap`` so that it
+    always runs on CPU (NumPy) chunks.  ``kernels`` is a list aligned with
+    ``array.ndim``; ``None`` entries skip the corresponding axis.
+    """
+    import scipy.ndimage
+
+    for axis, kernel in enumerate(kernels):
+        if kernel is not None:
+            array = scipy.ndimage.convolve1d(
+                array, kernel, axis=axis, mode=mode, cval=cval
+            )
+    return array
+
+
+def _lorentzian_source_size(
+    measurements,
+    half_width: float | tuple[float, float],
+    truncate: float = 10.0,
+):
+    if len(_scan_axes(measurements)) < 2:
+        raise RuntimeError(
+            "Lorentzian source size not implemented for diffraction patterns with less"
+            " than two scan axes."
+        )
+
+    if np.isscalar(half_width):
+        half_width = (half_width,) * 2
+
+    xp = get_array_module(measurements.array)
+
+    ensemble_axes = tuple(range(len(measurements.ensemble_shape)))
+    kernels = []
+    depth = []
+    i = 0
+    for axis, n in zip(ensemble_axes, measurements.ensemble_shape):
+        if axis in _scan_axes(measurements):
+            scan_sampling = _scan_sampling(measurements)[i]
+            hw_pix = half_width[i] / scan_sampling
+            kernel = _lorentzian_kernel_1d(hw_pix, truncate)
+            kernels.append(kernel)
+            depth.append(min(len(kernel) // 2, n))
+            i += 1
+        else:
+            kernels.append(None)
+            depth.append(0)
+
+    # Two trailing measurement axes — never filtered
+    kernels += [None, None]
+    depth += [0, 0]
+
+    if measurements.is_lazy:
+        array = measurements.array.map_overlap(
+            functools.partial(_apply_convolve1d, kernels=kernels, mode="wrap"),
+            depth=tuple(depth),
+            boundary="periodic",
+            meta=xp.array((), dtype=xp.float32),
+        )
+    else:
+        ndimage = get_ndimage_module(measurements._array)
+        array = measurements.array
+        for axis, kernel in enumerate(kernels):
+            if kernel is not None:
+                array = ndimage.convolve1d(
+                    array, xp.asarray(kernel), axis=axis, mode="wrap"
+                )
+
+    kwargs = measurements._copy_kwargs(exclude=("array",))
+    return measurements.__class__(array, **kwargs)
+
+
+def _voigtian_source_size(
+    measurements,
+    gaussian_sigma: float | tuple[float, float],
+    lorentzian_gamma: float | tuple[float, float],
+    truncate: float = 5.0,
+):
+    if len(_scan_axes(measurements)) < 2:
+        raise RuntimeError(
+            "Voigt source size not implemented for diffraction patterns with less"
+            " than two scan axes."
+        )
+
+    if np.isscalar(gaussian_sigma):
+        gaussian_sigma = (gaussian_sigma,) * 2
+    if np.isscalar(lorentzian_gamma):
+        lorentzian_gamma = (lorentzian_gamma,) * 2
+
+    xp = get_array_module(measurements.array)
+
+    ensemble_axes = tuple(range(len(measurements.ensemble_shape)))
+    kernels = []
+    depth = []
+    i = 0
+    for axis, n in zip(ensemble_axes, measurements.ensemble_shape):
+        if axis in _scan_axes(measurements):
+            scan_sampling = _scan_sampling(measurements)[i]
+            sigma_pix = gaussian_sigma[i] / scan_sampling
+            gamma_pix = lorentzian_gamma[i] / scan_sampling
+            kernel = _voigt_kernel_1d(sigma_pix, gamma_pix, truncate)
+            kernels.append(kernel)
+            depth.append(min(len(kernel) // 2, n))
+            i += 1
+        else:
+            kernels.append(None)
+            depth.append(0)
+
+    kernels += [None, None]
+    depth += [0, 0]
+
+    if measurements.is_lazy:
+        array = measurements.array.map_overlap(
+            functools.partial(_apply_convolve1d, kernels=kernels, mode="wrap"),
+            depth=tuple(depth),
+            boundary="periodic",
+            meta=xp.array((), dtype=xp.float32),
+        )
+    else:
+        ndimage = get_ndimage_module(measurements._array)
+        array = measurements.array
+        for axis, kernel in enumerate(kernels):
+            if kernel is not None:
+                array = ndimage.convolve1d(
+                    array, xp.asarray(kernel), axis=axis, mode="wrap"
+                )
+
+    kwargs = measurements._copy_kwargs(exclude=("array",))
+    return measurements.__class__(array, **kwargs)
+
+
 def _gaussian_source_size(measurements, sigma: float | tuple[float, float]):
     if len(_scan_axes(measurements)) < 2:
         raise RuntimeError(
@@ -2964,6 +3336,69 @@ class DiffractionPatterns(_BaseMeasurement2D):
         """
 
         return _gaussian_source_size(self, sigma)
+
+    def lorentzian_source_size(
+        self,
+        half_width: float | tuple[float, float],
+        truncate: float = 10.0,
+    ) -> DiffractionPatterns:
+        """
+        Simulate the effect of a finite source size on diffraction pattern(s) using a
+        Lorentzian (Cauchy) filter.
+
+        The filter mixes intensities across scan axes (not within each diffraction
+        pattern) and requires two linear scan axes. Applying this filter before
+        integrating gives the same result as integrating first and then applying a
+        :meth:`lorentzian_filter` to the resulting images.
+
+        Parameters
+        ----------
+        half_width : float or two float
+            Half-width at half-maximum (HWHM) of the Lorentzian kernel in the ``x``
+            and ``y``-direction [Å]. If given as a single number it is equal for
+            both axes.
+        truncate : float, optional
+            Truncate the kernel at this many half-widths (default is 10.0).
+
+        Returns
+        -------
+        filtered_diffraction_patterns : DiffractionPatterns
+            The filtered diffraction pattern(s).
+        """
+        return _lorentzian_source_size(self, half_width, truncate)
+
+    def voigtian_source_size(
+        self,
+        gaussian_sigma: float | tuple[float, float],
+        lorentzian_gamma: float | tuple[float, float],
+        truncate: float = 5.0,
+    ) -> DiffractionPatterns:
+        """
+        Simulate the effect of a finite source size on diffraction pattern(s) using a
+        Voigt filter (convolution of Gaussian and Lorentzian).
+
+        The filter mixes intensities across scan axes (not within each diffraction
+        pattern) and requires two linear scan axes. Applying this filter before
+        integrating gives the same result as integrating first and then applying a
+        :meth:`voigtian_filter` to the resulting images.
+
+        Parameters
+        ----------
+        gaussian_sigma : float or two float
+            Standard deviation (σ) of the Gaussian component [Å]. If given as a
+            single number it is equal for both axes.
+        lorentzian_gamma : float or two float
+            Half-width at half-maximum (HWHM, γ) of the Lorentzian component [Å].
+            If given as a single number it is equal for both axes.
+        truncate : float, optional
+            Truncate the kernel at this many Voigt half-widths (default is 5.0).
+
+        Returns
+        -------
+        filtered_diffraction_patterns : DiffractionPatterns
+            The filtered diffraction pattern(s).
+        """
+        return _voigtian_source_size(self, gaussian_sigma, lorentzian_gamma, truncate)
 
     def poisson_noise(
         self,
@@ -3941,6 +4376,65 @@ class PolarMeasurements(BaseMeasurements):
         """
 
         return _gaussian_source_size(self, sigma)
+
+    def lorentzian_source_size(
+        self,
+        half_width: float | tuple[float, float],
+        truncate: float = 10.0,
+    ) -> PolarMeasurements:
+        """
+        Simulate the effect of a finite source size on polar measurement(s) using a
+        Lorentzian (Cauchy) filter.
+
+        The filter mixes intensities across scan axes (not within each measurement)
+        and requires two linear scan axes.
+
+        Parameters
+        ----------
+        half_width : float or two float
+            Half-width at half-maximum (HWHM) of the Lorentzian kernel in the ``x``
+            and ``y``-direction [Å]. If given as a single number it is equal for
+            both axes.
+        truncate : float, optional
+            Truncate the kernel at this many half-widths (default is 10.0).
+
+        Returns
+        -------
+        filtered_measurements : PolarMeasurements
+            The filtered measurement(s).
+        """
+        return _lorentzian_source_size(self, half_width, truncate)
+
+    def voigtian_source_size(
+        self,
+        gaussian_sigma: float | tuple[float, float],
+        lorentzian_gamma: float | tuple[float, float],
+        truncate: float = 5.0,
+    ) -> PolarMeasurements:
+        """
+        Simulate the effect of a finite source size on polar measurement(s) using a
+        Voigt filter (convolution of Gaussian and Lorentzian).
+
+        The filter mixes intensities across scan axes (not within each measurement)
+        and requires two linear scan axes.
+
+        Parameters
+        ----------
+        gaussian_sigma : float or two float
+            Standard deviation (σ) of the Gaussian component [Å]. If given as a
+            single number it is equal for both axes.
+        lorentzian_gamma : float or two float
+            Half-width at half-maximum (HWHM, γ) of the Lorentzian component [Å].
+            If given as a single number it is equal for both axes.
+        truncate : float, optional
+            Truncate the kernel at this many Voigt half-widths (default is 5.0).
+
+        Returns
+        -------
+        filtered_measurements : PolarMeasurements
+            The filtered measurement(s).
+        """
+        return _voigtian_source_size(self, gaussian_sigma, lorentzian_gamma, truncate)
 
     def poisson_noise(
         self,

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -41,7 +41,13 @@ from abtem.core.axes import (
     ScaleAxis,
     ScanAxis,
 )
-from abtem.core.backend import asnumpy, cp, get_array_module, get_ndimage_module
+from abtem.core.backend import (
+    asnumpy,
+    cp,
+    get_array_module,
+    get_ndimage_module,
+    get_scipy_module,
+)
 from abtem.core.complex import abs2
 from abtem.core.energy import energy2wavelength
 from abtem.core.fft import fft_crop, fft_interpolate
@@ -1235,11 +1241,12 @@ class _BaseMeasurement2D(BaseMeasurements):
         else:
             # Use FFT-based convolution: cost is independent of kernel size,
             # which matters because the heavy-tailed Lorentzian kernel can
-            # easily be comparable in size to the image itself.
+            # easily be comparable in size to the image itself. The helper
+            # dispatches to scipy.signal or cupyx.scipy.signal based on the
+            # array's backend.
             array = _apply_convolve_2d_on_axes(
-                np.asarray(self.array), kernel_2d, axes=axes, mode=mode, cval=cval
+                self.array, kernel_2d, axes=axes, mode=mode, cval=cval
             )
-            array = xp.asarray(array)
 
         kwargs = self._copy_kwargs(exclude=("array",))
         kwargs["array"] = array
@@ -2552,17 +2559,19 @@ def _lorentzian_kernel_2d(
 def _apply_convolve_2d_on_axes(array, kernel_2d, axes, mode, cval=0.0):
     """Apply a 2-D convolution on a specified pair of axes of an n-D array.
 
-    Uses FFT-based convolution (``scipy.signal.fftconvolve``) so the cost is
-    O(N log N) per spatial slice — independent of kernel size. The heavy tails
-    of the Lorentzian and Voigtian kernels can make them comparable in size to
-    the image itself, which would be prohibitively slow with direct
-    convolution. The image is first padded according to ``mode`` so that the
-    valid-mode convolution returns the same shape as the input.
+    Uses FFT-based convolution (``scipy.signal.fftconvolve`` on CPU,
+    ``cupyx.scipy.signal.fftconvolve`` on GPU) so the cost is O(N log N) per
+    spatial slice — independent of kernel size. The heavy tails of the
+    Lorentzian and Voigtian kernels can make them comparable in size to the
+    image itself, which would be prohibitively slow with direct convolution.
+    The image is first padded according to ``mode`` so that the valid-mode
+    convolution returns the same shape as the input.
 
     The kernel is broadcast to ``array.ndim`` with size-1 dimensions on all
     axes other than ``axes``. Suitable for ``dask.array.map_overlap``.
     """
-    import scipy.signal
+    xp = get_array_module(array)
+    scipy_signal = get_scipy_module(array).signal
 
     kh, kw = kernel_2d.shape
 
@@ -2581,20 +2590,20 @@ def _apply_convolve_2d_on_axes(array, kernel_2d, axes, mode, cval=0.0):
     pad_widths[axes[1]] = (pw, pw)
 
     if mode == "wrap":
-        padded = np.pad(array, pad_widths, mode="wrap")
+        padded = xp.pad(array, pad_widths, mode="wrap")
     elif mode == "reflect":
-        padded = np.pad(array, pad_widths, mode="reflect")
+        padded = xp.pad(array, pad_widths, mode="reflect")
     elif mode == "constant":
-        padded = np.pad(array, pad_widths, mode="constant", constant_values=cval)
+        padded = xp.pad(array, pad_widths, mode="constant", constant_values=cval)
     else:
         raise ValueError(f"Unknown convolution mode: {mode!r}")
 
     shape = [1] * array.ndim
     shape[axes[0]] = kh
     shape[axes[1]] = kw
-    kernel_nd = kernel_2d.reshape(shape)
+    kernel_nd = xp.asarray(kernel_2d).reshape(shape)
 
-    result = scipy.signal.fftconvolve(padded, kernel_nd, mode="valid", axes=axes)
+    result = scipy_signal.fftconvolve(padded, kernel_nd, mode="valid", axes=axes)
     return result.astype(array.dtype, copy=False)
     return array
 
@@ -2650,9 +2659,8 @@ def _lorentzian_source_size(
         )
     else:
         array = _apply_convolve_2d_on_axes(
-            np.asarray(measurements.array), kernel_2d, axes=axes, mode="wrap"
+            measurements.array, kernel_2d, axes=axes, mode="wrap"
         )
-        array = xp.asarray(array)
 
     kwargs = measurements._copy_kwargs(exclude=("array",))
     return measurements.__class__(array, **kwargs)

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -1185,15 +1185,6 @@ class _BaseMeasurement2D(BaseMeasurements):
         Note that :meth:`gaussian_filter` uses the standard deviation σ as its
         width parameter. For the same FWHM one needs γ = FWHM / 2 whereas
         σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
-
-        The Lorentzian source-size model is described in [1]_.
-
-        References
-        ----------
-        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
-           function in scanning transmission electron microscopy and spectroscopy",
-           *Ultramicroscopy* **146**, 6–16 (2014).
-           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         xp = get_array_module(self.array)
 
@@ -1289,15 +1280,6 @@ class _BaseMeasurement2D(BaseMeasurements):
         Because the two components use different parameterizations, σ and γ are
         *not* directly comparable: for the same FWHM, γ = FWHM / 2 whereas
         σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
-
-        The Voigt source-size model is described in [1]_.
-
-        References
-        ----------
-        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
-           function in scanning transmission electron microscopy and spectroscopy",
-           *Ultramicroscopy* **146**, 6–16 (2014).
-           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         xp = get_array_module(self.array)
 
@@ -3423,15 +3405,6 @@ class DiffractionPatterns(_BaseMeasurement2D):
         The Lorentzian kernel is parameterized by its HWHM γ (``half_width``),
         with FWHM_L = 2γ. This differs from :meth:`gaussian_source_size`,
         which uses the standard deviation σ (FWHM_G ≈ 2.3548·σ).
-
-        The Lorentzian source-size model is described in [1]_.
-
-        References
-        ----------
-        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
-           function in scanning transmission electron microscopy and spectroscopy",
-           *Ultramicroscopy* **146**, 6–16 (2014).
-           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         return _lorentzian_source_size(self, half_width, truncate)
 
@@ -3476,15 +3449,6 @@ class DiffractionPatterns(_BaseMeasurement2D):
           FWHM_L = 2γ.
 
         For the same FWHM, γ = FWHM / 2 but σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
-
-        The Voigt source-size model is described in [1]_.
-
-        References
-        ----------
-        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
-           function in scanning transmission electron microscopy and spectroscopy",
-           *Ultramicroscopy* **146**, 6–16 (2014).
-           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         return _voigtian_source_size(self, gaussian_sigma, lorentzian_gamma, truncate)
 
@@ -4496,15 +4460,6 @@ class PolarMeasurements(BaseMeasurements):
         The Lorentzian kernel is parameterized by its HWHM γ (``half_width``),
         with FWHM_L = 2γ. This differs from :meth:`gaussian_source_size`,
         which uses the standard deviation σ (FWHM_G ≈ 2.3548·σ).
-
-        The Lorentzian source-size model is described in [1]_.
-
-        References
-        ----------
-        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
-           function in scanning transmission electron microscopy and spectroscopy",
-           *Ultramicroscopy* **146**, 6–16 (2014).
-           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         return _lorentzian_source_size(self, half_width, truncate)
 
@@ -4547,15 +4502,6 @@ class PolarMeasurements(BaseMeasurements):
           FWHM_L = 2γ.
 
         For the same FWHM, γ = FWHM / 2 but σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
-
-        The Voigt source-size model is described in [1]_.
-
-        References
-        ----------
-        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
-           function in scanning transmission electron microscopy and spectroscopy",
-           *Ultramicroscopy* **146**, 6–16 (2014).
-           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         return _voigtian_source_size(self, gaussian_sigma, lorentzian_gamma, truncate)
 

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -2614,26 +2614,16 @@ def _apply_convolve_2d_on_axes(array, kernel_2d, axes, mode, cval=0.0):
     # Convolve over all axes (no ``axes=`` kwarg). The size-1 dims of the
     # kernel make the FFT along non-target axes a length-1 no-op, so the
     # result is numerically identical to passing ``axes=axes`` — verified
-    # against scipy.signal.fftconvolve with explicit axes. We do not depend
-    # on the kwarg purely for code simplicity; ``axes=`` has actually been
-    # available in cupyx.scipy.signal.fftconvolve since the first version
-    # that shipped fftconvolve (CuPy 9.0, April 2021), which is also the
-    # effective minimum CuPy version for any GPU code in this module.
+    # against scipy.signal.fftconvolve with explicit axes.
     #
     # cupyx.scipy.signal.fftconvolve internally uses cupyx.jit.rawkernel,
-    # which raises a FutureWarning ("cupyx.jit.rawkernel is experimental ...").
-    # This is purely an upstream API-stability notice we cannot fix, but it
-    # would fail tests under filterwarnings=error and clutter library output,
-    # so suppress it precisely here. The filter is message- *and*
-    # category-matched: if CuPy changes the warning text, the category, or
-    # the fftconvolve interface itself, our GPU tests will catch the change.
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=r"cupyx\.jit\.rawkernel is experimental",
-            category=FutureWarning,
-        )
-        result = scipy_signal.fftconvolve(padded, kernel_nd, mode="valid")
+    # which emits a FutureWarning at import / decorator-application time
+    # ("cupyx.jit.rawkernel is experimental ..."). That warning is purely
+    # an upstream API-stability notice, so it is silenced project-wide via
+    # the ``filterwarnings`` block in pyproject.toml. If CuPy changes the
+    # warning text, the category, or the fftconvolve interface itself, the
+    # filter stops matching and the GPU tests catch the change.
+    result = scipy_signal.fftconvolve(padded, kernel_nd, mode="valid")
     return result.astype(array.dtype, copy=False)
     return array
 

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -1064,8 +1064,10 @@ class _BaseMeasurement2D(BaseMeasurements):
         Parameters
         ----------
         sigma : float or two float
-            Standard deviation for the Gaussian kernel in the `x` and `y`-direction. If
-            given as a single number, the standard deviation is equal for both axes.
+            Standard deviation for the Gaussian kernel in the `x` and `y`-direction
+            given in physical units (Å for real-space images, 1/Å for diffraction
+            patterns). If given as a single number, the standard deviation is equal
+            for both axes.
 
         boundary : {'periodic', 'reflect', 'constant'}
             The boundary parameter determines how the images are extended beyond their
@@ -1090,6 +1092,16 @@ class _BaseMeasurement2D(BaseMeasurements):
         -------
         filtered_images : Images
             The filtered image(s).
+
+        Notes
+        -----
+        The Gaussian kernel is parameterized by its standard deviation σ
+        (``sigma``). The corresponding full-width at half-maximum is
+        FWHM_G = 2√(2 ln 2)·σ ≈ 2.3548·σ.
+
+        The Lorentzian and Voigtian filters use the half-width at half-maximum
+        (HWHM) γ as their width parameter: for the same FWHM, γ = FWHM / 2
+        whereas σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
         """
         xp = get_array_module(self.array)
         gaussian_filter = get_ndimage_module(self.array).gaussian_filter
@@ -1163,6 +1175,25 @@ class _BaseMeasurement2D(BaseMeasurements):
         -------
         filtered : same type as input
             The filtered measurement(s).
+
+        Notes
+        -----
+        The Lorentzian kernel is parameterized by its half-width at half-maximum
+        (HWHM) γ (``half_width``). The corresponding full-width at half-maximum
+        is FWHM_L = 2γ.
+
+        Note that :meth:`gaussian_filter` uses the standard deviation σ as its
+        width parameter. For the same FWHM one needs γ = FWHM / 2 whereas
+        σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
+
+        The Lorentzian source-size model is described in [1]_.
+
+        References
+        ----------
+        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
+           function in scanning transmission electron microscopy and spectroscopy",
+           *Ultramicroscopy* **146**, 6–16 (2014).
+           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         xp = get_array_module(self.array)
 
@@ -1245,6 +1276,28 @@ class _BaseMeasurement2D(BaseMeasurements):
         -------
         filtered : same type as input
             The filtered measurement(s).
+
+        Notes
+        -----
+        The Voigt kernel has two independent width parameters:
+
+        * ``gaussian_sigma`` (σ): standard deviation of the Gaussian component,
+          FWHM_G = 2√(2 ln 2)·σ ≈ 2.3548·σ.
+        * ``lorentzian_gamma`` (γ): half-width at half-maximum (HWHM) of the
+          Lorentzian component, FWHM_L = 2γ.
+
+        Because the two components use different parameterizations, σ and γ are
+        *not* directly comparable: for the same FWHM, γ = FWHM / 2 whereas
+        σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
+
+        The Voigt source-size model is described in [1]_.
+
+        References
+        ----------
+        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
+           function in scanning transmission electron microscopy and spectroscopy",
+           *Ultramicroscopy* **146**, 6–16 (2014).
+           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         xp = get_array_module(self.array)
 
@@ -3364,6 +3417,21 @@ class DiffractionPatterns(_BaseMeasurement2D):
         -------
         filtered_diffraction_patterns : DiffractionPatterns
             The filtered diffraction pattern(s).
+
+        Notes
+        -----
+        The Lorentzian kernel is parameterized by its HWHM γ (``half_width``),
+        with FWHM_L = 2γ. This differs from :meth:`gaussian_source_size`,
+        which uses the standard deviation σ (FWHM_G ≈ 2.3548·σ).
+
+        The Lorentzian source-size model is described in [1]_.
+
+        References
+        ----------
+        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
+           function in scanning transmission electron microscopy and spectroscopy",
+           *Ultramicroscopy* **146**, 6–16 (2014).
+           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         return _lorentzian_source_size(self, half_width, truncate)
 
@@ -3397,6 +3465,26 @@ class DiffractionPatterns(_BaseMeasurement2D):
         -------
         filtered_diffraction_patterns : DiffractionPatterns
             The filtered diffraction pattern(s).
+
+        Notes
+        -----
+        The Voigt profile combines two width parameters:
+
+        * ``gaussian_sigma`` (σ): standard deviation of the Gaussian component,
+          FWHM_G = 2√(2 ln 2)·σ ≈ 2.3548·σ.
+        * ``lorentzian_gamma`` (γ): HWHM of the Lorentzian component,
+          FWHM_L = 2γ.
+
+        For the same FWHM, γ = FWHM / 2 but σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
+
+        The Voigt source-size model is described in [1]_.
+
+        References
+        ----------
+        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
+           function in scanning transmission electron microscopy and spectroscopy",
+           *Ultramicroscopy* **146**, 6–16 (2014).
+           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         return _voigtian_source_size(self, gaussian_sigma, lorentzian_gamma, truncate)
 
@@ -4402,6 +4490,21 @@ class PolarMeasurements(BaseMeasurements):
         -------
         filtered_measurements : PolarMeasurements
             The filtered measurement(s).
+
+        Notes
+        -----
+        The Lorentzian kernel is parameterized by its HWHM γ (``half_width``),
+        with FWHM_L = 2γ. This differs from :meth:`gaussian_source_size`,
+        which uses the standard deviation σ (FWHM_G ≈ 2.3548·σ).
+
+        The Lorentzian source-size model is described in [1]_.
+
+        References
+        ----------
+        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
+           function in scanning transmission electron microscopy and spectroscopy",
+           *Ultramicroscopy* **146**, 6–16 (2014).
+           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         return _lorentzian_source_size(self, half_width, truncate)
 
@@ -4433,6 +4536,26 @@ class PolarMeasurements(BaseMeasurements):
         -------
         filtered_measurements : PolarMeasurements
             The filtered measurement(s).
+
+        Notes
+        -----
+        The Voigt profile combines two width parameters:
+
+        * ``gaussian_sigma`` (σ): standard deviation of the Gaussian component,
+          FWHM_G = 2√(2 ln 2)·σ ≈ 2.3548·σ.
+        * ``lorentzian_gamma`` (γ): HWHM of the Lorentzian component,
+          FWHM_L = 2γ.
+
+        For the same FWHM, γ = FWHM / 2 but σ = FWHM / (2√(2 ln 2)) ≈ FWHM / 2.3548.
+
+        The Voigt source-size model is described in [1]_.
+
+        References
+        ----------
+        .. [1] D.T. Nguyen, S.D. Findlay, J. Etheridge, "The spatial coherence
+           function in scanning transmission electron microscopy and spectroscopy",
+           *Ultramicroscopy* **146**, 6–16 (2014).
+           https://doi.org/10.1016/j.ultramic.2014.04.008
         """
         return _voigtian_source_size(self, gaussian_sigma, lorentzian_gamma, truncate)
 

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -2603,7 +2603,20 @@ def _apply_convolve_2d_on_axes(array, kernel_2d, axes, mode, cval=0.0):
     shape[axes[1]] = kw
     kernel_nd = xp.asarray(kernel_2d).reshape(shape)
 
-    result = scipy_signal.fftconvolve(padded, kernel_nd, mode="valid", axes=axes)
+    # cupyx.scipy.signal.fftconvolve internally uses cupyx.jit.rawkernel, which
+    # raises a FutureWarning ("cupyx.jit.rawkernel is experimental ..."). The
+    # warning is purely an upstream API-stability notice we can do nothing
+    # about, but it would fail tests under filterwarnings=error and clutter
+    # library output, so suppress it precisely at the call site.
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"cupyx\.jit\.rawkernel is experimental",
+            category=FutureWarning,
+        )
+        result = scipy_signal.fftconvolve(
+            padded, kernel_nd, mode="valid", axes=axes
+        )
     return result.astype(array.dtype, copy=False)
     return array
 

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -2613,9 +2613,12 @@ def _apply_convolve_2d_on_axes(array, kernel_2d, axes, mode, cval=0.0):
 
     # Convolve over all axes (no ``axes=`` kwarg). The size-1 dims of the
     # kernel make the FFT along non-target axes a length-1 no-op, so the
-    # result is identical to passing ``axes=axes`` — but we stay compatible
-    # with CuPy versions whose cupyx.scipy.signal.fftconvolve predates the
-    # ``axes`` parameter.
+    # result is numerically identical to passing ``axes=axes`` — verified
+    # against scipy.signal.fftconvolve with explicit axes. We do not depend
+    # on the kwarg purely for code simplicity; ``axes=`` has actually been
+    # available in cupyx.scipy.signal.fftconvolve since the first version
+    # that shipped fftconvolve (CuPy 9.0, April 2021), which is also the
+    # effective minimum CuPy version for any GPU code in this module.
     #
     # cupyx.scipy.signal.fftconvolve internally uses cupyx.jit.rawkernel,
     # which raises a FutureWarning ("cupyx.jit.rawkernel is experimental ...").

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,8 @@ filterwarnings = [
     "ignore:FNV hashing is not implemented in Numba:UserWarning",
     "ignore:ensemble_mean=False returns the full frozen-phonon ensemble:UserWarning",
     "ignore:.*Grid size.*will likely result in GPU under-utilization:numba.core.errors.NumbaPerformanceWarning",
-    "ignore:Setting the shape on a NumPy array has been deprecated:DeprecationWarning"
+    "ignore:Setting the shape on a NumPy array has been deprecated:DeprecationWarning",
+    "ignore:cupyx.jit.rawkernel is experimental:FutureWarning"
 ]
 
 [tool.numpydoc_validation]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,8 @@ filterwarnings = [
     "ignore:Passing storage-related arguments:FutureWarning",
     "ignore:FNV hashing is not implemented in Numba:UserWarning",
     "ignore:ensemble_mean=False returns the full frozen-phonon ensemble:UserWarning",
-    "ignore:.*Grid size.*will likely result in GPU under-utilization:numba.core.errors.NumbaPerformanceWarning"
+    "ignore:.*Grid size.*will likely result in GPU under-utilization:numba.core.errors.NumbaPerformanceWarning",
+    "ignore:cupyx.jit.rawkernel is experimental:FutureWarning"
 ]
 
 [tool.numpydoc_validation]

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from abtem import distributions
 from abtem.transfer import CTF
@@ -78,3 +79,74 @@ def test_focal_series_with_incoherent_spread():
 
     assert reduced.shape[0] == 3  # focal series axis survives
     assert np.allclose(reduced, ref, atol=1e-4)
+
+
+def test_lorentzian_distribution_normalized():
+    defocus = distributions.lorentzian(1.0, num_samples=21, center=3)
+    wave = Probe(energy=100e3, semiangle_cutoff=30, defocus=defocus, extent=10, gpts=64)
+    assert np.allclose(
+        wave.build().diffraction_patterns().reduce_ensemble().array.sum().compute(), 1.0
+    )
+
+
+def test_lorentzian_distribution_shape():
+    dist = distributions.lorentzian(2.0, num_samples=15)
+    assert dist.shape == (15,)
+    assert len(dist.values) == 15
+    assert len(dist.weights) == 15
+    # peak at center
+    center_idx = len(dist.values) // 2
+    assert dist.weights[center_idx] == dist.weights.max()
+
+
+def test_lorentzian_distribution_multidimensional():
+    dist = distributions.lorentzian(1.0, num_samples=11, dimension=2)
+    assert dist.dimensions == 2
+    assert dist.shape == (11, 11)
+
+
+def test_voigt_distribution_normalized():
+    defocus = distributions.voigt(1.0, 0.5, num_samples=21, center=3)
+    wave = Probe(energy=100e3, semiangle_cutoff=30, defocus=defocus, extent=10, gpts=64)
+    assert np.allclose(
+        wave.build().diffraction_patterns().reduce_ensemble().array.sum().compute(), 1.0
+    )
+
+
+def test_voigt_distribution_shape():
+    dist = distributions.voigt(1.0, 0.5, num_samples=15)
+    assert dist.shape == (15,)
+    assert len(dist.values) == 15
+    assert len(dist.weights) == 15
+    # peak at center
+    center_idx = len(dist.values) // 2
+    assert dist.weights[center_idx] == dist.weights.max()
+
+
+def test_voigt_distribution_multidimensional():
+    dist = distributions.voigt(1.0, 0.5, num_samples=11, dimension=2)
+    assert dist.dimensions == 2
+    assert dist.shape == (11, 11)
+
+
+def test_voigt_pure_gaussian_limit():
+    # With gamma=0, weights must be proportional to a Gaussian at the sampled points
+    sigma = 1.5
+    v = distributions.voigt(sigma, 0.0, num_samples=31)
+    expected = np.exp(-0.5 * v.values**2 / sigma**2)
+    expected /= np.sqrt((expected**2).sum())
+    assert np.allclose(v.weights, expected, atol=1e-6)
+
+
+def test_voigt_pure_lorentzian_limit():
+    # With sigma=0, weights must be proportional to a Lorentzian at the sampled points
+    gamma = 1.5
+    v = distributions.voigt(0.0, gamma, num_samples=31)
+    expected = 1.0 / (1.0 + (v.values / gamma) ** 2)
+    expected /= np.sqrt((expected**2).sum())
+    assert np.allclose(v.weights, expected, atol=1e-6)
+
+
+def test_voigt_both_zero_raises():
+    with pytest.raises(ValueError, match="non-zero"):
+        distributions.voigt(0.0, 0.0, num_samples=11)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -105,16 +105,16 @@ def test_lorentzian_distribution_multidimensional():
     assert dist.shape == (11, 11)
 
 
-def test_voigt_distribution_normalized():
-    defocus = distributions.voigt(1.0, 0.5, num_samples=21, center=3)
+def test_voigtian_distribution_normalized():
+    defocus = distributions.voigtian(1.0, 0.5, num_samples=21, center=3)
     wave = Probe(energy=100e3, semiangle_cutoff=30, defocus=defocus, extent=10, gpts=64)
     assert np.allclose(
         wave.build().diffraction_patterns().reduce_ensemble().array.sum().compute(), 1.0
     )
 
 
-def test_voigt_distribution_shape():
-    dist = distributions.voigt(1.0, 0.5, num_samples=15)
+def test_voigtian_distribution_shape():
+    dist = distributions.voigtian(1.0, 0.5, num_samples=15)
     assert dist.shape == (15,)
     assert len(dist.values) == 15
     assert len(dist.weights) == 15
@@ -123,30 +123,77 @@ def test_voigt_distribution_shape():
     assert dist.weights[center_idx] == dist.weights.max()
 
 
-def test_voigt_distribution_multidimensional():
-    dist = distributions.voigt(1.0, 0.5, num_samples=11, dimension=2)
+def test_voigtian_distribution_multidimensional():
+    dist = distributions.voigtian(1.0, 0.5, num_samples=11, dimension=2)
     assert dist.dimensions == 2
     assert dist.shape == (11, 11)
 
 
-def test_voigt_pure_gaussian_limit():
+def test_voigtian_pure_gaussian_limit():
     # With gamma=0, weights must be proportional to a Gaussian at the sampled points
     sigma = 1.5
-    v = distributions.voigt(sigma, 0.0, num_samples=31)
+    v = distributions.voigtian(sigma, 0.0, num_samples=31)
     expected = np.exp(-0.5 * v.values**2 / sigma**2)
     expected /= np.sqrt((expected**2).sum())
     assert np.allclose(v.weights, expected, atol=1e-6)
 
 
-def test_voigt_pure_lorentzian_limit():
+def test_voigtian_pure_lorentzian_limit():
     # With sigma=0, weights must be proportional to a Lorentzian at the sampled points
     gamma = 1.5
-    v = distributions.voigt(0.0, gamma, num_samples=31)
+    v = distributions.voigtian(0.0, gamma, num_samples=31)
     expected = 1.0 / (1.0 + (v.values / gamma) ** 2)
     expected /= np.sqrt((expected**2).sum())
     assert np.allclose(v.weights, expected, atol=1e-6)
 
 
-def test_voigt_both_zero_raises():
+def test_voigtian_both_zero_raises():
     with pytest.raises(ValueError, match="non-zero"):
-        distributions.voigt(0.0, 0.0, num_samples=11)
+        distributions.voigtian(0.0, 0.0, num_samples=11)
+
+
+def test_pseudo_voigtian_distribution_normalized():
+    defocus = distributions.pseudo_voigtian(1.0, 0.5, eta=0.4, num_samples=21, center=3)
+    wave = Probe(energy=100e3, semiangle_cutoff=30, defocus=defocus, extent=10, gpts=64)
+    assert np.allclose(
+        wave.build().diffraction_patterns().reduce_ensemble().array.sum().compute(), 1.0
+    )
+
+
+def test_pseudo_voigtian_distribution_shape():
+    dist = distributions.pseudo_voigtian(1.0, 0.5, eta=0.4, num_samples=15)
+    assert dist.shape == (15,)
+    assert len(dist.values) == 15
+    assert len(dist.weights) == 15
+    # peak at center (symmetric profile)
+    center_idx = len(dist.values) // 2
+    assert dist.weights[center_idx] == dist.weights.max()
+
+
+def test_pseudo_voigtian_distribution_multidimensional():
+    dist = distributions.pseudo_voigtian(1.0, 0.5, eta=0.4, num_samples=11, dimension=2)
+    assert dist.dimensions == 2
+    assert dist.shape == (11, 11)
+
+
+def test_pseudo_voigtian_pure_gaussian_limit():
+    # eta=0 must give a pure Gaussian
+    sigma = 1.5
+    pv = distributions.pseudo_voigtian(sigma, 1.0, eta=0.0, num_samples=31)
+    expected = np.exp(-0.5 * pv.values**2 / sigma**2)
+    expected /= np.sqrt((expected**2).sum())
+    assert np.allclose(pv.weights, expected, atol=1e-6)
+
+
+def test_pseudo_voigtian_pure_lorentzian_limit():
+    # eta=1 must give a pure Lorentzian
+    gamma = 1.5
+    pv = distributions.pseudo_voigtian(1.0, gamma, eta=1.0, num_samples=31)
+    expected = 1.0 / (1.0 + (pv.values / gamma) ** 2)
+    expected /= np.sqrt((expected**2).sum())
+    assert np.allclose(pv.weights, expected, atol=1e-6)
+
+
+def test_pseudo_voigtian_both_zero_raises():
+    with pytest.raises(ValueError, match="non-zero"):
+        distributions.pseudo_voigtian(0.0, 0.0, eta=0.5, num_samples=11)

--- a/test/test_measure.py
+++ b/test/test_measure.py
@@ -284,14 +284,43 @@ def test_voigtian_filter_pure_lorentzian_limit():
     assert np.allclose(lor.array, voigt.array, atol=1e-5)
 
 
+def test_pseudo_voigtian_filter_changes_image():
+    """Pseudo-Voigtian filter with non-trivial parameters should change the image."""
+    wave = Probe(energy=100e3, semiangle_cutoff=30, extent=10, gpts=64)
+    images = wave.build((0, 0), lazy=False).intensity()
+    filtered = images.pseudo_voigtian_filter(0.3, 0.3, eta=0.5)
+    assert not np.allclose(filtered.array, images.array)
+
+
+def test_pseudo_voigtian_filter_pure_gaussian_limit():
+    """pseudo_voigtian_filter with eta=0 must equal gaussian_filter."""
+    wave = Probe(energy=100e3, semiangle_cutoff=30, extent=10, gpts=64)
+    images = wave.build((0, 0), lazy=False).intensity()
+    sigma = 0.4
+    gauss = images.gaussian_filter(sigma)
+    pv = images.pseudo_voigtian_filter(sigma, 1.0, eta=0.0)
+    assert np.allclose(gauss.array, pv.array, atol=1e-5)
+
+
+def test_pseudo_voigtian_filter_pure_lorentzian_limit():
+    """pseudo_voigtian_filter with eta=1 must equal lorentzian_filter."""
+    wave = Probe(energy=100e3, semiangle_cutoff=30, extent=10, gpts=64)
+    images = wave.build((0, 0), lazy=False).intensity()
+    hw = 0.4
+    lor = images.lorentzian_filter(hw)
+    pv = images.pseudo_voigtian_filter(1.0, hw, eta=1.0)
+    assert np.allclose(lor.array, pv.array, atol=1e-5)
+
+
 def test_filter_boundary_modes():
-    """All three filter methods accept all three boundary modes without error."""
+    """All four filter methods accept all three boundary modes without error."""
     wave = Probe(energy=100e3, semiangle_cutoff=30, extent=10, gpts=32)
     images = wave.build((0, 0), lazy=False).intensity()
     for boundary in ("periodic", "reflect", "constant"):
         images.gaussian_filter(0.3, boundary=boundary).array
         images.lorentzian_filter(0.3, boundary=boundary).array
         images.voigtian_filter(0.3, 0.3, boundary=boundary).array
+        images.pseudo_voigtian_filter(0.3, 0.3, eta=0.5, boundary=boundary).array
 
 
 def test_lorentzian_filter_lazy():
@@ -307,6 +336,14 @@ def test_voigtian_filter_lazy():
     wave = Probe(energy=100e3, semiangle_cutoff=30, extent=10, gpts=32)
     images = wave.build((0, 0), lazy=True).intensity()
     filtered = images.voigtian_filter(0.3, 0.3)
+    assert np.isfinite(filtered.array.compute()).all()
+
+
+def test_pseudo_voigtian_filter_lazy():
+    """Pseudo-Voigtian filter works on a lazy (dask-backed) image."""
+    wave = Probe(energy=100e3, semiangle_cutoff=30, extent=10, gpts=32)
+    images = wave.build((0, 0), lazy=True).intensity()
+    filtered = images.pseudo_voigtian_filter(0.3, 0.3, eta=0.5)
     assert np.isfinite(filtered.array.compute()).all()
 
 

--- a/test/test_measure.py
+++ b/test/test_measure.py
@@ -203,6 +203,113 @@ def test_gaussian_filter_images(data, sigma, lazy, device):
         assert not np.allclose(filtered.array, measurement.array)
 
 
+@given(data=st.data(), sigma=sigma())
+@pytest.mark.parametrize("lazy", [True, False])
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_lorentzian_filter_images(data, sigma, lazy, device):
+    if lazy is True and device == gpu.values[0]:
+        return
+
+    measurement = data.draw(abtem_st.images(lazy=lazy, device=device))
+    assume(all(n > 1 for n in measurement.base_shape))
+    try:
+        filtered = measurement.lorentzian_filter(sigma)
+        filtered.compute()
+        measurement.compute()
+    except OSError:
+        pytest.skip(
+            "Known CuPy error, but only reproducible in pytest https://github.com/cupy/cupy/issues/8218"
+        )
+
+    if np.any(np.array(sigma)) > 1:
+        assert not np.allclose(filtered.array, measurement.array)
+
+
+@given(data=st.data(), sigma=sigma())
+@pytest.mark.parametrize("lazy", [True, False])
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_voigtian_filter_images(data, sigma, lazy, device):
+    if lazy is True and device == gpu.values[0]:
+        return
+
+    measurement = data.draw(abtem_st.images(lazy=lazy, device=device))
+    assume(all(n > 1 for n in measurement.base_shape))
+    try:
+        # Use sigma as both gaussian_sigma and lorentzian_gamma
+        filtered = measurement.voigtian_filter(sigma, sigma)
+        filtered.compute()
+        measurement.compute()
+    except OSError:
+        pytest.skip(
+            "Known CuPy error, but only reproducible in pytest https://github.com/cupy/cupy/issues/8218"
+        )
+
+    if np.any(np.array(sigma)) > 1:
+        assert not np.allclose(filtered.array, measurement.array)
+
+
+def test_lorentzian_filter_changes_image():
+    """Lorentzian filter with a non-trivial HWHM should change the image."""
+    wave = Probe(energy=100e3, semiangle_cutoff=30, extent=10, gpts=64)
+    images = wave.build((0, 0), lazy=False).intensity()
+    filtered = images.lorentzian_filter(0.5)
+    assert not np.allclose(filtered.array, images.array)
+
+
+def test_voigtian_filter_changes_image():
+    """Voigtian filter with non-trivial parameters should change the image."""
+    wave = Probe(energy=100e3, semiangle_cutoff=30, extent=10, gpts=64)
+    images = wave.build((0, 0), lazy=False).intensity()
+    filtered = images.voigtian_filter(0.3, 0.3)
+    assert not np.allclose(filtered.array, images.array)
+
+
+def test_voigtian_filter_pure_gaussian_limit():
+    """voigtian_filter with lorentzian_gamma=0 must equal gaussian_filter."""
+    wave = Probe(energy=100e3, semiangle_cutoff=30, extent=10, gpts=64)
+    images = wave.build((0, 0), lazy=False).intensity()
+    sigma = 0.4
+    gauss = images.gaussian_filter(sigma)
+    voigt = images.voigtian_filter(sigma, 0.0)
+    assert np.allclose(gauss.array, voigt.array, atol=1e-5)
+
+
+def test_voigtian_filter_pure_lorentzian_limit():
+    """voigtian_filter with gaussian_sigma=0 must equal lorentzian_filter."""
+    wave = Probe(energy=100e3, semiangle_cutoff=30, extent=10, gpts=64)
+    images = wave.build((0, 0), lazy=False).intensity()
+    hw = 0.4
+    lor = images.lorentzian_filter(hw)
+    voigt = images.voigtian_filter(0.0, hw)
+    assert np.allclose(lor.array, voigt.array, atol=1e-5)
+
+
+def test_filter_boundary_modes():
+    """All three filter methods accept all three boundary modes without error."""
+    wave = Probe(energy=100e3, semiangle_cutoff=30, extent=10, gpts=32)
+    images = wave.build((0, 0), lazy=False).intensity()
+    for boundary in ("periodic", "reflect", "constant"):
+        images.gaussian_filter(0.3, boundary=boundary).array
+        images.lorentzian_filter(0.3, boundary=boundary).array
+        images.voigtian_filter(0.3, 0.3, boundary=boundary).array
+
+
+def test_lorentzian_filter_lazy():
+    """Lorentzian filter works on a lazy (dask-backed) image."""
+    wave = Probe(energy=100e3, semiangle_cutoff=30, extent=10, gpts=32)
+    images = wave.build((0, 0), lazy=True).intensity()
+    filtered = images.lorentzian_filter(0.5)
+    assert np.isfinite(filtered.array.compute()).all()
+
+
+def test_voigtian_filter_lazy():
+    """Voigtian filter works on a lazy (dask-backed) image."""
+    wave = Probe(energy=100e3, semiangle_cutoff=30, extent=10, gpts=32)
+    images = wave.build((0, 0), lazy=True).intensity()
+    filtered = images.voigtian_filter(0.3, 0.3)
+    assert np.isfinite(filtered.array.compute()).all()
+
+
 # @given(data=st.data())
 # @pytest.mark.parametrize('lazy', [True, False])
 # @pytest.mark.parametrize('device', ['cpu', gpu])

--- a/test/test_measure.py
+++ b/test/test_measure.py
@@ -256,6 +256,37 @@ def test_lorentzian_filter_changes_image():
     assert not np.allclose(filtered.array, images.array)
 
 
+@pytest.mark.parametrize("precision", ["float32", "float64"])
+def test_lorentzian_filter_respects_precision_config(precision):
+    """The Lorentzian family of filters must honour ``abtem.config['precision']``.
+
+    The kernel is built via :func:`_lorentzian_kernel_2d`, which queries the
+    config — and the output dtype must match the configured precision rather
+    than being silently downcast to float32. Regression for a bug where the
+    kernel was hardcoded to ``np.float32``.
+    """
+    expected_dtype = np.dtype(precision)
+    n = 21
+    with abtem.config.set({"precision": precision}):
+        arr = np.zeros((n, n), dtype=expected_dtype)
+        arr[n // 2, n // 2] = 1.0
+        images = Images(arr, sampling=(0.1, 0.1))
+
+        out_l = images.lorentzian_filter(0.3).array
+        out_v = images.voigtian_filter(0.2, 0.3).array
+        out_pv = images.pseudo_voigtian_filter(0.2, 0.3, eta=0.5).array
+
+    assert out_l.dtype == expected_dtype, (
+        f"lorentzian_filter: got {out_l.dtype}, expected {expected_dtype}"
+    )
+    assert out_v.dtype == expected_dtype, (
+        f"voigtian_filter: got {out_v.dtype}, expected {expected_dtype}"
+    )
+    assert out_pv.dtype == expected_dtype, (
+        f"pseudo_voigtian_filter: got {out_pv.dtype}, expected {expected_dtype}"
+    )
+
+
 @pytest.mark.parametrize(
     "filter_name,kwargs",
     [

--- a/test/test_measure.py
+++ b/test/test_measure.py
@@ -256,6 +256,49 @@ def test_lorentzian_filter_changes_image():
     assert not np.allclose(filtered.array, images.array)
 
 
+@pytest.mark.parametrize(
+    "filter_name,kwargs",
+    [
+        ("lorentzian_filter", dict(half_width=0.5, truncate=10.0)),
+        ("voigtian_filter", dict(gaussian_sigma=0.1, lorentzian_gamma=0.5)),
+        (
+            "pseudo_voigtian_filter",
+            dict(gaussian_sigma=0.1, lorentzian_gamma=0.5, eta=0.5),
+        ),
+    ],
+)
+def test_lorentzian_family_filters_are_rotationally_symmetric(filter_name, kwargs):
+    """
+    Filtering a delta image with the Lorentzian family of filters must produce
+    a rotationally-symmetric impulse response. A naively separable 1-D × 1-D
+    Lorentzian would be several times brighter along the x and y axes than
+    along the diagonal at the same radius, producing visible cross-shaped halos
+    around sharp features. Regression for that bug.
+    """
+    # Square delta image with isotropic sampling
+    n = 81
+    arr = np.zeros((n, n), dtype=np.float32)
+    arr[n // 2, n // 2] = 1.0
+    images = Images(arr, sampling=(0.1, 0.1))
+
+    out = getattr(images, filter_name)(**kwargs).array
+    c = n // 2
+
+    # Sample at several radii; compare on-axis vs along-diagonal at the same r.
+    for r in (4, 8, 12, 20):
+        d = int(round(r / np.sqrt(2)))  # so √2·d ≈ r
+        ax_val = float(out[c, c + r])
+        diag_val = float(out[c + d, c + d])
+        ratio = ax_val / diag_val
+        # True 2-D Lorentzian / Voigt is rotationally symmetric → ratio ≈ 1.
+        # The old separable implementation gave ratio ≳ 3 at large r.
+        assert 0.85 < ratio < 1.15, (
+            f"{filter_name}: axis/diag ratio = {ratio:.3g} at r={r} "
+            f"(ax={ax_val:.4g}, diag={diag_val:.4g}); kernel is not "
+            "rotationally symmetric"
+        )
+
+
 def test_voigtian_filter_changes_image():
     """Voigtian filter with non-trivial parameters should change the image."""
     wave = Probe(energy=100e3, semiangle_cutoff=30, extent=10, gpts=64)


### PR DESCRIPTION
## Summary

### Distributions

Adds three new distribution functions alongside the existing `gaussian()`, usable as ensemble parameters for `PlaneWave`, `DiffractionPatterns`, and the `defocus` parameter of `Probe`:

- `lorentzian(half_width, num_samples, ...)` — Cauchy/Lorentzian profile parameterised by HWHM γ (FWHM_L = 2γ). A larger default `sampling_limit=10` accommodates the heavier tails.
- `voigtian(gaussian_sigma, lorentzian_gamma, num_samples, ...)` — exact Voigt profile (convolution of Gaussian and Lorentzian) computed via `scipy.special.wofz` (Faddeeva function). The sampling range uses the Thompson et al. (1987) HWHM approximation. Degenerate limits are handled analytically.
- `pseudo_voigtian(gaussian_sigma, lorentzian_gamma, eta, num_samples, ...)` — weighted linear sum PV = (1−η)·G + η·L, as proposed by Nguyen et al. (2014). η = 0 recovers a pure Gaussian; η = 1 recovers a pure Lorentzian.

### Filters

Adds `lorentzian_filter`, `voigtian_filter`, and `pseudo_voigtian_filter` to `_BaseMeasurement2D`, alongside the existing `gaussian_filter`. All support the same `boundary` modes (`'periodic'`, `'reflect'`, `'constant'`) and lazy (dask) evaluation.

Adds `lorentzian_source_size`, `voigtian_source_size`, and `pseudo_voigtian_source_size` to `DiffractionPatterns` and `PolarMeasurements`.

#### Implementation note — true 2-D Lorentzian, FFT-based

The Lorentzian profile is **not** separable: `1/(1+x²)·1/(1+y²) ≠ 1/(1+x²+y²)`. A naive separable implementation produces a cross-shaped impulse response — several times brighter along the x and y axes than along the diagonal at the same radius — which manifests as visible halos/lines around sharp features (reported in [#268](https://github.com/abTEM/abTEM/discussions/268#discussioncomment-17177109); quantified: axis/diagonal ratio at r = 10 px was 3.4× before the fix, 1.0× after).

The implementation therefore:
- Builds a **true 2-D** Lorentzian kernel `L(x, y) = 1 / (1 + (x/γ_x)² + (y/γ_y)² )` — elliptical when γ_x ≠ γ_y, isotropic when equal.
- Uses **FFT-based convolution** (`scipy.signal.fftconvolve`) so cost is O(N log N), independent of kernel size. This matters because the heavy-tailed Lorentzian kernel can easily be comparable in size to the image itself.
- `voigtian_filter` exploits convolution associativity: `gaussian_filter` then `lorentzian_filter` — each with its proper (separable Gaussian / true 2-D Lorentzian) kernel.
- `pseudo_voigtian_filter` exploits linearity: `(1−η)·G_filtered + η·L_filtered`.
- Same scheme applied to the `_source_size` variants.

A regression test (`test_lorentzian_family_filters_are_rotationally_symmetric`) asserts the axis/diagonal ratio is within ±15 % at multiple radii for all three filter families.

### Parameterisation note

The Gaussian filter/distribution uses the standard deviation σ (FWHM_G ≈ 2.3548·σ), while the Lorentzian and Voigtian use the half-width at half-maximum γ (FWHM_L = 2γ). For the same FWHM, γ = FWHM/2 but σ = FWHM/(2√(2 ln 2)) ≈ FWHM/2.3548. This difference is documented in the docstrings.

The `lorentzian` and `pseudo_voigtian` distributions are based on [Nguyen, Findlay & Etheridge, *Ultramicroscopy* **146**, 6–16 (2014)](https://doi.org/10.1016/j.ultramic.2014.04.008).

## Usage

```python
import abtem
from abtem import distributions

# Lorentzian focal spread (HWHM = 5 Å)
defocus = distributions.lorentzian(5.0, num_samples=21)
probe = abtem.Probe(energy=100e3, semiangle_cutoff=30, defocus=defocus, ...)

# Pseudo-Voigtian focal spread (Gaussian σ=3 Å, Lorentzian γ=2 Å, η=0.4)
defocus = distributions.pseudo_voigtian(3.0, 2.0, eta=0.4, num_samples=21)
probe = abtem.Probe(energy=100e3, semiangle_cutoff=30, defocus=defocus, ...)

# Apply a Lorentzian source-size filter to images (HWHM = 0.5 Å)
images.lorentzian_filter(0.5)

# Apply a pseudo-Voigtian source-size filter to diffraction patterns
dp.pseudo_voigtian_source_size(gaussian_sigma=0.3, lorentzian_gamma=0.2, eta=0.4)
```

## Test plan

**Distributions**
- [x] `test_lorentzian_distribution_normalized` — ensemble-reduced diffraction pattern sums to 1.0 via `Probe`
- [x] `test_lorentzian_distribution_shape` — correct shape, length, and peak position
- [x] `test_lorentzian_distribution_multidimensional` — 2D construction
- [x] `test_voigtian_distribution_normalized` — normalization round-trip via `Probe`
- [x] `test_voigtian_distribution_shape` — correct shape and peak
- [x] `test_voigtian_distribution_multidimensional` — 2D construction
- [x] `test_voigtian_pure_gaussian_limit` — weights proportional to Gaussian when `lorentzian_gamma=0`
- [x] `test_voigtian_pure_lorentzian_limit` — weights proportional to Lorentzian when `gaussian_sigma=0`
- [x] `test_voigtian_both_zero_raises` — `ValueError` when both components are zero
- [x] `test_pseudo_voigtian_distribution_normalized` — normalization round-trip via `Probe`
- [x] `test_pseudo_voigtian_distribution_shape` — correct shape and peak
- [x] `test_pseudo_voigtian_distribution_multidimensional` — 2D construction
- [x] `test_pseudo_voigtian_pure_gaussian_limit` — weights match Gaussian when `eta=0`
- [x] `test_pseudo_voigtian_pure_lorentzian_limit` — weights match Lorentzian when `eta=1`
- [x] `test_pseudo_voigtian_both_zero_raises` — `ValueError` when both widths are zero

**Filters**
- [x] `test_lorentzian_filter_images` / `test_voigtian_filter_images` — hypothesis-based round-trip for Images
- [x] `test_lorentzian_filter_changes_image` / `test_voigtian_filter_changes_image` / `test_pseudo_voigtian_filter_changes_image`
- [x] `test_voigtian_filter_pure_gaussian_limit` — `voigtian_filter(sigma, 0)` equals `gaussian_filter(sigma)`
- [x] `test_voigtian_filter_pure_lorentzian_limit` — `voigtian_filter(0, gamma)` equals `lorentzian_filter(gamma)`
- [x] `test_pseudo_voigtian_filter_pure_gaussian_limit` — `pseudo_voigtian_filter(sigma, *, eta=0)` equals `gaussian_filter(sigma)`
- [x] `test_pseudo_voigtian_filter_pure_lorentzian_limit` — `pseudo_voigtian_filter(*, gamma, eta=1)` equals `lorentzian_filter(gamma)`
- [x] `test_lorentzian_family_filters_are_rotationally_symmetric` — **regression test for the cross-shape artefact**: axis/diagonal ratio of the impulse response within ±15 % at r ∈ {4, 8, 12, 20}, for all three filters
- [x] `test_filter_boundary_modes` — all four filters × all three boundary modes
- [x] `test_lorentzian_filter_lazy` / `test_voigtian_filter_lazy` / `test_pseudo_voigtian_filter_lazy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)