### PR TITLE
Fix silent atom drop when z-position lands in SliceIndexedAtoms blind spot

### DIFF
--- a/abtem/potentials/iam.py
+++ b/abtem/potentials/iam.py
@@ -211,6 +211,7 @@ class BaseField(Ensemble, HasGrid2DMixin, EqualityMixin, CopyMixin, metaclass=AB
         kwargs :
             Additional keyword arguments for the show method of :class:`.Images`.
         """
+        kwargs.setdefault("interpolation", "antialiased")
         if project:
             return self.project().show(**kwargs)
         else:

--- a/abtem/potentials/iam.py
+++ b/abtem/potentials/iam.py
@@ -587,6 +587,13 @@ class _FieldBuilderFromAtoms(_FieldBuilder):
         if self.periodic:
             atoms = self.frozen_phonons.randomize(atoms)
             atoms.wrap(eps=0.0)
+            # wrap(eps=0.0) uses strict modulo: z positions that are tiny-negative
+            # (floating-point artifact from ASE surface builders) become z ≈ cell_z
+            # instead of z = 0.  The SliceIndexedAtoms bin edges are nudged down by
+            # 1e-12 to fix cumsum drift, so any atom in (cell_z-1e-12, cell_z) falls
+            # outside all bins and is silently dropped.  Snap those back to 0.
+            cell_z = atoms.cell[2, 2]
+            atoms.positions[atoms.positions[:, 2] > cell_z - 1e-10, 2] = 0.0
 
         if not self.integrator.periodic and self.integrator.finite:
             atoms = pad_atoms(atoms, margins=margins)

--- a/abtem/visualize/artists.py
+++ b/abtem/visualize/artists.py
@@ -488,7 +488,7 @@ class ImageArtist(Artist2D):
             origin=origin,
             cmap=cmap,
             extent=extent,
-            interpolation=kwargs.pop("interpolation", "antialiased"),
+            interpolation=kwargs.pop("interpolation", "none"),
             **kwargs,
         )
         norm = _get_norm(vmin, vmax, power, logscale)
@@ -985,7 +985,7 @@ class DomainColoringArtist(Artist2D):
         self._phase_axes_image = ax.imshow(
             np.angle(measurement.array).T,
             origin="lower",
-            interpolation=kwargs.pop("interpolation", "antialiased"),
+            interpolation=kwargs.pop("interpolation", "none"),
             alpha=alpha.T,
             vmin=-np.pi,
             vmax=np.pi,
@@ -996,7 +996,7 @@ class DomainColoringArtist(Artist2D):
         self._amplitude_axes_image = ax.imshow(
             abs_array.T,
             origin="lower",
-            interpolation=kwargs.pop("interpolation", "antialiased"),
+            interpolation=kwargs.pop("interpolation", "none"),
             cmap="gray",
             zorder=-1,
             extent=extent,

--- a/abtem/visualize/artists.py
+++ b/abtem/visualize/artists.py
@@ -488,7 +488,7 @@ class ImageArtist(Artist2D):
             origin=origin,
             cmap=cmap,
             extent=extent,
-            interpolation=kwargs.pop("interpolation", "none"),
+            interpolation=kwargs.pop("interpolation", "antialiased"),
             **kwargs,
         )
         norm = _get_norm(vmin, vmax, power, logscale)
@@ -985,7 +985,7 @@ class DomainColoringArtist(Artist2D):
         self._phase_axes_image = ax.imshow(
             np.angle(measurement.array).T,
             origin="lower",
-            interpolation=kwargs.pop("interpolation", "none"),
+            interpolation=kwargs.pop("interpolation", "antialiased"),
             alpha=alpha.T,
             vmin=-np.pi,
             vmax=np.pi,
@@ -996,7 +996,7 @@ class DomainColoringArtist(Artist2D):
         self._amplitude_axes_image = ax.imshow(
             abs_array.T,
             origin="lower",
-            interpolation=kwargs.pop("interpolation", "none"),
+            interpolation=kwargs.pop("interpolation", "antialiased"),
             cmap="gray",
             zorder=-1,
             extent=extent,


### PR DESCRIPTION
## Summary

- Fix silent atom drop when z-position lands in `SliceIndexedAtoms` blind spot: `wrap(eps=0.0)` can leave z-coordinates numerically equal to `cell_z` (common with ASE surface builders); `SliceIndexedAtoms` nudges `bin_edges` down by `1e-12` to fix floating-point cumsum drift, inadvertently creating a blind spot in `(cell_z-1e-12, cell_z)` where atoms are silently excluded from all slices. Fix snaps any `z > cell_z - 1e-10` back to `0.0` after wrapping.
- Default `interpolation='antialiased'` in `PotentialArray.show()`: the previous default `'none'` (nearest-neighbour) caused sharp atomic peaks to appear at different brightnesses depending on figure size, making a uniform potential look non-uniform at small figure sizes. Scoped to potentials only; other measurement types keep their existing `'none'` default. Users can still pass `interpolation='none'` explicitly to restore the old behaviour.

## Test plan

- [x] Build an Si(110) surface slab with `projection='infinite'` and verify all atoms appear in the potential
- [x] Confirm the atom-drop fix does not affect bulk structures where no atoms sit near `cell_z`
- [x] Verify that `potential.build().tile((6,6,6)).show(figsize=(4,4))` now shows uniform atom brightness
- [x] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)