### PR TITLE
Fix "model not found" widget errors in JupyterLab

### DIFF
--- a/abtem/array.py
+++ b/abtem/array.py
@@ -454,7 +454,7 @@ def _get_progress_bar(
 
     if progress_bar:
         if progress_bar == "tqdm":
-            progress_bar_obj = TqdmCallback(desc="tasks")
+            progress_bar_obj = TqdmCallback(desc="tasks", delay=0.5)
         else:
             progress_bar_obj = ProgressBar()
     else:

--- a/abtem/core/diagnostics.py
+++ b/abtem/core/diagnostics.py
@@ -39,6 +39,7 @@ class TqdmWrapper:
         self._pbar: Optional[tqdm_asyncio] = None
 
         if tqdm is not None and enabled:
+            kwargs.setdefault("delay", 0.5)
             self._pbar = tqdm(*args, **kwargs)
 
     @property

--- a/abtem/inelastic/core_loss.py
+++ b/abtem/inelastic/core_loss.py
@@ -1065,7 +1065,7 @@ def linear_scaling_transition_multislice(
         S2_multislice = S2
 
     images = np.zeros(len(positions), dtype=np.float32)
-    for i in tqdm(range(len(potential))):
+    for i in tqdm(range(len(potential)), delay=0.5):
         if stream:
             S1 = S1.streaming_multislice(
                 potential, chunks=chunks, start=max(i - 1, 0), stop=i

--- a/abtem/reconstruct.py
+++ b/abtem/reconstruct.py
@@ -53,6 +53,7 @@ class ProgressBar:
     def __init__(self, **kwargs):
         from tqdm.auto import tqdm
 
+        kwargs.setdefault("delay", 0.5)
         self._tqdm = tqdm(**kwargs)
 
     @property


### PR DESCRIPTION
## Summary
- Adds `delay=0.5` to all tqdm progress bars across the codebase (multislice, PRISM, Bloch wave, ptychography, core loss, dask callbacks)
- When a progress bar completes in under 0.5s, the widget is never shown to the JupyterLab frontend, eliminating the race condition where the widget model gets destroyed before the frontend finishes rendering it
- Longer computations display progress bars normally after the 0.5s delay

## Test plan
- [x] Run a notebook with fast multislice calculations that previously produced "Error displaying widget: model not found" — verify the errors are gone
- [x] Run a longer calculation (>0.5s) and verify the progress bar still appears and works correctly
- [x] Verify `delay` can still be overridden by callers (e.g. `TqdmWrapper(delay=0, ...)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)