### PR TITLE
Fix scan visualization bugs and unify add_to_plot API

### DIFF
--- a/abtem/inelastic/core_loss.py
+++ b/abtem/inelastic/core_loss.py
@@ -1023,7 +1023,7 @@ class TransitionPotentialArray(ArrayObject, BaseTransitionPotential):
         )
 
     def show(self, **kwargs):
-        self.to_images().show(**kwargs)
+        return self.to_images().show(**kwargs)
 
 
 def linear_scaling_transition_multislice(

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -1836,7 +1836,7 @@ class _BaseMeasurement1D(BaseMeasurements):
 
         return LineScan(start=start, end=end, sampling=sampling)
 
-    def _add_to_visualization(self, *args, **kwargs):
+    def _add_to_plot(self, *args, **kwargs):
         if not all(key in self.metadata for key in ("start", "end")):
             raise RuntimeError(
                 "The metadata does not contain the keys 'start' and 'end'"
@@ -1845,7 +1845,7 @@ class _BaseMeasurement1D(BaseMeasurements):
         if "width" in self.metadata:
             kwargs["width"] = self.metadata["width"]
 
-        self._line_scan().add_to_axes(*args, **kwargs)
+        self._line_scan().add_to_plot(*args, **kwargs)
 
     @staticmethod
     def _calculate_widths(array, sampling, height):

--- a/abtem/scan.py
+++ b/abtem/scan.py
@@ -364,6 +364,26 @@ class CustomScan(BaseScan):
     def get_positions(self) -> np.ndarray:
         return self._positions
 
+    def add_to_plot(self, ax, **kwargs):
+        """
+        Add a visualization of the scan positions to a matplotlib plot.
+
+        Parameters
+        ----------
+        ax : matplotlib Axes or Visualization
+            The axes of the matplotlib plot the visualization should be added to.
+        kwargs :
+            Additional options for matplotlib.pyplot.scatter as keyword arguments.
+        """
+        if isinstance(ax, Visualization):
+            for ax in np.array(ax.axes).ravel():
+                self.add_to_plot(ax, **kwargs)
+            return
+
+        kwargs.setdefault("color", "r")
+        kwargs.setdefault("s", 10)
+        return ax.scatter(self.positions[:, 0], self.positions[:, 1], **kwargs)
+
 
 def validate_coordinate(
     coordinate: float | tuple[float, float] | Atom | None,
@@ -766,30 +786,42 @@ class LineScan(BaseScan):
         )
         return np.stack((np.reshape(x, (-1,)), np.reshape(y, (-1,))), axis=1)
 
-    def add_to_axes(self, ax: Axes, width: float = 0.0, **kwargs):
+    def add_to_plot(self, ax, width: float = 0.0, **kwargs):
         """
         Add a visualization of a scan line to a matplotlib plot.
 
         Parameters
         ----------
-        ax : matplotlib Axes
+        ax : matplotlib Axes or Visualization
             The axes of the matplotlib plot the visualization should be added to.
         width : float, optional
             Width of line [Å].
         kwargs :
             Additional options for matplotlib.pyplot.plot as keyword arguments.
         """
-        assert isinstance(self.start, tuple)
-        assert isinstance(self.end, tuple)
-        assert isinstance(self.extent, float)
+        if isinstance(ax, Visualization):
+            for ax in np.array(ax.axes).ravel():
+                self.add_to_plot(ax, width=width, **kwargs)
+            return
+
+        if self.start is None or self.end is None:
+            raise RuntimeError(
+                "start or end is not defined, pass explicit 'start' and 'end' "
+                "when creating the LineScan"
+            )
 
         if width:
             rect = Rectangle(self.start, self.extent, width, angle=self.angle, **kwargs)
             ax.add_patch(rect)
+            return rect
         else:
-            ax.plot(
+            return ax.plot(
                 [self.start[0], self.end[0]], [self.start[1], self.end[1]], **kwargs
             )
+
+    def add_to_axes(self, *args, **kwargs):
+        """Deprecated: use :meth:`add_to_plot` instead."""
+        return self.add_to_plot(*args, **kwargs)
 
 
 class GridScan(HasGrid2DMixin, BaseScan):
@@ -842,6 +874,10 @@ class GridScan(HasGrid2DMixin, BaseScan):
         self._end = validate_coordinate(
             coordinate=end, potential=potential, fractional=fractional
         )
+
+        if self._end is None and potential is not None:
+            validated = validate_potential(potential)
+            self._end = validated._valid_extent
 
         if self._start is not None and self._end is not None:
             extent = (self._end[0] - self._start[0], self._end[1] - self._start[1])
@@ -1093,9 +1129,13 @@ class GridScan(HasGrid2DMixin, BaseScan):
                 self.add_to_plot(
                     ax, alpha=alpha, facecolor=facecolor, edgecolor=edgecolor, **kwargs
                 )
+            return
 
         if self.start is None or self.extent is None:
-            raise RuntimeError("start or extent is not defined")
+            raise RuntimeError(
+                "start or extent is not defined, pass 'potential' or explicit "
+                "'start'/'end' when creating the GridScan"
+            )
 
         rect = Rectangle(
             xy=self.start,
@@ -1107,3 +1147,4 @@ class GridScan(HasGrid2DMixin, BaseScan):
             **kwargs,
         )
         ax.add_patch(rect)
+        return rect

--- a/abtem/visualize/artists.py
+++ b/abtem/visualize/artists.py
@@ -397,9 +397,9 @@ class Artist2D(Artist):
         raise NotImplementedError
         # for i, ax in enumerate(np.array(self.axes).ravel()):
         #     if panel == "first" and i == 0:
-        #         area_indicator._add_to_visualization(ax, **kwargs)
+        #         area_indicator._add_to_plot(ax, **kwargs)
         #     elif panel == "all":
-        #         area_indicator._add_to_visualization(ax, **kwargs)
+        #         area_indicator._add_to_plot(ax, **kwargs)
 
 
 def default_cbar_scalar_formatter():


### PR DESCRIPTION
## Summary
- **Fix GridScan.add_to_plot crash** when start/end are implicitly defined via the `potential` parameter. The extent is now eagerly resolved in `__init__` instead of waiting for `match_probe`, so `add_to_plot` (and `get_positions`) work immediately.
- **Unify `add_to_plot` across all scan types**: `CustomScan` gets a new scatter-based `add_to_plot`; `LineScan.add_to_axes` is renamed to `add_to_plot` (old name kept as deprecated alias). All three methods now handle `Visualization` objects and return matplotlib artists.
- **Fix silent bugs**: missing `return` in `GridScan.add_to_plot` Visualization branch (caused duplicate patches), missing `return` in `IsotropicCoreExcitation.show()` (returned `None` instead of `Visualization`), bare `assert` statements in `LineScan` replaced with descriptive `RuntimeError`.
- **Rename `_add_to_visualization` to `_add_to_plot`** in measurements for consistency.

## Test plan
- [x] `GridScan(potential=potential).add_to_plot(ax)` works without explicit start/end
- [x] `GridScan(potential=atoms).add_to_plot(ax)` works with Atoms directly
- [x] Explicit `start`/`end` still respected, not overridden by potential
- [x] `LineScan.add_to_plot` and `add_to_axes` (alias) both work
- [x] `CustomScan.add_to_plot` scatter-plots positions
- [x] All `add_to_plot` methods return matplotlib artists
- [x] 189 scan tests pass, 46 visualization/measurement tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)