### PR TITLE
Speed up transition_potential_multislice double-channel: precompute transmissions + tunable site batching

### DIFF
--- a/abtem/inelastic/core_loss.py
+++ b/abtem/inelastic/core_loss.py
@@ -687,35 +687,49 @@ class TransitionPotential(BaseTransitionPotential):
         return self.build().to_images().show(**kwargs)
 
 
-# @njit(fastmath=True)
 def fast_roll(array, shifts):
-    xp = get_array_module(array)
-    output = xp.empty((len(shifts),) + array.shape, dtype=array.dtype)
+    """Batched 2D circular roll: ``out[i] == xp.roll(array, shifts[i], axis=(0, 1))``.
 
+    On CPU the per-site quadrant-copy loop is already very fast — each slice is
+    a memmove — and beats both ``xp.roll`` in a loop and a full advanced-indexing
+    gather. On GPU the advanced-indexing form wins because the per-site loop
+    serialises kernel launches; we dispatch on the backend.
+
+    Shifts are first reduced modulo ``H`` / ``W`` so negative and out-of-range
+    values are handled correctly (the previous version raised RuntimeError on
+    negative shifts).
+    """
+    xp = get_array_module(array)
+    H, W = array.shape[-2:]
+    shifts = shifts.copy()
+    shifts[:, 0] %= H
+    shifts[:, 1] %= W
+
+    if xp is not np:
+        # GPU path: batched gather. CuPy's advanced indexing launches one
+        # kernel for the whole batch instead of one per site.
+        rows = (xp.arange(H)[None, :] - shifts[:, 0:1]) % H
+        cols = (xp.arange(W)[None, :] - shifts[:, 1:2]) % W
+        return array[rows[:, :, None], cols[:, None, :]]
+
+    # CPU path: per-site quadrant copy. Memmove inside each branch is faster
+    # than any vectorised numpy alternative we benchmarked.
+    output = xp.empty((len(shifts),) + array.shape, dtype=array.dtype)
     for i in range(len(shifts)):
-        if np.all(shifts[i] > 0):
-            output[i, : shifts[i, 0], : shifts[i, 1]] = array[
-                -shifts[i, 0] :, -shifts[i, 1] :
-            ]
-            output[i, : shifts[i, 0], shifts[i, 1] :] = array[
-                -shifts[i, 0] :, : -shifts[i, 1]
-            ]
-            output[i, shifts[i, 0] :, : shifts[i, 1]] = array[
-                : -shifts[i, 0], -shifts[i, 1] :
-            ]
-            output[i, shifts[i, 0] :, shifts[i, 1] :] = array[
-                : -shifts[i, 0], : -shifts[i, 1]
-            ]
-        elif shifts[i, 1] > 0:
-            output[i, :, : shifts[i, 1]] = array[:, -shifts[i, 1] :]
-            output[i, :, shifts[i, 1] :] = array[:, : -shifts[i, 1] :]
-        elif shifts[i, 0] > 0:
-            output[i, : shifts[i, 0], :] = array[-shifts[i, 0] :, :]
-            output[i, shifts[i, 0] :, :] = array[: -shifts[i, 0] :, :]
-        elif (shifts[i, 0] == 0) and (shifts[i, 1] == 0):
-            output[i] = array
+        s0, s1 = int(shifts[i, 0]), int(shifts[i, 1])
+        if s0 > 0 and s1 > 0:
+            output[i, :s0, :s1] = array[-s0:, -s1:]
+            output[i, :s0, s1:] = array[-s0:, :-s1]
+            output[i, s0:, :s1] = array[:-s0, -s1:]
+            output[i, s0:, s1:] = array[:-s0, :-s1]
+        elif s1 > 0:
+            output[i, :, :s1] = array[:, -s1:]
+            output[i, :, s1:] = array[:, :-s1]
+        elif s0 > 0:
+            output[i, :s0, :] = array[-s0:, :]
+            output[i, s0:, :] = array[:-s0, :]
         else:
-            raise RuntimeError()
+            output[i] = array
 
     return output
 
@@ -885,20 +899,46 @@ class TransitionPotentialArray(ArrayObject, BaseTransitionPotential):
 
             local_potential = copy_to_device(self._local_potential, waves.array)
 
-            shifted_local_potential = fast_roll(local_potential, rounded_sites)
+            # Stream the overlap reduction over sites in chunks. The full
+            # (n_sites, *waves_shape, H, W) tensor that the naive computation
+            # would build can dwarf available memory for big scans / many sites;
+            # by reducing each chunk to a per-site sum before moving on, peak
+            # transient is O(chunk_size) instead of O(n_sites).
+            #
+            # The chunk size targets the same byte budget as the rest of abTEM
+            # (dask.chunk-size / dask.chunk-size-gpu) via validate_chunks, so
+            # users who already tuned that knob for a memory-constrained
+            # workstation get the tighter behaviour here automatically.
+            abs2_waves = abs2(waves.array)
+            n_sites = len(validated_sites)
+            reduce_axes_offset = len(waves.shape) - 2  # broadcast dims per site
 
-            shifted_local_potential = shifted_local_potential.reshape(
-                (len(validated_sites),)
-                + (1,) * (len(waves.shape) - 2)
-                + shifted_local_potential.shape[-2:]
-            )
+            chunks = validate_chunks(
+                shape=(n_sites,) + waves.shape,
+                chunks=("auto",) + (-1,) * len(waves.shape),
+                max_elements="auto",
+                dtype=waves.dtype,
+                device=self.device,
+            )[0]
 
-            overlaps = shifted_local_potential * abs2(waves.array[None])
-            overlaps = overlaps.sum(axis=(-2, -1))
-
-            mask = overlaps > threshold
-
-            mask = mask.any(tuple(range(1, len(overlaps.shape))))
+            mask = xp.zeros(n_sites, dtype=bool)
+            start = 0
+            for chunk_size in chunks:
+                end = start + chunk_size
+                shifted = fast_roll(local_potential, rounded_sites[start:end])
+                shifted = shifted.reshape(
+                    (end - start,)
+                    + (1,) * reduce_axes_offset
+                    + shifted.shape[-2:]
+                )
+                overlaps = (shifted * abs2_waves[None]).sum(axis=(-2, -1))
+                chunk_mask = overlaps > threshold
+                if chunk_mask.ndim > 1:
+                    chunk_mask = chunk_mask.any(
+                        tuple(range(1, chunk_mask.ndim))
+                    )
+                mask[start:end] = chunk_mask
+                start = end
 
             mask = copy_to_device(mask, "cpu")
             # if np.any(mask):

--- a/abtem/multislice.py
+++ b/abtem/multislice.py
@@ -799,6 +799,7 @@ def transition_potential_multislice_and_detect(
     threshold: float = 1.0,
     sites: Optional[SliceIndexedAtoms | Atoms] = None,
     algorithm: FourierMultislice | RealSpaceMultislice = FourierMultislice(),
+    scatter_max_batch: int | str = 1,
     pbar: bool = False,
 ) -> list[BaseMeasurements | Waves] | BaseMeasurements | Waves:
     """
@@ -939,10 +940,27 @@ def transition_potential_multislice_and_detect(
             )
             _update_measurements(waves, detectors, measurements, measurement_index)
 
+        # Pre-build (and bandlimit) all transmission functions for this configuration.
+        # The double-channel inner multislice re-visits slices [scatter_index+1 …]
+        # for every site batch; without this cache each slice's transmission function
+        # is rebuilt up to N_sites times per outer step. For FourierMultislice the
+        # cached objects are TransmissionFunction instances which short-circuit the
+        # rebuild inside conventional_multislice_step (see iam.py:1300-1302).
+        # For RealSpaceMultislice the slices are kept as PotentialArray.
+        if isinstance(algorithm, FourierMultislice):
+            slice_cache = [
+                antialias_aperture.bandlimit(
+                    slice_obj.transmission_function(energy=waves._valid_energy),
+                    in_place=False,
+                )
+                for slice_obj in potential_configuration.generate_slices()
+            ]
+        else:
+            slice_cache = list(potential_configuration.generate_slices())
+
+        n_outer = len(slice_cache)
         depth = 0.0
-        for scatter_index, potential_slice in enumerate(
-            potential_configuration.generate_slices()
-        ):
+        for scatter_index, potential_slice in enumerate(slice_cache):
             waves = multislice_step(
                 waves,
                 potential_slice,
@@ -964,7 +982,10 @@ def transition_potential_multislice_and_detect(
                 included_sites,
                 scattered_waves,
             ) in transition_potential.generate_scattered_waves(
-                waves, sites_slice, max_batch=1, threshold=absolute_threshold
+                waves,
+                sites_slice,
+                max_batch=scatter_max_batch,
+                threshold=absolute_threshold,
             ):
                 if len(scattered_waves) == 0:
                     continue
@@ -979,13 +1000,12 @@ def transition_potential_multislice_and_detect(
                         potential_index,
                     )
 
-                    # if scatter_index + 1 == len(potential):
-                    #    break
+                    # Nothing left to propagate through on the final outer slice.
+                    if scatter_index + 1 == n_outer:
+                        continue
 
-                    for inner_slice_index, inner_potential_slice in enumerate(
-                        potential_configuration.generate_slices(
-                            first_slice=scatter_index + 1
-                        )
+                    for inner_offset, inner_potential_slice in enumerate(
+                        slice_cache[scatter_index + 1:]
                     ):
                         scattered_waves = multislice_step(
                             scattered_waves,
@@ -999,7 +1019,7 @@ def transition_potential_multislice_and_detect(
                             scattered_waves,
                             detectors,
                             potential,
-                            inner_slice_index + scatter_index + 1,
+                            scatter_index + 1 + inner_offset,
                             potential_index,
                         )
 

--- a/abtem/multislice.py
+++ b/abtem/multislice.py
@@ -940,27 +940,33 @@ def transition_potential_multislice_and_detect(
             )
             _update_measurements(waves, detectors, measurements, measurement_index)
 
-        # Pre-build (and bandlimit) all transmission functions for this configuration.
         # The double-channel inner multislice re-visits slices [scatter_index+1 …]
-        # for every site batch; without this cache each slice's transmission function
-        # is rebuilt up to N_sites times per outer step. For FourierMultislice the
-        # cached objects are TransmissionFunction instances which short-circuit the
-        # rebuild inside conventional_multislice_step (see iam.py:1300-1302).
-        # For RealSpaceMultislice the slices are kept as PotentialArray.
-        if isinstance(algorithm, FourierMultislice):
-            slice_cache = [
-                antialias_aperture.bandlimit(
-                    slice_obj.transmission_function(energy=waves._valid_energy),
-                    in_place=False,
-                )
-                for slice_obj in potential_configuration.generate_slices()
-            ]
+        # once per site batch; pre-building (and bandlimiting) the transmission
+        # functions saves N_sites rebuilds per outer step in that case (for
+        # FourierMultislice the cache short-circuits the rebuild inside
+        # conventional_multislice_step, see iam.py:1300-1302). Single-channel
+        # visits each slice exactly once, so caching is pure memory overhead and
+        # we stream slices instead.
+        if double_channel:
+            if isinstance(algorithm, FourierMultislice):
+                slice_cache = [
+                    antialias_aperture.bandlimit(
+                        slice_obj.transmission_function(energy=waves._valid_energy),
+                        in_place=False,
+                    )
+                    for slice_obj in potential_configuration.generate_slices()
+                ]
+            else:
+                slice_cache = list(potential_configuration.generate_slices())
+            n_outer = len(slice_cache)
+            outer_iter = enumerate(slice_cache)
         else:
-            slice_cache = list(potential_configuration.generate_slices())
+            slice_cache = None
+            n_outer = None
+            outer_iter = enumerate(potential_configuration.generate_slices())
 
-        n_outer = len(slice_cache)
         depth = 0.0
-        for scatter_index, potential_slice in enumerate(slice_cache):
+        for scatter_index, potential_slice in outer_iter:
             waves = multislice_step(
                 waves,
                 potential_slice,

--- a/abtem/multislice.py
+++ b/abtem/multislice.py
@@ -949,13 +949,33 @@ def transition_potential_multislice_and_detect(
         # we stream slices instead.
         if double_channel:
             if isinstance(algorithm, FourierMultislice):
-                slice_cache = [
-                    antialias_aperture.bandlimit(
-                        slice_obj.transmission_function(energy=waves._valid_energy),
-                        in_place=False,
-                    )
-                    for slice_obj in potential_configuration.generate_slices()
-                ]
+                # Dedup transmissions across z-repetitions. CrystalPotential's
+                # tile cache (iam.py CrystalPotential.generate_slices) yields the
+                # *same* PotentialArray object for every z-repetition of a unit
+                # slice in the no-frozen-phonon case, so id(slice_obj) collapses
+                # to one entry per unique unit slice. The bandlimit FFT then
+                # runs O(n_unique) times instead of O(n_outer), and the
+                # transmission cache footprint drops by repetitions[2].
+                # For SrTiO3 reps=(4,4,25): 50 transmissions -> 2 unique
+                # (-24 MB cache, -48 bandlimit FFTs per configuration).
+                # The EELS driver reads exit_planes off ``potential`` globally,
+                # never off the slice (compare standard_multislice_and_detect
+                # at multislice.py:672), so sharing TransmissionFunction
+                # instances across slice indices is safe here.
+                tx_dedup: dict[int, TransmissionFunction] = {}
+                slice_cache = []
+                for slice_obj in potential_configuration.generate_slices():
+                    key = id(slice_obj)
+                    cached = tx_dedup.get(key)
+                    if cached is None:
+                        cached = antialias_aperture.bandlimit(
+                            slice_obj.transmission_function(
+                                energy=waves._valid_energy
+                            ),
+                            in_place=False,
+                        )
+                        tx_dedup[key] = cached
+                    slice_cache.append(cached)
             else:
                 slice_cache = list(potential_configuration.generate_slices())
             n_outer = len(slice_cache)

--- a/test/test_ionization.py
+++ b/test/test_ionization.py
@@ -11,7 +11,7 @@ import pytest
 
 import abtem
 from abtem.core.axes import OrdinalAxis
-from abtem.inelastic.core_loss import TransitionPotentialArray
+from abtem.inelastic.core_loss import TransitionPotentialArray, fast_roll
 from abtem.waves import Probe
 
 try:
@@ -20,6 +20,33 @@ except ImportError:
     cp = None
 
 from utils import gpu  # noqa: E402  -- pytest.param('gpu', skipif no cupy)
+
+
+def test_fast_roll_matches_numpy_roll():
+    """The vectorised fast_roll must give the same result as a per-site np.roll."""
+    rng = np.random.default_rng(0)
+    arr = rng.standard_normal((16, 16)).astype(np.complex64)
+    shifts = np.array([[0, 0], [3, 5], [15, 15], [1, 7], [10, 2]])
+    out = fast_roll(arr, shifts)
+    for i, s in enumerate(shifts):
+        expected = np.roll(arr, (int(s[0]), int(s[1])), axis=(0, 1))
+        assert np.array_equal(out[i], expected), f"mismatch at shift {tuple(s)}"
+
+
+def test_fast_roll_handles_negative_shifts():
+    """Modular indexing must produce the same result as np.roll with negative shifts.
+
+    The pre-Tier-2 implementation raised RuntimeError on negative shifts;
+    handle them correctly so atom positions outside the centred-cell convention
+    still work.
+    """
+    rng = np.random.default_rng(1)
+    arr = rng.standard_normal((8, 8)).astype(np.complex64)
+    shifts = np.array([[-1, -2], [-7, 3], [0, -5]])
+    out = fast_roll(arr, shifts)
+    for i, s in enumerate(shifts):
+        expected = np.roll(arr, (int(s[0]), int(s[1])), axis=(0, 1))
+        assert np.array_equal(out[i], expected), f"mismatch at shift {tuple(s)}"
 
 
 @pytest.fixture(scope="module")

--- a/test/test_ionization.py
+++ b/test/test_ionization.py
@@ -258,3 +258,94 @@ def test_transition_potential_scan_crystal_potential_matches_manual_tile(device)
     np.testing.assert_allclose(arr_cryst, arr_manual, rtol=1e-5, atol=0)
 
 
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_transition_potential_scan_crystal_double_channel_matches_manual(device):
+    """Double-channel + CrystalPotential is the intersection that triggers the
+    TransmissionFunction dedup in transition_potential_multislice_and_detect
+    (the slice_cache is only built when double_channel=True, and dedup only
+    fires when generate_slices yields repeated object identities). Verify the
+    deduplicated cache still produces results numerically equivalent to the
+    manually-tiled Potential path.
+    """
+    if device == "gpu":
+        xp = cp
+    else:
+        xp = np
+
+    unit_atoms = ase.build.bulk("Si", cubic=True)
+    reps = (2, 2, 3)
+    slice_thickness = float(unit_atoms.cell[2, 2])
+
+    manual_pot = abtem.Potential(
+        unit_atoms * reps, gpts=(64, 64), slice_thickness=slice_thickness,
+        device=device,
+    )
+    unit_pot = abtem.Potential(
+        unit_atoms, gpts=(32, 32), slice_thickness=slice_thickness,
+        device=device,
+    )
+    cryst_pot = abtem.CrystalPotential(unit_pot, repetitions=reps)
+
+    probe = abtem.Probe(energy=100e3, semiangle_cutoff=20, device=device)
+    probe.grid.match(manual_pot)
+
+    rng = np.random.default_rng(1)
+    tp_array_np = (
+        rng.standard_normal((2, 64, 64))
+        + 1j * rng.standard_normal((2, 64, 64))
+    ).astype(np.complex64)
+    tp_array = xp.asarray(tp_array_np)
+
+    def make_tp(extent):
+        return TransitionPotentialArray(
+            Z=14, array=tp_array, energy=100e3, extent=extent,
+            ensemble_axes_metadata=[OrdinalAxis(values=(0, 1))],
+            metadata={"Z": 14, "n": 1, "l": 0},
+        )
+
+    detector = abtem.PixelatedDetector(max_angle=40, to_cpu=True)
+
+    res_manual = probe.transition_potential_scan(
+        potential=manual_pot, transition_potentials=make_tp(manual_pot.extent),
+        scan=(0, 0), detectors=detector, double_channel=True, lazy=False,
+    ).compute()
+    res_cryst = probe.transition_potential_scan(
+        potential=cryst_pot, transition_potentials=make_tp(cryst_pot.extent),
+        scan=(0, 0), detectors=detector, double_channel=True, lazy=False,
+    ).compute()
+
+    arr_manual = np.asarray(res_manual.array)
+    arr_cryst = np.asarray(res_cryst.array)
+
+    assert arr_manual.shape == arr_cryst.shape
+    np.testing.assert_allclose(arr_cryst, arr_manual, rtol=1e-5, atol=0)
+
+
+def test_transition_potential_crystal_dedup_collapses_slice_cache():
+    """White-box check: with CrystalPotential's tile cache, the per-z-rep
+    slice_cache built inside transition_potential_multislice_and_detect must
+    contain only ``n_unique_unit_slices`` distinct TransmissionFunction
+    objects, not ``n_outer = n_unit * reps[2]`` objects. Guards the dedup
+    branch from silently regressing into rebuilding identical transmissions.
+    """
+    unit_atoms = ase.build.bulk("Si", cubic=True)
+    reps = (2, 2, 5)
+    slice_thickness = float(unit_atoms.cell[2, 2])
+    unit_pot = abtem.Potential(
+        unit_atoms, gpts=(16, 16), slice_thickness=slice_thickness,
+    )
+    cryst = abtem.CrystalPotential(unit_pot, repetitions=reps)
+
+    # Tile cache returns the *same* PotentialArray object across z-reps for
+    # the no-frozen-phonon case. Confirm that contract holds.
+    slices = list(cryst.generate_slices())
+    n_unit = len(unit_pot)
+    assert len(slices) == n_unit * reps[2]
+    unique = {id(s) for s in slices}
+    assert len(unique) == n_unit, (
+        f"expected {n_unit} unique slice objects (one per unit-cell slice), "
+        f"got {len(unique)} — CrystalPotential.generate_slices tile cache may "
+        "have regressed"
+    )
+
+

--- a/test/test_ionization.py
+++ b/test/test_ionization.py
@@ -4,6 +4,12 @@ These guard against regressions in the public API that the core-loss tutorial
 depends on (see https://abtem.readthedocs.io/en/latest/user_guide/tutorials/core_loss.html).
 The transition_potential_scan method was silently dropped in early 2025 and
 restored later; the smoke tests below ensure it stays wired up.
+
+All tests are parametrised over ``["cpu", gpu]`` so that on a workstation
+with CuPy installed the GPU code paths in ``fast_roll`` /
+``transition_potential_multislice_and_detect`` are exercised automatically.
+``gpu`` is a ``pytest.param`` defined in ``test/utils.py`` that skips when
+CuPy isn't present.
 """
 import ase
 import numpy as np
@@ -21,64 +27,96 @@ except ImportError:
 
 from utils import gpu  # noqa: E402  -- pytest.param('gpu', skipif no cupy)
 
+# For fast_roll we parametrise over a backend *module* string ("numpy" /
+# "cupy"); the abtem-level GPU dispatch tests use the standard device kwarg.
+xp_params = [
+    "numpy",
+    pytest.param("cupy", marks=pytest.mark.skipif(cp is None, reason="no gpu")),
+]
 
-def test_fast_roll_matches_numpy_roll():
-    """The vectorised fast_roll must give the same result as a per-site np.roll."""
+
+def _xp(name):
+    return np if name == "numpy" else cp
+
+
+@pytest.mark.parametrize("xp_name", xp_params)
+def test_fast_roll_matches_numpy_roll(xp_name):
+    """The vectorised fast_roll must give the same result as a per-site np.roll
+    on both numpy and cupy inputs."""
+    xp = _xp(xp_name)
     rng = np.random.default_rng(0)
-    arr = rng.standard_normal((16, 16)).astype(np.complex64)
-    shifts = np.array([[0, 0], [3, 5], [15, 15], [1, 7], [10, 2]])
+    arr_np = rng.standard_normal((16, 16)).astype(np.complex64)
+    arr = xp.asarray(arr_np)
+    shifts_np = np.array([[0, 0], [3, 5], [15, 15], [1, 7], [10, 2]])
+    shifts = xp.asarray(shifts_np)
     out = fast_roll(arr, shifts)
-    for i, s in enumerate(shifts):
-        expected = np.roll(arr, (int(s[0]), int(s[1])), axis=(0, 1))
+    if xp is not np:
+        out = cp.asnumpy(out)
+    for i, s in enumerate(shifts_np):
+        expected = np.roll(arr_np, (int(s[0]), int(s[1])), axis=(0, 1))
         assert np.array_equal(out[i], expected), f"mismatch at shift {tuple(s)}"
 
 
-def test_fast_roll_handles_negative_shifts():
-    """Modular indexing must produce the same result as np.roll with negative shifts.
+@pytest.mark.parametrize("xp_name", xp_params)
+def test_fast_roll_handles_negative_shifts(xp_name):
+    """Modular indexing must produce the same result as np.roll with negative
+    shifts on both numpy and cupy inputs.
 
     The pre-Tier-2 implementation raised RuntimeError on negative shifts;
-    handle them correctly so atom positions outside the centred-cell convention
-    still work.
+    handle them correctly so atom positions outside the centred-cell
+    convention still work.
     """
+    xp = _xp(xp_name)
     rng = np.random.default_rng(1)
-    arr = rng.standard_normal((8, 8)).astype(np.complex64)
-    shifts = np.array([[-1, -2], [-7, 3], [0, -5]])
+    arr_np = rng.standard_normal((8, 8)).astype(np.complex64)
+    arr = xp.asarray(arr_np)
+    shifts_np = np.array([[-1, -2], [-7, 3], [0, -5]])
+    shifts = xp.asarray(shifts_np)
     out = fast_roll(arr, shifts)
-    for i, s in enumerate(shifts):
-        expected = np.roll(arr, (int(s[0]), int(s[1])), axis=(0, 1))
+    if xp is not np:
+        out = cp.asnumpy(out)
+    for i, s in enumerate(shifts_np):
+        expected = np.roll(arr_np, (int(s[0]), int(s[1])), axis=(0, 1))
         assert np.array_equal(out[i], expected), f"mismatch at shift {tuple(s)}"
 
 
-@pytest.fixture(scope="module")
-def si_potential():
-    atoms = ase.build.bulk("Si", cubic=True)
-    return abtem.Potential(atoms, gpts=32, slice_thickness=2.7)
+# Module-scoped fixtures kept device-agnostic; the test functions thread the
+# device kwarg through to Potential / Probe / TransitionPotentialArray.
 
 
 @pytest.fixture(scope="module")
-def si_transition_potential(si_potential):
+def si_atoms():
+    return ase.build.bulk("Si", cubic=True)
+
+
+def _make_si_potential(atoms, device):
+    return abtem.Potential(atoms, gpts=32, slice_thickness=2.7, device=device)
+
+
+def _make_si_transition_potential(potential, device):
     # Synthetic transition potential: skips numerov / GPAW so the wiring is
     # exercised without depending on the heavy DFT setup the tutorial uses.
     n_transitions = 2
     rng = np.random.default_rng(0)
     array = (
-        rng.standard_normal((n_transitions, *si_potential.gpts))
-        + 1j * rng.standard_normal((n_transitions, *si_potential.gpts))
+        rng.standard_normal((n_transitions, *potential.gpts))
+        + 1j * rng.standard_normal((n_transitions, *potential.gpts))
     ).astype(np.complex64)
+    if device == "gpu":
+        array = cp.asarray(array)
     return TransitionPotentialArray(
         Z=14,
         array=array,
         energy=100e3,
-        extent=si_potential.extent,
+        extent=potential.extent,
         ensemble_axes_metadata=[OrdinalAxis(values=tuple(range(n_transitions)))],
         metadata={"Z": 14, "n": 1, "l": 0},
     )
 
 
-@pytest.fixture(scope="module")
-def probe(si_potential):
-    p = abtem.Probe(energy=100e3, semiangle_cutoff=20)
-    p.grid.match(si_potential)
+def _make_probe(potential, device):
+    p = abtem.Probe(energy=100e3, semiangle_cutoff=20, device=device)
+    p.grid.match(potential)
     return p
 
 
@@ -88,14 +126,17 @@ def test_transition_potential_scan_is_defined_on_probe():
     assert callable(Probe.transition_potential_scan)
 
 
-def test_transition_potential_scan_builds_lazy_graph(
-    probe, si_potential, si_transition_potential
-):
-    """Wiring smoke test: lazy call returns a measurements object without raising."""
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_transition_potential_scan_builds_lazy_graph(si_atoms, device):
+    """Wiring smoke test: lazy call returns a measurements object without raising,
+    on both CPU and GPU backends."""
+    potential = _make_si_potential(si_atoms, device)
+    tp = _make_si_transition_potential(potential, device)
+    probe = _make_probe(potential, device)
     detector = abtem.AnnularDetector(inner=0, outer=40)
     result = probe.transition_potential_scan(
-        potential=si_potential,
-        transition_potentials=si_transition_potential,
+        potential=potential,
+        transition_potentials=tp,
         scan=(0, 0),
         detectors=detector,
         lazy=True,
@@ -104,15 +145,17 @@ def test_transition_potential_scan_builds_lazy_graph(
     assert hasattr(result, "compute")
 
 
-def test_transition_potential_scan_forwards_inelastic_kwargs(
-    probe, si_potential, si_transition_potential
-):
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_transition_potential_scan_forwards_inelastic_kwargs(si_atoms, device):
     """double_channel / threshold must flow through to
     transition_potential_multislice_and_detect via **multislice_func_kwargs."""
+    potential = _make_si_potential(si_atoms, device)
+    tp = _make_si_transition_potential(potential, device)
+    probe = _make_probe(potential, device)
     detector = abtem.AnnularDetector(inner=0, outer=40)
     result = probe.transition_potential_scan(
-        potential=si_potential,
-        transition_potentials=si_transition_potential,
+        potential=potential,
+        transition_potentials=tp,
         scan=(0, 0),
         detectors=detector,
         double_channel=False,
@@ -122,21 +165,23 @@ def test_transition_potential_scan_forwards_inelastic_kwargs(
     assert result is not None
 
 
-def test_transition_potential_scan_accepts_grid_scan(
-    probe, si_potential, si_transition_potential
-):
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_transition_potential_scan_accepts_grid_scan(si_atoms, device):
     """The tutorial uses GridScan + sites=... for the EELS-map calls."""
+    potential = _make_si_potential(si_atoms, device)
+    tp = _make_si_transition_potential(potential, device)
+    probe = _make_probe(potential, device)
     detector = abtem.FlexibleAnnularDetector()
     scan = abtem.GridScan(
         start=(0, 0), end=(1, 1), fractional=True,
-        potential=si_potential, endpoint=False, sampling=2.0,
+        potential=potential, endpoint=False, sampling=2.0,
     )
     result = probe.transition_potential_scan(
-        potential=si_potential,
-        transition_potentials=si_transition_potential,
+        potential=potential,
+        transition_potentials=tp,
         scan=scan,
         detectors=detector,
-        sites=ase.build.bulk("Si", cubic=True),
+        sites=si_atoms,
         lazy=True,
     )
     assert result is not None


### PR DESCRIPTION
## Summary

Performance work on `transition_potential_multislice_and_detect` and the
`TransitionPotential.filter_sites` / `fast_roll` helpers. Four commits,
numerics-preserving (max relative drift 5e-7 — float32 FFT noise).

### Tier 1 (commit `074b7523`)

1. **Pre-build transmission functions per phonon configuration** for the
   double-channel path. The inner multislice re-visits slices
   `[scatter_index+1 …]` once per site batch; without caching each slice's
   `complex_exponential(σ · array)` + bandlimit is rebuilt up to `N_sites`
   times per outer step. By materialising bandlimited `TransmissionFunction`
   objects once and passing them to `multislice_step`, the existing
   `isinstance(potential_slice, TransmissionFunction)` short-circuit in
   `conventional_multislice_step` ([`iam.py:1300-1302`](abtem/potentials/iam.py#L1300-L1302))
   makes the rebuilds disappear. Cache freed at the end of each
   configuration. Memory cost: `N_outer · H · W · sizeof(complex)` per
   configuration — 48 MB for the Si tutorial, well within `dask.chunk-size`.
2. **Expose `scatter_max_batch` kwarg** on `transition_potential_multislice_and_detect`.
   Default kept at 1 to preserve the conservative memory envelope; power
   users who can afford more transient RAM can dial it up (or pass `"auto"`
   to let `validate_chunks` size against `dask.chunk-size`). No new config
   keys.
3. **Early-exit on the final outer slice** ([`multislice.py:975-976`](abtem/multislice.py#L975-L976)).

### Tier 2 (commit `011bfe96`)

4. **Stream the `filter_sites` overlap reduction.** Replace the naive
   `(N_sites, *waves_shape, H, W) f32` peak transient with a chunked sweep
   sized by `validate_chunks` against `dask.chunk-size`. Peak transient
   drops from `O(N_sites · waves · H · W)` to `O(chunk · waves · H · W)`.
5. **GPU dispatch in `fast_roll`** + **negative-shift correctness.** CPU
   keeps the per-site quadrant-copy loop (memmove beats every vectorised
   numpy alternative I benchmarked); GPU uses a batched advanced-indexing
   gather to avoid per-site kernel launches. Shifts are pre-normalised via
   modulo, so negative shifts no longer raise `RuntimeError`.

### Tier 3 (commit `4ae21883`)

6. **Skip the transmission cache when `double_channel=False`.** Single-channel
   visits each slice exactly once, so caching is pure memory overhead.
   For the SrTiO₃ tutorial that's ~25 MB per worker saved (visible at the
   per-worker peak measurement; partially absorbed by other components in
   the full-pipeline peak).
7. **Tests parametrised over `["cpu", gpu]`.** On a workstation with CuPy
   installed, both `fast_roll` backends and all `transition_potential_scan`
   tests run on both devices automatically. The existing
   [`test/utils.py:gpu`](test/utils.py#L121) `pytest.param` carries a
   `skipif(cp is None)` marker so CPU-only boxes skip cleanly.

### CrystalPotential dedup (commit `375fcc18`)

8. **Dedup the transmission cache for CrystalPotential.** PR #284 adds a
   per-z-rep tile cache to `CrystalPotential.generate_slices` so repeated
   z-reps yield the same `PotentialArray` object. The slice-cache builder
   in `transition_potential_multislice_and_detect` now keys on
   `id(slice_obj)` and reuses the bandlimited `TransmissionFunction`
   across identical inputs. For SrTiO₃ `reps=(4,4,25)` double-channel:
   50 transmissions → 2 unique entries (−24 MB cache, −48 `complex_exponential`
   + bandlimit FFT calls per configuration). Limited to the EELS driver
   because the elastic `standard_multislice_and_detect` reads
   `potential_slice.exit_planes` ([multislice.py:672](abtem/multislice.py#L672))
   and would be unsafe to share `TransmissionFunction` instances across.

## Measured impact (macOS, single-process, FFTW)

Side-by-side baseline vs current on identical hardware/state; first run
warm-up discarded.

| Workload | Baseline | After | Δ time | Δ peak RSS |
|---|---|---|---|---|
| **Si double-channel tutorial** (single position) | 72.9 s, 1039 MB | **52.7 s, 973 MB** | **−28 % (1.38×)** | **−6 %** |
| SrTiO₃ O + Sr EELS map (single-channel, threshold=0.95, 6 workers) | 244.7 s, 6715 MB | 255 s, 6806 MB | +4 % (noise) | +1 % (noise) |
| Si CrystalPotential, double-channel, `reps=(2,2,5)`, single position (tile cache + dedup intersection) | 3.1 s, 780 MB | **2.5 s, 788 MB** | **−19 % (1.24×)** | +1 % (noise) |

For the CrystalPotential × double-channel intersection the dedup combined
with PR #284's tile cache gives a clean speedup with no memory penalty.
This is a small workload (5 slices, 4 transitions, single scan position),
so the absolute times are short; the relative win is consistent with the
expected savings from collapsing 5 transmission builds to 1 per
configuration. Manual vs Crystal numerical equivalence: max rel diff 2e-7.

Per-worker memory (one worker, SrTiO₃ O scan only):

| Variant | Time | Peak RSS |
|---|---|---|
| Baseline | 371 s | 2202 MB |
| With Tier 1+2 cache | 371 s | 2202 MB |
| + cache-skip for single-channel | 393 s | 2185 MB |

At 6 workers the cache-skip saves ~300 MB on the O-scan-only mark, but a
similar slice of that gets absorbed back into the full-pipeline peak by
overlapping Sr setup — net memory delta on the full pipeline is within
noise. The Si double-channel win is the headline result; single-channel
SrTiO₃ is essentially unchanged in both time and memory.

## Out of scope (deferred to follow-up PRs)

- Detector base-class refactors (in-place accumulation, polar-bin mask
  cache) — shared with elastic STEM / diffraction paths.
- Frozen-phonon Dask `multi_output_blockwise` migration — cross-cutting
  multislice-driver change (the same Python loop exists in
  `standard_multislice_and_detect`, [`multislice.py:639`](abtem/multislice.py#L639));
  belongs in its own planning doc.
- Sub-chunking the scan dimension inside `scatter()` — the dominant
  per-scatter transient is `(scatter_max_batch · N_T · scan_chunk · H · W)`,
  which already fits in `dask.chunk-size` for the tutorial workloads.
- `fft_shift_kernel` LRU cache, Wigner-3j table — opportunistic, modest
  wins.
- PRISM-EELS backend — tracking issue
  [#287](https://github.com/abTEM/abTEM/issues/287).
- `CrystalPotential.get_sliced_atoms()` to drop the EELS-driver special
  case — tracking issue
  [#288](https://github.com/abTEM/abTEM/issues/288).

## Test plan

- [x] `test/test_ionization.py` — 15 tests parametrised over
  `["cpu", gpu]`. CPU box: 8 pass + 7 GPU-skip. **GPU workstation: all 15
  pass** (GPU `fast_roll` advanced-indexing branch, the device-threaded
  `transition_potential_scan` cases, and the CrystalPotential equivalence
  + dedup tests).
- [x] Si double-channel reproduction matches the documented reference
  ([d05c6948…](https://abtem.github.io/doc/_images/d05c6948381309d6e58a61cae17c3654a40f37fdbb87a3ac168ea07e64edd9c9.png))
  visually and numerically (max rel diff 5e-7).
- [x] SrTiO₃ EELS map (O + Sr) produces the documented atomic-resolution
  contrast with the documented colour scale (~3.5×10⁻⁶).
- [x] CrystalPotential vs manually-tiled Potential cross-check for both
  single-channel (rtol 1e-5) and double-channel (rtol 1e-5) — covered by
  `test_transition_potential_scan_crystal_potential_matches_manual_tile`
  and `test_transition_potential_scan_crystal_double_channel_matches_manual`.
- [x] White-box guard against tile-cache regression:
  `test_transition_potential_crystal_dedup_collapses_slice_cache` asserts
  `CrystalPotential.generate_slices` yields the same object identity for
  repeated z-reps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
