### PR TITLE
Fix eager multislice reusing mutated waves across frozen-phonon configs

### DIFF
--- a/abtem/multislice.py
+++ b/abtem/multislice.py
@@ -636,9 +636,12 @@ def multislice_and_detect(
         enabled=pbar, total=int(n_slices), leave=False, desc="multislice"
     )
 
+    waves_input = waves.copy()
+
     for potential_index, potential_configuration in _generate_potential_configurations(
         potential
     ):
+        waves = waves_input.copy()
         exit_plane_index = 0
 
         # Handle entrance plane detection (before first slice)
@@ -922,10 +925,13 @@ def transition_potential_multislice_and_detect(
         enabled=pbar, total=int(n_slices), leave=False, desc="multislice"
     )
 
+    waves_input = waves.copy()
+
     for (
         potential_index,
         potential_configuration,
     ) in _generate_potential_configurations(potential):
+        waves = waves_input.copy()
         if potential.exit_planes[0] == -1:
             measurement_index = _validate_potential_ensemble_indices(
                 potential_index, 0, potential

--- a/test/test_simulate.py
+++ b/test/test_simulate.py
@@ -1,10 +1,13 @@
 import hypothesis.strategies as st
+import numpy as np
 import pytest
 import strategies as abtem_st
+from ase import Atoms
 from hypothesis import given
 from utils import gpu
 
-from abtem import AnnularDetector, PixelatedDetector
+from abtem import AnnularDetector, PixelatedDetector, PlaneWave
+from abtem.inelastic.phonons import FrozenPhonons
 from abtem.scan import CustomScan
 
 
@@ -219,3 +222,24 @@ def test_probe_scan(data, waves_builder, detector, scan, device, frozen_phonons,
 # #     measurements.compute()
 # #
 # #     assert_scanned_measurement_as_expected(measurements, atoms, probe, detectors, scan=scan)
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+@pytest.mark.parametrize("ensemble_mean", [True, False])
+def test_frozen_phonon_lazy_vs_eager(device, ensemble_mean):
+    atoms = Atoms("Si", positions=[(0, 0, 1)], cell=(5, 5, 2), pbc=True)
+    frozen_phonons = FrozenPhonons(
+        atoms, num_configs=2, sigmas=0.1, ensemble_mean=ensemble_mean, seed=42
+    )
+
+    waves = PlaneWave(energy=100e3, gpts=(32, 32), device=device)
+    detector = PixelatedDetector(max_angle=None)
+
+    result_lazy = waves.multislice(frozen_phonons, detectors=detector, lazy=True)
+    result_lazy = result_lazy.compute()
+
+    result_eager = waves.multislice(frozen_phonons, detectors=detector, lazy=False)
+
+    np.testing.assert_allclose(
+        result_eager.array, result_lazy.array, rtol=1e-5, atol=1e-7
+    )


### PR DESCRIPTION
## Summary

Follows up on #267, which fixed frozen-phonon averaging in the S-matrix path. This fixes the same class of bug in the two remaining eager multislice functions:

- **`multislice_and_detect`** (standard multislice): `waves` was mutated by `multislice_step` through all slices of config 0, then config 1 started propagation from config 0's exit waves instead of the original input.
- **`transition_potential_multislice_and_detect`** (EELS/core-loss): Same issue.

The `lazy=True` path was never affected — dask partitions each config into an independent task that captures the original input. Only `lazy=False` was wrong, producing results empirically ~Nx too large for N configs (up to 154% relative error with 2 configs).

**Fix:** Save `waves_input = waves.copy()` before the configuration loop, restore `waves = waves_input.copy()` at each iteration start in both functions.

**Why existing tests didn't catch this:** `test_multislice_detect_with_frozen_phonons` parametrizes over `lazy=True/False` but only asserts on output **shapes**, never values. The buggy eager path produced correctly shaped output — the numbers were just wrong.

## Test plan

- [x] New `test_frozen_phonon_lazy_vs_eager` compares `lazy=True` vs `lazy=False` array values with `FrozenPhonons(num_configs=2)`, parametrized over `ensemble_mean` and device
- [x] Confirmed test **fails** on the original code (25.4% elements mismatched, up to 154% relative error) and **passes** with the fix
- [x] All existing frozen-phonon tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)