### PR TITLE
Add calculate_exit_waves to BlochwaveEnsemble

### DIFF
--- a/abtem/bloch/dynamical.py
+++ b/abtem/bloch/dynamical.py
@@ -2260,3 +2260,222 @@ class BlochwaveEnsemble(Ensemble, CopyMixin):
         )
 
         return result
+
+    def _calculate_exit_waves_eager(
+        self,
+        thicknesses: np.ndarray,
+        gpts: tuple[int, int],
+        extent: tuple[float, float],
+        normalization: str,
+        g_max: Optional[float],
+        pbar: bool,
+    ) -> np.ndarray:
+        orientation_matrices = self.get_orientation_matrices()
+
+        shape = orientation_matrices.shape[:-2] + (len(thicknesses),) + gpts
+
+        pbar_obj = TqdmWrapper(
+            enabled=pbar,
+            total=int(np.prod(orientation_matrices.shape[:-2])),
+            leave=False,
+        )
+
+        xp = get_array_module(self.device)
+        array = xp.zeros(shape, dtype=get_dtype(complex=True))
+
+        for i in np.ndindex(orientation_matrices.shape[:-2]):
+            bw = BlochWaves(
+                structure_factor=self._structure_factor,
+                energy=self.energy,
+                sg_max=self.sg_max,
+                g_max=self.g_max,
+                orientation_matrix=orientation_matrices[i],
+                centering=self.centering,
+                device=self.device,
+                use_wave_eq=self._use_wave_eq,
+            )
+
+            waves = bw.calculate_exit_waves(
+                thicknesses=thicknesses,
+                gpts=gpts,
+                extent=extent,
+                normalization=normalization,
+                g_max=g_max,
+                lazy=False,
+            )
+
+            array[i] = waves.array
+            pbar_obj.update_if_exists(1)
+
+        pbar_obj.close_if_exists()
+        return array
+
+    @staticmethod
+    def _run_calculate_exit_waves(
+        block: np.ndarray,
+        thicknesses: np.ndarray,
+        gpts: tuple[int, int],
+        extent: tuple[float, float],
+        normalization: str,
+        g_max: Optional[float],
+        pbar: bool,
+    ) -> np.ndarray:
+        unpacked_block: BlochwaveEnsemble = block.item()
+        return unpacked_block._calculate_exit_waves_eager(
+            thicknesses=thicknesses,
+            gpts=gpts,
+            extent=extent,
+            normalization=normalization,
+            g_max=g_max,
+            pbar=pbar,
+        )
+
+    def _lazy_calculate_exit_waves(
+        self,
+        thicknesses: np.ndarray,
+        gpts: tuple[int, int],
+        extent: tuple[float, float],
+        normalization: str,
+        g_max: Optional[float],
+        pbar: bool,
+    ) -> da.core.Array:
+        blocks = self.ensemble_blocks(1)
+
+        shape = self.ensemble_shape + (len(thicknesses),) + gpts
+        out_ind = tuple(range(len(shape)))
+
+        xp = get_array_module(self.device)
+
+        out = da.blockwise(
+            self._run_calculate_exit_waves,
+            out_ind,
+            blocks,
+            tuple(range(len(self.ensemble_shape))),
+            new_axes={
+                out_ind[-3]: shape[-3],
+                out_ind[-2]: shape[-2],
+                out_ind[-1]: shape[-1],
+            },
+            thicknesses=thicknesses,
+            gpts=gpts,
+            extent=extent,
+            normalization=normalization,
+            g_max=g_max,
+            pbar=pbar,
+            concatenate=True,
+            meta=xp.zeros(shape, dtype=get_dtype(complex=True)),
+        )
+        return out
+
+    def calculate_exit_waves(
+        self,
+        thicknesses: float | Sequence[float] | np.ndarray,
+        gpts: Optional[tuple[int, int]] = None,
+        extent: Optional[tuple[float, float]] = None,
+        normalization: str = "values",
+        g_max: Optional[float] = None,
+        lazy: bool = True,
+        pbar: Optional[bool] = None,
+    ) -> Waves:
+        """Calculate the exit waves for the ensemble for a given set of
+        thicknesses.
+
+        Parameters
+        ----------
+        thicknesses : float or sequence of floats
+            The thicknesses of the sample [Å].
+        gpts : tuple of ints, optional
+            The grid points of the exit waves.
+        extent : tuple of floats, optional
+            The extent of the exit waves [Å].
+        normalization : {'values', 'amplitude'}
+            The normalization of the exit waves.
+        g_max : float, optional
+            Maximum scattering vector length for the plane wave
+            expansion [1/Å].
+        lazy : bool
+            If True, the calculation is done lazily using dask. If False,
+            the calculation is done eagerly.
+        pbar : bool, optional
+            If True, a progress bar is shown. Default is None, which means
+            the value is taken from the configuration.
+
+        Returns
+        -------
+        Waves
+            The exit waves.
+        """
+
+        if pbar is None:
+            pbar = config.get("local_diagnostics.task_level_progress", False)
+
+        if extent is None:
+            base_cell = np.array(self._structure_factor.cell)
+            orientation_matrices = self.get_orientation_matrices()
+            max_extent = np.zeros(2)
+            for i in np.ndindex(orientation_matrices.shape[:-2]):
+                rotated_cell = Cell(np.dot(base_cell, orientation_matrices[i].T))
+                bounds = cell_bounds(rotated_cell)[:2]
+                max_extent = np.maximum(max_extent, bounds)
+            extent = (float(max_extent[0]), float(max_extent[1]))
+
+        if gpts is None:
+            effective_g_max = g_max if g_max is not None else self.g_max
+            sampling = (1 / effective_g_max / 2, 1 / effective_g_max / 2)
+            gpts = (
+                int(np.ceil(extent[0] / sampling[0])),
+                int(np.ceil(extent[1] / sampling[1])),
+            )
+
+        if isinstance(thicknesses, (float, int)):
+            ensemble_axes_metadata: list[AxisMetadata] = []
+        else:
+            ensemble_axes_metadata = [
+                ThicknessAxis(
+                    label="z", units="Å", values=tuple(thicknesses)
+                )
+            ]
+
+        thicknesses = np.array(thicknesses, dtype=get_dtype())
+
+        if thicknesses.ndim == 0:
+            thicknesses = thicknesses[None]
+            squeeze_thickness_dim = True
+        else:
+            squeeze_thickness_dim = False
+
+        array: np.ndarray | da.core.Array
+        if lazy:
+            array = self._lazy_calculate_exit_waves(
+                thicknesses=thicknesses,
+                gpts=gpts,
+                extent=extent,
+                normalization=normalization,
+                g_max=g_max,
+                pbar=pbar,
+            )
+        else:
+            array = self._calculate_exit_waves_eager(
+                thicknesses=thicknesses,
+                gpts=gpts,
+                extent=extent,
+                normalization=normalization,
+                g_max=g_max,
+                pbar=pbar,
+            )
+
+        if squeeze_thickness_dim:
+            array = array[..., 0, :, :]
+
+        waves = Waves(
+            array=array,
+            extent=extent,
+            energy=self.energy,
+            ensemble_axes_metadata=[
+                *self.ensemble_axes_metadata,
+                *ensemble_axes_metadata,
+            ],
+            metadata={"normalization": normalization},
+        )
+
+        return waves


### PR DESCRIPTION
## Summary
- Add `calculate_exit_waves()` method to `BlochwaveEnsemble`, closing the API gap where `calculate_diffraction_patterns()` existed but exit waves did not (reported in #214)
- Supports both lazy (dask) and eager computation paths, mirroring the existing diffraction pattern implementation
- Default real-space extent is the componentwise maximum of `cell_bounds` across all orientations, so the grid accommodates even the large rotations that Bloch waves support

## Test plan
- [x] Scalar and multi-thickness inputs produce correct array shapes and axis metadata
- [x] 1D and 2D ensemble shapes (single-axis and multi-axis rotations)
- [x] Lazy and eager paths produce numerically identical results (atol=1e-10)
- [x] Large rotations (+-30 deg, +-45 deg) correctly expand the default extent
- [x] Existing Bloch wave tests pass (no regressions)

Closes #214