### PR TITLE
Feature: Bloch-wave inelastic (plasmon/phonon) scattering [Mendis 2024]

### DIFF
--- a/abtem/bloch/dynamical.py
+++ b/abtem/bloch/dynamical.py
@@ -1778,6 +1778,107 @@ class BlochWaves:
             },
         )
 
+    def calculate_diffuse_dp_deterministic(
+        self,
+        thickness: float,
+        plasmons: "MonteCarloPlasmons",
+        num_slices: int = 19,
+        dp_full: float = 150.0,
+        dp_step: float = 0.5,
+        dp_max: float | None = None,
+    ) -> "DiffractionPatterns":
+        """Deterministic depth-slice diffuse diffraction pattern.
+
+        Implements the algorithm of Mendis's ``Bloch_plasmon_DP.m`` /
+        ``Bloch_phonon_DP.m``.  The specimen is divided into depth slices and
+        for every scattering-angle pixel the beam is deflected, the structure
+        matrix is re-diagonalised, and the electron is propagated to the exit
+        surface.  This produces smooth, noise-free diffuse patterns (unlike the
+        MC rigid-shift approach).
+
+        Parameters
+        ----------
+        thickness : float
+            Specimen thickness [Å].
+        plasmons : MonteCarloPlasmons or MonteCarloPhonons
+            The inelastic scattering parameters.
+        num_slices : int
+            Number of depth slices (default 19).
+        dp_full : float
+            Half-extent of the output DP [mrad] (default 150).
+        dp_step : float
+            Angular pixel size [mrad] (default 0.5).
+        dp_max : float, optional
+            Maximum scattering angle [mrad].  Defaults to ``θ_c`` for plasmons
+            or ``θ_max`` for phonons.
+
+        Returns
+        -------
+        DiffractionPatterns
+        """
+        from abtem.bloch.inelastic import (
+            _phonon_probability_grid,
+            _plasmon_probability_grid,
+            _prepare_bloch_matrices,
+            calculate_deterministic_diffuse_dp,
+        )
+        from abtem.inelastic.plasmons import MonteCarloPhonons, MonteCarloPlasmons
+
+        dp_full_rad = dp_full / 1000
+        dp_step_rad = dp_step / 1000
+        dp_range = np.arange(-dp_full_rad, dp_full_rad + dp_step_rad * 0.5, dp_step_rad)
+        nDP = len(dp_range)
+
+        precomputed = _prepare_bloch_matrices(self)
+
+        if isinstance(plasmons, MonteCarloPhonons):
+            if dp_max is None:
+                dp_max = plasmons._theta_max * 1000
+            dp_max_rad = dp_max / 1000
+
+            f_func = plasmons._get_scattering_factor_func()
+            P, theta, phi, sigma_total = _phonon_probability_grid(
+                dp_range, dp_step_rad, dp_max_rad,
+                f_func, plasmons.debye_waller_factor, self.energy,
+            )
+            mfp = plasmons.mean_free_path(self.energy)
+        else:
+            theta_E_rad = plasmons.characteristic_angle(self.energy) / 1000
+            theta_c_rad = plasmons._critical_angle / 1000
+            if dp_max is None:
+                dp_max = plasmons._critical_angle
+            dp_max_rad = dp_max / 1000
+
+            P, theta, phi = _plasmon_probability_grid(
+                dp_range, dp_step_rad, theta_E_rad, theta_c_rad,
+            )
+            mfp = plasmons.mean_free_path
+
+        dp_total = calculate_deterministic_diffuse_dp(
+            self, thickness, mfp, P, theta, phi,
+            dp_range, dp_step_rad, num_slices=num_slices,
+            _precomputed=precomputed,
+        )
+
+        wavelength = energy2wavelength(self.energy)
+        K = 1.0 / wavelength
+        pixel_size_inv_A = K * dp_step_rad
+        sampling = (pixel_size_inv_A, pixel_size_inv_A)
+
+        return DiffractionPatterns(
+            array=dp_total[None],
+            sampling=sampling,
+            fftshift=True,
+            ensemble_axes_metadata=[
+                OrdinalAxis(label="energy loss", values=("Single scattering",)),
+            ],
+            metadata={
+                "energy": self.energy,
+                "label": "Intensity",
+                "units": "arb. unit",
+            },
+        )
+
     def calculate_diffraction_patterns(
         self,
         thicknesses: float | Sequence[float] | np.ndarray,

--- a/abtem/bloch/dynamical.py
+++ b/abtem/bloch/dynamical.py
@@ -56,7 +56,7 @@ from abtem.atoms import (
     validate_per_atom_property,
     validate_sigmas,
 )
-from abtem.measurements import IndexedDiffractionPatterns
+from abtem.measurements import DiffractionPatterns, IndexedDiffractionPatterns
 from abtem.parametrizations import Parametrization, validate_parametrization
 from abtem.potentials.iam import PotentialArray
 
@@ -1711,7 +1711,7 @@ class BlochWaves:
         plasmons: "MonteCarloPlasmons",
         gpts: tuple[int, int] = (256, 256),
         extent: tuple[float, float] | None = None,
-    ) -> dict:
+    ) -> "DiffractionPatterns":
         """Render a 2D diffuse-background diffraction pattern (rigid-shift model).
 
         Each Monte-Carlo configuration's exit-wave intensity is placed at
@@ -1735,16 +1735,18 @@ class BlochWaves:
 
         Returns
         -------
-        dict
-            ``"orders"`` — list of excitation orders,
-            ``"images"`` — ndarray ``(num_orders, ny, nx)``,
-            ``"weights"`` — Poisson weights ``P(n)``,
-            ``"extent"`` — the actual ``(ky_max, kx_max)`` used.
+        DiffractionPatterns
+            A ``DiffractionPatterns`` measurement with a leading ordinal axis for
+            the excitation order (``"Zero loss"``, ``"Single plasmon"``, etc.).
+            The Poisson weights ``P(n)`` and excitation orders are stored in the
+            metadata (keys ``"plasmon_weights"`` and ``"plasmon_orders"``).
+            Call ``.show()`` to visualize.
         """
         from abtem.bloch.inelastic import (
             _prepare_bloch_matrices,
             calculate_bloch_diffuse_pattern,
         )
+        from abtem.inelastic.plasmons import ntuples
 
         precomputed = _prepare_bloch_matrices(self)
         events = plasmons._draw_events(thickness=float(thickness), energy=self.energy)
@@ -1754,12 +1756,27 @@ class BlochWaves:
             _precomputed=precomputed,
         )
 
-        return {
-            "orders": orders,
-            "images": images,
-            "weights": weights,
-            "extent": actual_extent,
-        }
+        ny, nx = gpts
+        ky_max, kx_max = actual_extent
+        sampling_x = 2 * kx_max / max(nx - 1, 1)
+        sampling_y = 2 * ky_max / max(ny - 1, 1)
+
+        labels = tuple(ntuples.get(n, f"{n}-plasmon") for n in orders)
+        plasmon_axis = OrdinalAxis(label="energy loss", values=labels)
+
+        return DiffractionPatterns(
+            array=images,
+            sampling=(sampling_x, sampling_y),
+            fftshift=True,
+            ensemble_axes_metadata=[plasmon_axis],
+            metadata={
+                "energy": self.energy,
+                "label": "Intensity",
+                "units": "arb. unit",
+                "plasmon_orders": tuple(orders),
+                "plasmon_weights": weights.tolist(),
+            },
+        )
 
     def calculate_diffraction_patterns(
         self,

--- a/abtem/bloch/dynamical.py
+++ b/abtem/bloch/dynamical.py
@@ -40,7 +40,7 @@ from abtem.bloch.utils import (
 )
 from abtem.core import config
 from abtem.core.axes import AxisMetadata, NonLinearAxis, OrdinalAxis, ThicknessAxis
-from abtem.core.backend import cp, get_array_module, validate_device
+from abtem.core.backend import asnumpy, cp, get_array_module, validate_device
 from abtem.core.chunks import Chunks, equal_sized_chunks, validate_chunks
 from abtem.core.complex import abs2, complex_exponential
 from abtem.core.constants import kappa
@@ -1667,7 +1667,7 @@ class BlochWaves:
 
         def _compute():
             result = self._calculate_plasmon_eager(thicknesses, plasmons)
-            return np.asarray(result.array)
+            return asnumpy(result.array)
 
         array = da.from_delayed(
             dask.delayed(_compute)(),
@@ -2518,7 +2518,7 @@ class BlochwaveEnsemble(Ensemble, CopyMixin):
 
         for idx, (bw, dp) in all_results.items():
             dp_orders = dp.metadata["plasmon_orders"]
-            dp_array = np.asarray(dp.array)
+            dp_array = xp.asarray(dp.array)
             for j, n in enumerate(dp_orders):
                 i = order_index[n]
                 if scalar_thickness:

--- a/abtem/bloch/dynamical.py
+++ b/abtem/bloch/dynamical.py
@@ -2175,8 +2175,11 @@ class BlochwaveEnsemble(Ensemble, CopyMixin):
         orientation_matrices = np.eye(3)
         for axes, rotation in zip(self.axes[::-1], self.rotations[::-1]):
             if hasattr(rotation, "values"):
+                angles = rotation.values
+                if angles.ndim == 1 and len(axes) == 1:
+                    angles = angles[:, None]
                 R = Rotation.from_euler(
-                    axes, rotation.values, degrees=self._use_degrees
+                    axes, angles, degrees=self._use_degrees
                 ).as_matrix()
                 R = R[(slice(None),) + (None,) * (orientation_matrices.ndim - 2)]
             else:

--- a/abtem/bloch/dynamical.py
+++ b/abtem/bloch/dynamical.py
@@ -958,7 +958,7 @@ def calculate_structure_matrix(
 
     Mii = xp.asarray(Mii)
 
-    A *= prefactor * Mii[None] * Mii[:, None]
+    A = A * (prefactor * Mii[None] * Mii[:, None])
 
     set_structure_matrix_diagonal(
         A, g, Mii, energy, beam_direction=beam_direction, use_wave_eq=use_wave_eq

--- a/abtem/bloch/dynamical.py
+++ b/abtem/bloch/dynamical.py
@@ -39,7 +39,7 @@ from abtem.bloch.utils import (
     retrieve_structure_factor_values,
 )
 from abtem.core import config
-from abtem.core.axes import AxisMetadata, NonLinearAxis, ThicknessAxis
+from abtem.core.axes import AxisMetadata, NonLinearAxis, OrdinalAxis, ThicknessAxis
 from abtem.core.backend import cp, get_array_module, validate_device
 from abtem.core.chunks import Chunks, equal_sized_chunks, validate_chunks
 from abtem.core.complex import abs2, complex_exponential
@@ -66,7 +66,7 @@ if cp is not None:
 from abtem.waves import Waves
 
 if TYPE_CHECKING:
-    pass
+    from abtem.inelastic.plasmons import MonteCarloPlasmons
 
 
 def calculate_scattering_factors(
@@ -845,6 +845,55 @@ def calculate_M_matrix(
     return Mii
 
 
+def set_structure_matrix_diagonal(
+    A: np.ndarray,
+    g: np.ndarray,
+    Mii: np.ndarray,
+    energy: float,
+    beam_direction: Optional[np.ndarray] = None,
+    use_wave_eq: bool = False,
+) -> np.ndarray:
+    """Set the diagonal of a structure matrix in place from the excitation errors.
+
+    Only the diagonal of the structure matrix depends on the incident-beam direction
+    (through the excitation errors ``sg``); the off-diagonal structure-factor block is
+    beam-independent. This is used to cheaply re-form the structure matrix after an
+    inelastic deflection without re-retrieving the structure factors, following Mendis
+    (Acta Cryst. A80, 2024).
+
+    Parameters
+    ----------
+    A : np.ndarray
+        The structure matrix (modified in place). Its off-diagonal entries are left
+        untouched.
+    g : np.ndarray
+        The reciprocal space vectors [1/Å] of the selected beams, shape (N, 3).
+    Mii : np.ndarray
+        The diagonal of the M matrix for the selected beams, shape (N,).
+    energy : float
+        The energy of the electrons [eV].
+    beam_direction : np.ndarray, optional
+        The incident-beam direction. Default is None (beam along ``z``).
+    use_wave_eq : bool
+        If True, the excitation errors derived from the wave equation are used.
+
+    Returns
+    -------
+    np.ndarray
+        The structure matrix ``A`` with its diagonal set.
+    """
+    xp = get_array_module(A)
+    sg = xp.asarray(
+        excitation_errors(
+            g, energy, use_wave_eq=use_wave_eq, beam_direction=beam_direction
+        )
+    )
+    diag = 2 * 1 / energy2wavelength(energy) * sg
+    diag *= Mii
+    xp.fill_diagonal(A, diag)
+    return A
+
+
 def calculate_structure_matrix(
     structure_factor: np.ndarray,
     hkl: np.ndarray,
@@ -853,6 +902,7 @@ def calculate_structure_matrix(
     energy: float,
     gpts: tuple[int, int, int],
     use_wave_eq: bool = False,
+    beam_direction: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     """Calculate the structure matrix for a given set of reciprocal space vectors.
 
@@ -875,6 +925,10 @@ def calculate_structure_matrix(
     use_wave_eq : bool
         If True, the Bloch wave equation derived from the wave equation is used.
         Otherwise standard Bloch wave is used.
+    beam_direction : np.ndarray, optional
+        The incident-beam direction as a length-3 vector. Default is None (beam along
+        the surface normal ``z``). A tilted direction modifies only the diagonal
+        (excitation errors), used after an inelastic deflection.
 
     Returns
     -------
@@ -906,11 +960,9 @@ def calculate_structure_matrix(
 
     A *= prefactor * Mii[None] * Mii[:, None]
 
-    sg = xp.asarray(excitation_errors(g, energy, use_wave_eq=use_wave_eq))
-    diag = 2 * 1 / energy2wavelength(energy) * sg
-    diag *= Mii
-
-    xp.fill_diagonal(A, diag)
+    set_structure_matrix_diagonal(
+        A, g, Mii, energy, beam_direction=beam_direction, use_wave_eq=use_wave_eq
+    )
     return A
 
 
@@ -1507,11 +1559,214 @@ class BlochWaves:
 
         return array
 
+    def _calculate_plasmon_eager(
+        self,
+        thicknesses: float | Sequence[float] | np.ndarray,
+        plasmons: "MonteCarloPlasmons",
+    ) -> IndexedDiffractionPatterns:
+        from abtem.bloch.inelastic import (
+            _prepare_bloch_matrices,
+            calculate_bloch_plasmon_intensities,
+        )
+        from abtem.inelastic.plasmons import ntuples
+
+        thickness_array = np.atleast_1d(np.array(thicknesses, dtype=get_dtype()))
+        scalar_thickness = np.array(thicknesses).ndim == 0
+
+        precomputed = _prepare_bloch_matrices(self)
+
+        all_orders_set: set[int] = set()
+        per_thickness: list[tuple] = []
+        for t in thickness_array:
+            events = plasmons._draw_events(thickness=float(t), energy=self.energy)
+            orders, intensities, weights = calculate_bloch_plasmon_intensities(
+                self, events, float(t), _precomputed=precomputed,
+            )
+            per_thickness.append((orders, intensities, weights))
+            all_orders_set.update(orders)
+
+        all_orders = sorted(all_orders_set)
+        num_beams = len(self.hkl)
+
+        xp = get_array_module(self.device)
+        shape = (len(all_orders), len(thickness_array), num_beams)
+        combined = xp.zeros(shape, dtype=get_dtype())
+        combined_weights = np.zeros((len(all_orders), len(thickness_array)),
+                                    dtype=get_dtype())
+
+        order_index = {n: i for i, n in enumerate(all_orders)}
+        for t_idx, (orders, intensities, weights) in enumerate(per_thickness):
+            for j, n in enumerate(orders):
+                i = order_index[n]
+                combined[i, t_idx] = intensities[j]
+                combined_weights[i, t_idx] = weights[j]
+
+        labels = tuple(ntuples.get(n, f"{n}-plasmon") for n in all_orders)
+        plasmon_axis = OrdinalAxis(label="energy loss", values=labels)
+
+        ensemble_axes_metadata: list[AxisMetadata] = [plasmon_axis]
+        reciprocal_lattice_vectors = reciprocal_cell(self.cell)[None, None]
+
+        if scalar_thickness:
+            combined = combined[:, 0, :]
+            combined_weights = combined_weights[:, 0]
+            reciprocal_lattice_vectors = reciprocal_lattice_vectors[:, 0]
+        else:
+            ensemble_axes_metadata.append(
+                ThicknessAxis(
+                    label="z", units="Å",
+                    values=tuple(float(t) for t in thickness_array),
+                )
+            )
+
+        return IndexedDiffractionPatterns(
+            miller_indices=self.hkl,
+            array=combined,
+            reciprocal_lattice_vectors=reciprocal_lattice_vectors,
+            ensemble_axes_metadata=ensemble_axes_metadata,
+            metadata={
+                "energy": self.energy,
+                "sg_max": self.sg_max,
+                "g_max": self.g_max,
+                "label": "Intensity",
+                "units": "arb. unit",
+                "plasmon_orders": tuple(all_orders),
+                "plasmon_weights": combined_weights.tolist(),
+            },
+        )
+
+    def _calculate_plasmon_diffraction_patterns(
+        self,
+        thicknesses: float | Sequence[float] | np.ndarray,
+        plasmons: "MonteCarloPlasmons",
+        return_complex: bool = False,
+        lazy: bool = False,
+    ) -> IndexedDiffractionPatterns:
+        from abtem.inelastic.plasmons import ntuples
+
+        if return_complex:
+            raise ValueError(
+                "return_complex is not supported with plasmons (the inelastic average "
+                "is incoherent)."
+            )
+
+        if not lazy:
+            return self._calculate_plasmon_eager(thicknesses, plasmons)
+
+        import dask
+
+        thickness_array = np.atleast_1d(np.array(thicknesses, dtype=get_dtype()))
+        scalar_thickness = np.array(thicknesses).ndim == 0
+        all_orders = list(plasmons._num_excitations)
+        num_beams = len(self.hkl)
+
+        if scalar_thickness:
+            out_shape = (len(all_orders), num_beams)
+        else:
+            out_shape = (len(all_orders), len(thickness_array), num_beams)
+
+        def _compute():
+            result = self._calculate_plasmon_eager(thicknesses, plasmons)
+            return np.asarray(result.array)
+
+        array = da.from_delayed(
+            dask.delayed(_compute)(),
+            shape=out_shape,
+            dtype=get_dtype(),
+        )
+
+        labels = tuple(ntuples.get(n, f"{n}-plasmon") for n in all_orders)
+        plasmon_axis = OrdinalAxis(label="energy loss", values=labels)
+        ensemble_axes_metadata: list[AxisMetadata] = [plasmon_axis]
+        reciprocal_lattice_vectors = reciprocal_cell(self.cell)[None, None]
+
+        if scalar_thickness:
+            reciprocal_lattice_vectors = reciprocal_lattice_vectors[:, 0]
+        else:
+            ensemble_axes_metadata.append(
+                ThicknessAxis(
+                    label="z", units="Å",
+                    values=tuple(float(t) for t in thickness_array),
+                )
+            )
+
+        return IndexedDiffractionPatterns(
+            miller_indices=self.hkl,
+            array=array,
+            reciprocal_lattice_vectors=reciprocal_lattice_vectors,
+            ensemble_axes_metadata=ensemble_axes_metadata,
+            metadata={
+                "energy": self.energy,
+                "sg_max": self.sg_max,
+                "g_max": self.g_max,
+                "label": "Intensity",
+                "units": "arb. unit",
+                "plasmon_orders": tuple(all_orders),
+            },
+        )
+
+    def calculate_diffuse_diffraction_pattern(
+        self,
+        thickness: float,
+        plasmons: "MonteCarloPlasmons",
+        gpts: tuple[int, int] = (256, 256),
+        extent: tuple[float, float] | None = None,
+    ) -> dict:
+        """Render a 2D diffuse-background diffraction pattern (rigid-shift model).
+
+        Each Monte-Carlo configuration's exit-wave intensity is placed at
+        reciprocal-space positions **shifted** by the transverse component of the
+        accumulated beam tilt after all inelastic events. Averaging over
+        configurations creates a diffuse halo around each Bragg spot whose width
+        grows with excitation order [Mendis (2024), Sec. 2].
+
+        Parameters
+        ----------
+        thickness : float
+            The specimen thickness [Å].
+        plasmons : MonteCarloPlasmons
+            The Monte-Carlo plasmon (or phonon) scattering parameters.
+        gpts : tuple of int
+            Grid dimensions ``(ny, nx)`` for the output images.
+        extent : tuple of float, optional
+            Reciprocal-space half-extent ``(ky_max, kx_max)`` [1/Å] so the images
+            span ``[-ky_max, ky_max] × [-kx_max, kx_max]``. Defaults to 1.2 ×
+            the maximum g-vector length.
+
+        Returns
+        -------
+        dict
+            ``"orders"`` — list of excitation orders,
+            ``"images"`` — ndarray ``(num_orders, ny, nx)``,
+            ``"weights"`` — Poisson weights ``P(n)``,
+            ``"extent"`` — the actual ``(ky_max, kx_max)`` used.
+        """
+        from abtem.bloch.inelastic import (
+            _prepare_bloch_matrices,
+            calculate_bloch_diffuse_pattern,
+        )
+
+        precomputed = _prepare_bloch_matrices(self)
+        events = plasmons._draw_events(thickness=float(thickness), energy=self.energy)
+
+        orders, images, weights, actual_extent = calculate_bloch_diffuse_pattern(
+            self, events, float(thickness), gpts=gpts, extent=extent,
+            _precomputed=precomputed,
+        )
+
+        return {
+            "orders": orders,
+            "images": images,
+            "weights": weights,
+            "extent": actual_extent,
+        }
+
     def calculate_diffraction_patterns(
         self,
         thicknesses: float | Sequence[float] | np.ndarray,
         return_complex: bool = False,
         lazy: bool = True,
+        plasmons: Optional["MonteCarloPlasmons"] = None,
     ) -> IndexedDiffractionPatterns:
         """Calculate the dynamical diffraction patterns for a given set of thicknesses.
 
@@ -1525,12 +1780,25 @@ class BlochWaves:
         lazy : bool
             If True, the calculation is done lazily using dask. If False,
             the calculation is done eagerly.
+        plasmons : MonteCarloPlasmons, optional
+            If provided, inelastic plasmon scattering is included using the combined
+            Bloch wave--Monte Carlo method of Mendis (Acta Cryst. A80, 2024). The
+            returned patterns gain a leading ordinal axis resolved by excitation order
+            (energy loss): ``"Zero loss"``, ``"Single plasmon"``, etc. Each pattern is
+            the incoherent average of ``|phi_g|^2`` over Monte-Carlo configurations of
+            that order; the Poisson weights ``P(n)`` are stored in the metadata.
+            Both ``lazy=True`` and ``lazy=False`` are supported with ``plasmons``.
 
         Returns
         -------
         IndexedDiffractionPatterns
             The dynamical diffraction patterns.
         """
+        if plasmons is not None:
+            return self._calculate_plasmon_diffraction_patterns(
+                thicknesses, plasmons, return_complex=return_complex, lazy=lazy,
+            )
+
         ensemble_axes_metadata: list[AxisMetadata]
         if isinstance(thicknesses, (int, float)):
             ensemble_axes_metadata = []
@@ -2165,12 +2433,128 @@ class BlochwaveEnsemble(Ensemble, CopyMixin):
         )
         return out, hkl_mask
 
+    def _calculate_plasmon_diffraction_ensemble(
+        self,
+        thicknesses: float | Sequence[float] | np.ndarray,
+        plasmons: "MonteCarloPlasmons",
+        pbar: Optional[bool] = None,
+    ) -> IndexedDiffractionPatterns:
+        """Calculate inelastic diffraction patterns for all orientations in the ensemble.
+
+        For each orientation a ``BlochWaves`` is constructed and
+        ``calculate_diffraction_patterns(plasmons=...)`` is called. The results are mapped
+        into the unified beam set (``get_ensemble_hkl_mask``) and stacked along the
+        orientation axes. The returned array has shape
+        ``(*ensemble_shape, num_orders, [num_thicknesses,] num_beams)``.
+        """
+        from abtem.inelastic.plasmons import ntuples
+
+        if pbar is None:
+            pbar = config.get("local_diagnostics.task_level_progress", False)
+
+        thickness_array = np.atleast_1d(np.array(thicknesses, dtype=get_dtype()))
+        scalar_thickness = np.array(thicknesses).ndim == 0
+
+        hkl_mask = self.get_ensemble_hkl_mask()
+        orientation_matrices = self.get_orientation_matrices()
+
+        pbar_obj = TqdmWrapper(
+            enabled=pbar,
+            total=int(np.prod(orientation_matrices.shape[:-2])),
+            leave=False,
+        )
+
+        # First pass to collect orders across all orientations.
+        all_results: dict[tuple, IndexedDiffractionPatterns] = {}
+        all_orders_set: set[int] = set()
+        for idx in np.ndindex(orientation_matrices.shape[:-2]):
+            bw = BlochWaves(
+                structure_factor=self._structure_factor,
+                energy=self.energy,
+                sg_max=self.sg_max,
+                g_max=self.g_max,
+                orientation_matrix=orientation_matrices[idx],
+                centering=self.centering,
+                device=self.device,
+                use_wave_eq=self._use_wave_eq,
+            )
+            dp = bw.calculate_diffraction_patterns(thicknesses, plasmons=plasmons)
+            all_results[idx] = (bw, dp)
+            all_orders_set.update(dp.metadata["plasmon_orders"])
+            pbar_obj.update_if_exists(1)
+
+        pbar_obj.close_if_exists()
+
+        all_orders = sorted(all_orders_set)
+        order_index = {n: i for i, n in enumerate(all_orders)}
+
+        xp = get_array_module(self.device)
+        if scalar_thickness:
+            result_shape = orientation_matrices.shape[:-2] + (
+                len(all_orders), int(hkl_mask.sum()),
+            )
+        else:
+            result_shape = orientation_matrices.shape[:-2] + (
+                len(all_orders), len(thickness_array), int(hkl_mask.sum()),
+            )
+        array = xp.zeros(result_shape, dtype=get_dtype())
+
+        for idx, (bw, dp) in all_results.items():
+            dp_orders = dp.metadata["plasmon_orders"]
+            dp_array = np.asarray(dp.array)
+            for j, n in enumerate(dp_orders):
+                i = order_index[n]
+                if scalar_thickness:
+                    array[idx + (i,)][..., bw.hkl_mask[hkl_mask]] = dp_array[j]
+                else:
+                    array[idx + (i,)][..., bw.hkl_mask[hkl_mask]] = dp_array[j]
+
+        labels = tuple(ntuples.get(n, f"{n}-plasmon") for n in all_orders)
+        plasmon_axis = OrdinalAxis(label="energy loss", values=labels)
+
+        ensemble_axes_metadata: list[AxisMetadata] = [
+            *self.ensemble_axes_metadata,
+            plasmon_axis,
+        ]
+
+        hkl = self.structure_factor.hkl[hkl_mask]
+        reciprocal_lattice_vectors = np.matmul(
+            reciprocal_cell(self.structure_factor.cell)[None],
+            np.swapaxes(orientation_matrices, -2, -1),
+        )
+        # Add broadcast dims for (orders, [thicknesses]) axes.
+        reciprocal_lattice_vectors = reciprocal_lattice_vectors[..., None, :, :]
+        if not scalar_thickness:
+            ensemble_axes_metadata.append(
+                ThicknessAxis(
+                    label="z", units="Å",
+                    values=tuple(float(t) for t in thickness_array),
+                )
+            )
+            reciprocal_lattice_vectors = reciprocal_lattice_vectors[..., None, :, :]
+
+        return IndexedDiffractionPatterns(
+            array=array,
+            miller_indices=hkl,
+            reciprocal_lattice_vectors=reciprocal_lattice_vectors,
+            ensemble_axes_metadata=ensemble_axes_metadata,
+            metadata={
+                "label": "Intensity",
+                "units": "arb. unit",
+                "energy": self.energy,
+                "sg_max": self.sg_max,
+                "g_max": self.g_max,
+                "plasmon_orders": tuple(all_orders),
+            },
+        )
+
     def calculate_diffraction_patterns(
         self,
         thicknesses: float | Sequence[float] | np.ndarray,
         return_complex: bool = False,
         lazy: bool = True,
         pbar: Optional[bool] = None,
+        plasmons: Optional["MonteCarloPlasmons"] = None,
     ) -> IndexedDiffractionPatterns:
         """Calculate the dynamical diffraction patterns of the ensemble for a given set
         of thicknesses.
@@ -2188,12 +2572,20 @@ class BlochwaveEnsemble(Ensemble, CopyMixin):
         pbar : bool
             If True, a progress bar is shown. Default is None, which means the value is
             taken from the configuration.
+        plasmons : MonteCarloPlasmons, optional
+            If provided, inelastic plasmon scattering is included via the combined
+            Bloch wave--Monte Carlo method.
 
         Returns
         -------
         IndexedDiffractionPatterns
             The diffraction patterns.
         """
+
+        if plasmons is not None:
+            return self._calculate_plasmon_diffraction_ensemble(
+                thicknesses, plasmons, pbar=pbar,
+            )
 
         if pbar is None:
             pbar = config.get("local_diagnostics.task_level_progress", False)

--- a/abtem/bloch/inelastic.py
+++ b/abtem/bloch/inelastic.py
@@ -1,0 +1,392 @@
+"""Bloch-wave + Monte-Carlo inelastic (plasmon/phonon) scattering.
+
+This implements the combined Bloch wave--Monte Carlo method of B. G. Mendis,
+"Modelling dynamical 3D electron diffraction intensities. II. The role of inelastic
+scattering", Acta Cryst. A80 (2024).
+
+The elastic dynamical scattering is carried by the Bloch waves (diagonalize the
+structure matrix once and propagate analytically). Inelastic scattering is a chain of
+discrete Monte-Carlo events: between events the electron propagates elastically, and at
+each event the incident wavevector is deflected by a sampled (polar, azimuthal) angle.
+After a deflection only the diagonal of the structure matrix (the excitation errors)
+changes [Mendis Eq. 12], so the off-diagonal structure-factor block is reused and the
+matrix is cheaply re-diagonalized. The diffracted intensities ``|phi_g|^2`` are
+incoherently averaged over many sampled configurations [Mendis Eq. 15].
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import TYPE_CHECKING, Optional
+
+import numpy as np
+
+from abtem.bloch.dynamical import (
+    plane_wave_coefficients,
+    set_structure_matrix_diagonal,
+)
+from abtem.bloch.utils import calculate_g_vec
+from abtem.core.backend import get_array_module
+from abtem.core.complex import abs2
+from abtem.core.energy import energy2wavelength
+
+if TYPE_CHECKING:
+    from abtem.bloch.dynamical import BlochWaves
+    from abtem.inelastic.plasmons import MonteCarloPlasmons, PlasmonScatteringEvents
+
+
+def _rotation_y(theta: float) -> np.ndarray:
+    """Rotation tilting the z axis towards x by the polar angle ``theta`` [rad]."""
+    c, s = np.cos(theta), np.sin(theta)
+    return np.array([[c, 0.0, s], [0.0, 1.0, 0.0], [-s, 0.0, c]])
+
+
+def _rotation_z(phi: float) -> np.ndarray:
+    """Rotation about the z axis by the azimuthal angle ``phi`` [rad]."""
+    c, s = np.cos(phi), np.sin(phi)
+    return np.array([[c, -s, 0.0], [s, c, 0.0], [0.0, 0.0, 1.0]])
+
+
+def _deflect(rotation: np.ndarray, theta: float, phi: float) -> np.ndarray:
+    """Compose a deflection by (polar ``theta``, azimuthal ``phi``) onto the cumulative
+    rotation, applied in the current (post-deflection) electron frame.
+
+    The polar and azimuthal angles are defined with respect to the electron trajectory
+    prior to the scattering event, so successive deflections compose as intrinsic
+    rotations (Mendis 2024, Sec. 2; Euler-rotation tracking).
+    """
+    return rotation @ _rotation_z(phi) @ _rotation_y(theta)
+
+
+def _chain_one_configuration(
+    A_base: np.ndarray,
+    g: np.ndarray,
+    Mii: np.ndarray,
+    hkl: np.ndarray,
+    energy: float,
+    use_wave_eq: bool,
+    thickness: float,
+    depths: tuple[float, ...],
+    radial_angles: tuple[float, ...],
+    azimuthal_angles: tuple[float, ...],
+    _untilted_eig: tuple | None = None,
+) -> np.ndarray:
+    """Propagate a single Monte-Carlo scattering configuration through the crystal and
+    return the exit Bloch amplitudes ``phi_g``.
+
+    The electron starts as a plane wave (delta at ``000``) and propagates elastically
+    between events [Mendis Eq. 13]. At each event the incident-beam direction is
+    deflected, the structure-matrix diagonal is re-formed for the new direction
+    [Eq. 12], and propagation continues to the next event or the exit surface [Eq. 14].
+
+    Parameters
+    ----------
+    _untilted_eig : tuple, optional
+        Pre-computed ``(eigenvalues, eigenvectors)`` of the untilted structure matrix.
+        Avoids a redundant ``eigh`` for the first (pre-deflection) segment.
+    """
+    xp = get_array_module(A_base)
+    wavelength = energy2wavelength(energy)
+
+    phi = plane_wave_coefficients(hkl, xp)
+
+    rotation = np.eye(3)
+    beam_direction: Optional[np.ndarray] = None  # None == along z, exact legacy values
+    z_prev = 0.0
+    _z_hat = np.array([0.0, 0.0, 1.0])
+
+    def _propagate_eig(dz, v, C, amplitudes):
+        """Propagate using pre-computed eigendecomposition."""
+        phase = xp.exp(1.0j * xp.pi * dz * wavelength * v)
+        psi = amplitudes / Mii
+        psi = C @ (phase * (C.conj().T @ psi))
+        return Mii * psi
+
+    def propagate(dz: float, direction: Optional[np.ndarray], amplitudes):
+        if dz <= 0.0:
+            return amplitudes
+        A = A_base.copy()
+        set_structure_matrix_diagonal(
+            A, g, Mii, energy, beam_direction=direction, use_wave_eq=use_wave_eq
+        )
+        v, C = xp.linalg.eigh(A)
+        return _propagate_eig(dz, v, C, amplitudes)
+
+    if len(depths) == 0:
+        # No events — propagate full thickness with the untilted matrix.
+        if _untilted_eig is not None:
+            phi = _propagate_eig(thickness, *_untilted_eig, phi)
+        else:
+            phi = propagate(thickness, None, phi)
+        return phi, beam_direction
+
+    # First segment: use pre-computed eigendecomposition if available.
+    first_dz = depths[0]
+    if first_dz > 0.0:
+        if _untilted_eig is not None:
+            phi = _propagate_eig(first_dz, *_untilted_eig, phi)
+        else:
+            phi = propagate(first_dz, None, phi)
+
+    rotation = _deflect(rotation, radial_angles[0], azimuthal_angles[0])
+    beam_direction = rotation @ _z_hat
+    z_prev = depths[0]
+
+    for depth, theta, azimuth in zip(
+        depths[1:], radial_angles[1:], azimuthal_angles[1:]
+    ):
+        phi = propagate(depth - z_prev, beam_direction, phi)
+        rotation = _deflect(rotation, theta, azimuth)
+        beam_direction = rotation @ _z_hat
+        z_prev = depth
+
+    phi = propagate(thickness - z_prev, beam_direction, phi)
+    return phi, beam_direction
+
+
+def _prepare_bloch_matrices(bloch_waves: "BlochWaves"):
+    """Build the beam-independent matrices once and return them for reuse across
+    thicknesses."""
+    from abtem.bloch.dynamical import calculate_M_matrix
+
+    xp = get_array_module(bloch_waves.device)
+
+    hkl = bloch_waves.hkl
+    cell = bloch_waves.cell
+    energy = bloch_waves.energy
+
+    A_base = xp.asarray(bloch_waves.calculate_structure_matrix(lazy=False))
+    g = xp.asarray(calculate_g_vec(hkl, cell))
+    Mii = xp.asarray(calculate_M_matrix(hkl, cell, energy))
+
+    return A_base, g, Mii
+
+
+def _precompute_untilted_eig(A_base, g, Mii, energy, use_wave_eq, xp):
+    """Eigendecompose the untilted structure matrix once for reuse across all configs."""
+    A = A_base.copy()
+    set_structure_matrix_diagonal(
+        A, g, Mii, energy, beam_direction=None, use_wave_eq=use_wave_eq
+    )
+    v, C = xp.linalg.eigh(A)
+    return (v, C)
+
+
+def calculate_bloch_plasmon_intensities(
+    bloch_waves: "BlochWaves",
+    events: "PlasmonScatteringEvents",
+    thickness: float,
+    _precomputed: tuple | None = None,
+) -> tuple[list[int], np.ndarray, np.ndarray]:
+    """Incoherently average the Bloch-wave diffracted intensities over Monte-Carlo
+    inelastic scattering configurations, resolved by excitation order (energy loss)
+    [Mendis Eq. 15].
+
+    Within each excitation order ``n`` the randomly sampled configurations are averaged
+    without further weighting (the random sampling already follows the scattering
+    probability distributions; Mendis 2024, "alternative" to Eq. 15). The Poisson
+    probability ``P(n)`` of exactly ``n`` excitations is returned separately so that the
+    energy-filtered patterns can be combined into the total (unfiltered) pattern as
+    ``sum_n P(n) I^(n)``.
+
+    Parameters
+    ----------
+    bloch_waves : BlochWaves
+        The Bloch-wave object providing the (beam-independent) structure-factor block,
+        the beam set, the unit cell and the electron energy.
+    events : PlasmonScatteringEvents
+        The sampled scattering configurations (depths, polar/azimuthal angles, weights).
+    thickness : float
+        The specimen thickness [Å].
+    _precomputed : tuple, optional
+        ``(A_base, g, Mii)`` from :func:`_prepare_bloch_matrices`; avoids rebuilding
+        the structure matrix on every call when looping over thicknesses.
+
+    Returns
+    -------
+    orders : list of int
+        The excitation orders present, in increasing order.
+    intensities : np.ndarray
+        The energy-filtered diffracted intensities ``I^(n)_g`` averaged within each
+        order, shape ``(len(orders), num_beams)``.
+    weights : np.ndarray
+        The Poisson weight ``P(n)`` of each order, shape ``(len(orders),)``.
+    """
+    xp = get_array_module(bloch_waves.device)
+
+    hkl = bloch_waves.hkl
+    energy = bloch_waves.energy
+    use_wave_eq = bloch_waves.use_wave_eq
+
+    if _precomputed is not None:
+        A_base, g, Mii = _precomputed
+    else:
+        A_base, g, Mii = _prepare_bloch_matrices(bloch_waves)
+
+    # Pre-compute eigendecomposition of the untilted structure matrix — reused for
+    # every order-0 config and for the first (pre-deflection) segment of every
+    # higher-order config, saving one eigh per configuration.
+    untilted_eig = _precompute_untilted_eig(A_base, g, Mii, energy, use_wave_eq, xp)
+
+    num_excitations = events.num_excitations
+    order_counts = Counter(num_excitations)
+    orders = sorted(order_counts)
+
+    real_dtype = A_base.real.dtype
+    order_index = {n: i for i, n in enumerate(orders)}
+    accumulated = xp.zeros((len(orders), len(hkl)), dtype=real_dtype)
+    weights = np.zeros(len(orders), dtype=real_dtype)
+
+    iterator = zip(
+        events.depths,
+        events.radial_angles,
+        events.azimuthal_angles,
+        events.weights,
+        num_excitations,
+    )
+    for depths, radial, azimuthal, weight, order in iterator:
+        phi, _beam_dir = _chain_one_configuration(
+            A_base=A_base,
+            g=g,
+            Mii=Mii,
+            hkl=hkl,
+            energy=energy,
+            use_wave_eq=use_wave_eq,
+            thickness=thickness,
+            depths=depths,
+            radial_angles=radial,
+            azimuthal_angles=azimuthal,
+            _untilted_eig=untilted_eig,
+        )
+        i = order_index[order]
+        accumulated[i] += abs2(phi)
+        weights[i] = weight  # P(n); identical for all configs of a given order
+
+    for n, i in order_index.items():
+        accumulated[i] /= order_counts[n]
+
+    return orders, accumulated, weights
+
+
+def calculate_bloch_diffuse_pattern(
+    bloch_waves: "BlochWaves",
+    events: "PlasmonScatteringEvents",
+    thickness: float,
+    gpts: tuple[int, int],
+    extent: tuple[float, float] | None = None,
+    _precomputed: tuple | None = None,
+) -> tuple[list[int], np.ndarray, np.ndarray]:
+    """Render a 2D diffuse-background diffraction pattern using the rigid-shift model.
+
+    For each Monte-Carlo configuration the exit Bloch amplitudes are computed
+    at the discrete Bragg positions. The rigid-shift model then places each
+    spot's intensity at its reciprocal-space position **shifted** by the
+    transverse component of the accumulated beam tilt after all inelastic
+    events in that configuration [Mendis (2024), Sec. 2]. Incoherently
+    averaging over many configurations broadens each Bragg spot into a
+    diffuse halo whose width grows with excitation order.
+
+    Parameters
+    ----------
+    bloch_waves : BlochWaves
+        The Bloch-wave object.
+    events : PlasmonScatteringEvents
+        The sampled scattering configurations.
+    thickness : float
+        The specimen thickness [Å].
+    gpts : tuple of int
+        Grid dimensions ``(ny, nx)`` for the output image.
+    extent : tuple of float, optional
+        Reciprocal-space extent ``(ky_max, kx_max)`` [1/Å] so the output spans
+        ``[-ky_max, ky_max] × [-kx_max, kx_max]``. Defaults to 1.2 × the
+        maximum g-vector length.
+    _precomputed : tuple, optional
+        ``(A_base, g, Mii)`` from :func:`_prepare_bloch_matrices`.
+
+    Returns
+    -------
+    orders : list of int
+        The excitation orders present, in increasing order.
+    images : np.ndarray
+        The rendered 2D images, shape ``(len(orders), gpts[0], gpts[1])``.
+    weights : np.ndarray
+        The Poisson weight ``P(n)`` of each order, shape ``(len(orders),)``.
+    """
+    xp = get_array_module(bloch_waves.device)
+
+    hkl = bloch_waves.hkl
+    energy = bloch_waves.energy
+    use_wave_eq = bloch_waves.use_wave_eq
+
+    if _precomputed is not None:
+        A_base, g, Mii = _precomputed
+    else:
+        A_base, g, Mii = _prepare_bloch_matrices(bloch_waves)
+
+    untilted_eig = _precompute_untilted_eig(A_base, g, Mii, energy, use_wave_eq, xp)
+
+    g_np = np.asarray(g)
+    g_xy = g_np[:, :2]
+
+    if extent is None:
+        g_max = float(np.max(np.linalg.norm(g_xy, axis=1)))
+        extent = (g_max * 1.2, g_max * 1.2)
+
+    ny, nx = gpts
+    ky_max, kx_max = extent
+
+    num_excitations = events.num_excitations
+    order_counts = Counter(num_excitations)
+    orders = sorted(order_counts)
+
+    real_dtype = A_base.real.dtype
+    order_index = {n: i for i, n in enumerate(orders)}
+    images = np.zeros((len(orders), ny, nx), dtype=real_dtype)
+    weights = np.zeros(len(orders), dtype=real_dtype)
+
+    wavelength = energy2wavelength(energy)
+    K = 1.0 / wavelength
+
+    iterator = zip(
+        events.depths,
+        events.radial_angles,
+        events.azimuthal_angles,
+        events.weights,
+        num_excitations,
+    )
+    for depths, radial, azimuthal, weight, order in iterator:
+        phi, beam_dir = _chain_one_configuration(
+            A_base=A_base,
+            g=g,
+            Mii=Mii,
+            hkl=hkl,
+            energy=energy,
+            use_wave_eq=use_wave_eq,
+            thickness=thickness,
+            depths=depths,
+            radial_angles=radial,
+            azimuthal_angles=azimuthal,
+            _untilted_eig=untilted_eig,
+        )
+        intensities = np.asarray(abs2(phi))
+
+        if beam_dir is None:
+            dk_xy = np.array([0.0, 0.0])
+        else:
+            beam_dir_np = np.asarray(beam_dir)
+            dk_xy = K * beam_dir_np[:2]
+
+        shifted_xy = g_xy + dk_xy[None, :]
+
+        ix = np.round((shifted_xy[:, 0] + kx_max) / (2 * kx_max) * (nx - 1)).astype(int)
+        iy = np.round((shifted_xy[:, 1] + ky_max) / (2 * ky_max) * (ny - 1)).astype(int)
+
+        mask = (ix >= 0) & (ix < nx) & (iy >= 0) & (iy < ny)
+        i = order_index[order]
+        np.add.at(images[i], (iy[mask], ix[mask]), intensities[mask])
+        weights[i] = weight
+
+    for n, i in order_index.items():
+        images[i] /= order_counts[n]
+
+    return orders, images, weights, extent

--- a/abtem/bloch/inelastic.py
+++ b/abtem/bloch/inelastic.py
@@ -26,7 +26,7 @@ from abtem.bloch.dynamical import (
     set_structure_matrix_diagonal,
 )
 from abtem.bloch.utils import calculate_g_vec
-from abtem.core.backend import get_array_module
+from abtem.core.backend import asnumpy, get_array_module
 from abtem.core.complex import abs2
 from abtem.core.energy import energy2wavelength
 
@@ -325,7 +325,7 @@ def calculate_bloch_diffuse_pattern(
 
     untilted_eig = _precompute_untilted_eig(A_base, g, Mii, energy, use_wave_eq, xp)
 
-    g_np = np.asarray(g)
+    g_np = asnumpy(g)
     g_xy = g_np[:, :2]
 
     if extent is None:
@@ -368,7 +368,7 @@ def calculate_bloch_diffuse_pattern(
             azimuthal_angles=azimuthal,
             _untilted_eig=untilted_eig,
         )
-        intensities = np.asarray(abs2(phi))
+        intensities = asnumpy(abs2(phi))
 
         if beam_dir is None:
             dk_xy = np.array([0.0, 0.0])

--- a/abtem/bloch/inelastic.py
+++ b/abtem/bloch/inelastic.py
@@ -252,14 +252,22 @@ def _batched_eigh_propagate(
     diags_all = (2.0 / wavelength) * sg_all * Mii[None, :]
 
     if xp is np:
-        A_batch = np.broadcast_to(A_base[None], (B, N, N)).copy()
-        idx = np.arange(N)
-        A_batch[:, idx, idx] = diags_all
-
-        A_batch = np.ascontiguousarray(A_batch, dtype=np.complex128)
         psi_np = np.ascontiguousarray(psi_in, dtype=np.complex128)
         Mii_np = np.ascontiguousarray(Mii, dtype=np.float64)
-        return _numba_eigh_propagate(A_batch, Mii_np, wavelength, dz, psi_np)
+        all_intensities = np.empty((B, N))
+        idx = np.arange(N)
+
+        for start in range(0, B, batch_size):
+            end = min(start + batch_size, B)
+            bs = end - start
+            A_chunk = np.broadcast_to(A_base[None], (bs, N, N)).copy()
+            A_chunk[:, idx, idx] = diags_all[start:end]
+            A_chunk = np.ascontiguousarray(A_chunk, dtype=np.complex128)
+            all_intensities[start:end] = _numba_eigh_propagate(
+                A_chunk, Mii_np, wavelength, dz, psi_np,
+            )
+
+        return all_intensities
 
     psi = psi_in / Mii
     all_intensities = xp.empty((B, N), dtype=A_base.real.dtype)
@@ -374,7 +382,7 @@ def calculate_bloch_diffuse_pattern(
     gpts: tuple[int, int],
     extent: tuple[float, float] | None = None,
     _precomputed: tuple | None = None,
-) -> tuple[list[int], np.ndarray, np.ndarray]:
+) -> tuple[list[int], np.ndarray, np.ndarray, tuple[float, float]]:
     """Render a 2D diffuse-background diffraction pattern using the rigid-shift model.
 
     For each Monte-Carlo configuration the exit Bloch amplitudes are computed
@@ -410,6 +418,8 @@ def calculate_bloch_diffuse_pattern(
         The rendered 2D images, shape ``(len(orders), gpts[0], gpts[1])``.
     weights : np.ndarray
         The Poisson weight ``P(n)`` of each order, shape ``(len(orders),)``.
+    extent : tuple of float
+        The actual reciprocal-space half-extent ``(ky_max, kx_max)`` [1/Å].
     """
     xp = get_array_module(bloch_waves.device)
 
@@ -664,7 +674,7 @@ def calculate_deterministic_diffuse_dp(
     dp_total : np.ndarray, shape (nDP, nDP)
         The accumulated diffuse diffraction pattern.
     """
-    import sys
+    from abtem.core.diagnostics import TqdmWrapper
 
     xp = get_array_module(bloch_waves.device)
 
@@ -723,8 +733,8 @@ def calculate_deterministic_diffuse_dp(
         psi = C @ (phase * (C.conj().T @ psi))
         return Mii * psi
 
-    total_iters = num_slices * n_active
-    done = 0
+    pbar = TqdmWrapper(enabled=None, total=num_slices, desc="Depth slices", leave=False)
+
     for a in range(num_slices):
         depth = (a + 0.5) * slice_thickness
         remaining = thickness - depth
@@ -749,15 +759,9 @@ def calculate_deterministic_diffuse_dp(
                 weight * intensities_np[b, valid],
             )
 
-        done += n_active
-        pct = 100 * done / total_iters
-        sys.stderr.write(
-            f"\r  slice {a + 1}/{num_slices}  "
-            f"({done}/{total_iters} eigh, {pct:.0f}%)"
-        )
-        sys.stderr.flush()
+        pbar.update_if_exists(1)
 
-    sys.stderr.write("\n")
+    pbar.close_if_exists()
     return dp_total
 
 

--- a/abtem/bloch/inelastic.py
+++ b/abtem/bloch/inelastic.py
@@ -172,6 +172,118 @@ def _precompute_untilted_eig(A_base, g, Mii, energy, use_wave_eq, xp):
     return (v, C)
 
 
+import numba as _numba
+
+
+@_numba.njit(parallel=True, cache=True)
+def _numba_eigh_propagate(A_batch, Mii, wavelength, dz, psi_in):
+    """Parallel eigh + propagate over a batch of tilted structure matrices."""
+    B = A_batch.shape[0]
+    N = A_batch.shape[1]
+    intensities = np.empty((B, N))
+    for b in _numba.prange(B):
+        A = np.ascontiguousarray(A_batch[b])
+        with _numba.objmode(res="float64[:]"):
+            v, C = np.linalg.eigh(A)
+            phase = np.exp(1j * np.pi * dz * wavelength * v)
+            psi = psi_in / Mii
+            beams_f = Mii * (C @ (phase * (C.conj().T @ psi)))
+            res = beams_f.real ** 2 + beams_f.imag ** 2
+        intensities[b] = res
+    return intensities
+
+
+def _batched_excitation_errors(g, beam_dirs, wavelength, use_wave_eq, xp):
+    """Vectorized excitation errors for B beam directions at once.
+
+    Parameters
+    ----------
+    g : array, shape (N, 3)
+    beam_dirs : array, shape (B, 3) — need not be normalized.
+    wavelength : float
+    use_wave_eq : bool
+
+    Returns
+    -------
+    sg : array, shape (B, N)
+    """
+    norms = xp.linalg.norm(beam_dirs, axis=-1, keepdims=True)
+    d = beam_dirs / norms
+    gn = xp.einsum("ni,bi->bn", g, d)
+    g2 = xp.sum(g * g, axis=-1)
+    if use_wave_eq:
+        sg = -gn - wavelength * (g2[None, :] - gn ** 2) / 2.0
+    else:
+        sg = -gn - wavelength * g2[None, :] / 2.0
+    return sg
+
+
+def _batched_eigh_propagate(
+    A_base, g, Mii, beam_dirs, wavelength, use_wave_eq, dz, psi_in, xp,
+    batch_size=256,
+):
+    """Build tilted A matrices, eigendecompose, and propagate — all in batches.
+
+    On GPU (CuPy) the batched ``eigh`` runs via cuSOLVER.  On CPU with numba
+    available, ``numba.prange`` parallelises the per-matrix ``eigh`` calls across
+    cores (numba's threading layer cooperates with OpenBLAS's GIL release during
+    LAPACK).  Falls back to a sequential numpy loop otherwise.
+
+    Parameters
+    ----------
+    A_base : array, shape (N, N)
+    g : array, shape (N, 3)
+    Mii : array, shape (N,)
+    beam_dirs : array, shape (B, 3)
+    wavelength : float
+    use_wave_eq : bool
+    dz : float — propagation distance.
+    psi_in : array, shape (N,) — input Bloch amplitudes.
+    batch_size : int — sub-batch size to limit GPU memory.
+
+    Returns
+    -------
+    intensities : array, shape (B, N) — ``|phi_g|^2`` for each direction.
+    """
+    B = beam_dirs.shape[0]
+    N = A_base.shape[0]
+
+    sg_all = _batched_excitation_errors(g, beam_dirs, wavelength, use_wave_eq, xp)
+    diags_all = (2.0 / wavelength) * sg_all * Mii[None, :]
+
+    if xp is np:
+        A_batch = np.broadcast_to(A_base[None], (B, N, N)).copy()
+        idx = np.arange(N)
+        A_batch[:, idx, idx] = diags_all
+
+        A_batch = np.ascontiguousarray(A_batch, dtype=np.complex128)
+        psi_np = np.ascontiguousarray(psi_in, dtype=np.complex128)
+        Mii_np = np.ascontiguousarray(Mii, dtype=np.float64)
+        return _numba_eigh_propagate(A_batch, Mii_np, wavelength, dz, psi_np)
+
+    psi = psi_in / Mii
+    all_intensities = xp.empty((B, N), dtype=A_base.real.dtype)
+
+    for start in range(0, B, batch_size):
+        end = min(start + batch_size, B)
+        bs = end - start
+
+        A_batch = xp.broadcast_to(A_base[None], (bs, N, N)).copy()
+        idx = xp.arange(N)
+        A_batch[:, idx, idx] = diags_all[start:end]
+
+        vals, vecs = xp.linalg.eigh(A_batch)
+
+        phase = xp.exp(1.0j * xp.pi * dz * wavelength * vals)
+        C_H_psi = xp.einsum("bji,j->bi", vecs.conj(), psi)
+        beams_f = Mii[None, :] * xp.einsum(
+            "bij,bj->bi", vecs, phase * C_H_psi
+        )
+        all_intensities[start:end] = abs2(beams_f)
+
+    return all_intensities
+
+
 def calculate_bloch_plasmon_intensities(
     bloch_waves: "BlochWaves",
     events: "PlasmonScatteringEvents",
@@ -223,9 +335,6 @@ def calculate_bloch_plasmon_intensities(
     else:
         A_base, g, Mii = _prepare_bloch_matrices(bloch_waves)
 
-    # Pre-compute eigendecomposition of the untilted structure matrix — reused for
-    # every order-0 config and for the first (pre-deflection) segment of every
-    # higher-order config, saving one eigh per configuration.
     untilted_eig = _precompute_untilted_eig(A_base, g, Mii, energy, use_wave_eq, xp)
 
     num_excitations = events.num_excitations
@@ -238,29 +347,19 @@ def calculate_bloch_plasmon_intensities(
     weights = np.zeros(len(orders), dtype=real_dtype)
 
     iterator = zip(
-        events.depths,
-        events.radial_angles,
-        events.azimuthal_angles,
-        events.weights,
-        num_excitations,
+        events.depths, events.radial_angles,
+        events.azimuthal_angles, events.weights, num_excitations,
     )
     for depths, radial, azimuthal, weight, order in iterator:
         phi, _beam_dir = _chain_one_configuration(
-            A_base=A_base,
-            g=g,
-            Mii=Mii,
-            hkl=hkl,
-            energy=energy,
-            use_wave_eq=use_wave_eq,
-            thickness=thickness,
-            depths=depths,
-            radial_angles=radial,
-            azimuthal_angles=azimuthal,
+            A_base=A_base, g=g, Mii=Mii, hkl=hkl,
+            energy=energy, use_wave_eq=use_wave_eq, thickness=thickness,
+            depths=depths, radial_angles=radial, azimuthal_angles=azimuthal,
             _untilted_eig=untilted_eig,
         )
         i = order_index[order]
         accumulated[i] += abs2(phi)
-        weights[i] = weight  # P(n); identical for all configs of a given order
+        weights[i] = weight
 
     for n, i in order_index.items():
         accumulated[i] /= order_counts[n]
@@ -348,24 +447,14 @@ def calculate_bloch_diffuse_pattern(
     K = 1.0 / wavelength
 
     iterator = zip(
-        events.depths,
-        events.radial_angles,
-        events.azimuthal_angles,
-        events.weights,
-        num_excitations,
+        events.depths, events.radial_angles,
+        events.azimuthal_angles, events.weights, num_excitations,
     )
     for depths, radial, azimuthal, weight, order in iterator:
         phi, beam_dir = _chain_one_configuration(
-            A_base=A_base,
-            g=g,
-            Mii=Mii,
-            hkl=hkl,
-            energy=energy,
-            use_wave_eq=use_wave_eq,
-            thickness=thickness,
-            depths=depths,
-            radial_angles=radial,
-            azimuthal_angles=azimuthal,
+            A_base=A_base, g=g, Mii=Mii, hkl=hkl,
+            energy=energy, use_wave_eq=use_wave_eq, thickness=thickness,
+            depths=depths, radial_angles=radial, azimuthal_angles=azimuthal,
             _untilted_eig=untilted_eig,
         )
         intensities = asnumpy(abs2(phi))
@@ -377,10 +466,12 @@ def calculate_bloch_diffuse_pattern(
             dk_xy = K * beam_dir_np[:2]
 
         shifted_xy = g_xy + dk_xy[None, :]
-
-        ix = np.round((shifted_xy[:, 0] + kx_max) / (2 * kx_max) * (nx - 1)).astype(int)
-        iy = np.round((shifted_xy[:, 1] + ky_max) / (2 * ky_max) * (ny - 1)).astype(int)
-
+        ix = np.round(
+            (shifted_xy[:, 0] + kx_max) / (2 * kx_max) * (nx - 1)
+        ).astype(int)
+        iy = np.round(
+            (shifted_xy[:, 1] + ky_max) / (2 * ky_max) * (ny - 1)
+        ).astype(int)
         mask = (ix >= 0) & (ix < nx) & (iy >= 0) & (iy < ny)
         i = order_index[order]
         np.add.at(images[i], (iy[mask], ix[mask]), intensities[mask])
@@ -390,3 +481,435 @@ def calculate_bloch_diffuse_pattern(
         images[i] /= order_counts[n]
 
     return orders, images, weights, extent
+
+
+# ---------------------------------------------------------------------------
+# Deterministic depth-slice integration (Mendis Matlab approach)
+# ---------------------------------------------------------------------------
+
+
+def _plasmon_probability_grid(dp_range_rad, dp_step_rad, theta_E_rad, theta_c_rad):
+    """Build 2D plasmon Lorentzian scattering probability grid.
+
+    Follows the angular discretisation in ``Bloch_plasmon_DP.m``.
+
+    Parameters
+    ----------
+    dp_range_rad : np.ndarray
+        1D array of angular pixel positions [rad], e.g. ``np.arange(-0.15, 0.1505, 0.0005)``.
+    dp_step_rad : float
+        Angular pixel size [rad].
+    theta_E_rad : float
+        Characteristic plasmon scattering angle [rad].
+    theta_c_rad : float
+        Critical (cutoff) plasmon scattering angle [rad].
+
+    Returns
+    -------
+    P : np.ndarray, shape (nDP, nDP)
+        Scattering probability per pixel (sums to ~1 over the active region).
+    theta : np.ndarray, shape (nDP, nDP)
+        Polar scattering angle [rad] for each pixel.
+    phi : np.ndarray, shape (nDP, nDP)
+        Azimuthal scattering angle [rad] for each pixel.
+    """
+    nDP = len(dp_range_rad)
+    dtheta = np.sqrt(2) * dp_step_rad
+    theta_ratio_sq = (theta_c_rad / theta_E_rad) ** 2
+    log_norm = np.log(1 + theta_ratio_sq)
+
+    angle_x = dp_range_rad[:, None]
+    angle_y = dp_range_rad[None, :]
+    kt = np.sqrt(angle_x ** 2 + angle_y ** 2)
+
+    mask = (kt > 0) & (kt < theta_c_rad)
+    dphi = np.where(kt > 0, np.minimum(dtheta / kt, 2 * np.pi), 0.0)
+    P_theta = 2 * kt * dtheta / (kt ** 2 + theta_E_rad ** 2) / log_norm
+    P_phi = dphi / (2 * np.pi)
+    P = np.where(mask, P_theta * P_phi, 0.0)
+
+    phi = np.arctan2(angle_y, angle_x)
+    phi = np.where(phi < 0, phi + 2 * np.pi, phi)
+
+    return P, kt, phi
+
+
+def _phonon_probability_grid(
+    dp_range_rad,
+    dp_step_rad,
+    dp_max_rad,
+    scattering_factor_func,
+    debye_waller_factor,
+    energy,
+):
+    """Build 2D phonon (TDS) scattering probability grid.
+
+    Follows the angular discretisation in ``Bloch_phonon_DP.m``.
+
+    Parameters
+    ----------
+    dp_range_rad : np.ndarray
+        1D angular pixel positions [rad].
+    dp_step_rad : float
+        Angular pixel size [rad].
+    dp_max_rad : float
+        Maximum scattering angle [rad].
+    scattering_factor_func : callable
+        Electron scattering factor ``f(g²)`` [1/Å].
+    debye_waller_factor : float
+        Isotropic Debye–Waller factor ``B = 8π²⟨u²⟩`` [Å²].
+    energy : float
+        Electron energy [eV].
+
+    Returns
+    -------
+    P : np.ndarray, shape (nDP, nDP)
+    theta : np.ndarray, shape (nDP, nDP)
+    phi : np.ndarray, shape (nDP, nDP)
+    sigma_total : float
+        Total TDS cross-section (for MFP calculation).
+    """
+    from scipy.interpolate import interp1d
+
+    from abtem.inelastic.plasmons import _tds_differential_cross_section
+
+    wavelength = energy2wavelength(energy)
+    K = 1.0 / wavelength
+
+    qc_mrad = dp_max_rad * 1000
+    theta_1d_mrad = np.arange(0.5, qc_mrad + 1.0, 1.0)
+    theta_1d_rad = theta_1d_mrad / 1000
+
+    dsigma = _tds_differential_cross_section(
+        theta_1d_rad, scattering_factor_func, debye_waller_factor, energy,
+    )
+    sigma_p = 2 * np.pi * dsigma * np.sin(theta_1d_rad)
+    sigma_total = float(np.sum(sigma_p) * 1e-3)
+
+    nDP = len(dp_range_rad)
+    dtheta = np.sqrt(2) * dp_step_rad
+
+    angle_x = dp_range_rad[:, None]
+    angle_y = dp_range_rad[None, :]
+    kt = np.sqrt(angle_x ** 2 + angle_y ** 2)
+
+    mask = (kt > 0) & (kt < dp_max_rad)
+    dphi = np.where(kt > 0, np.minimum(dtheta / kt, 2 * np.pi), 0.0)
+
+    sigma_interp = interp1d(
+        theta_1d_mrad, sigma_p, bounds_error=False, fill_value=0.0,
+    )
+    P_theta = np.where(mask, sigma_interp(kt * 1000) * dtheta / sigma_total, 0.0)
+    P_phi = dphi / (2 * np.pi)
+    P = P_theta * P_phi
+
+    phi = np.arctan2(angle_y, angle_x)
+    phi = np.where(phi < 0, phi + 2 * np.pi, phi)
+
+    return P, kt, phi, sigma_total
+
+
+def calculate_deterministic_diffuse_dp(
+    bloch_waves: "BlochWaves",
+    thickness: float,
+    mfp: float,
+    P_grid: np.ndarray,
+    theta_grid: np.ndarray,
+    phi_grid: np.ndarray,
+    dp_range_rad: np.ndarray,
+    dp_step_rad: float,
+    num_slices: int = 19,
+    batch_size: int = 256,
+    _precomputed: tuple | None = None,
+) -> np.ndarray:
+    """Deterministic depth-slice integration for a diffuse diffraction pattern.
+
+    Implements the algorithm of ``Bloch_plasmon_DP.m`` / ``Bloch_phonon_DP.m``
+    (Mendis, Acta Cryst. A80, 2024).  The specimen is divided into *num_slices*
+    depth slices.  At each slice the electron is propagated elastically to that
+    depth, then for every scattering-angle pixel with non-zero probability the
+    beam is deflected, the structure-matrix diagonal is updated for the new beam
+    direction, and the electron is propagated to the exit surface.  The diffracted
+    intensities are placed on the DP grid shifted by the transverse momentum
+    transfer, weighted by ``exp(−z/λ) (Δz/λ) P(θ,φ)``.
+
+    The eigendecompositions are batched: on GPU (CuPy) the batched ``eigh`` runs
+    in parallel via cuSOLVER; on CPU (NumPy) it avoids Python-loop overhead.
+
+    Parameters
+    ----------
+    bloch_waves : BlochWaves
+        Provides the structure matrix, beam set, cell and energy.
+    thickness : float
+        Specimen thickness [Å].
+    mfp : float
+        Mean free path [Å] for the scattering process.
+    P_grid, theta_grid, phi_grid : np.ndarray
+        2D grids from :func:`_plasmon_probability_grid` or
+        :func:`_phonon_probability_grid`.
+    dp_range_rad : np.ndarray
+        1D angular axis [rad] (same as used to build the grids).
+    dp_step_rad : float
+        Angular pixel size [rad].
+    num_slices : int
+        Number of depth slices (default 19 for 1990 Å / 100 Å).
+    batch_size : int
+        Number of tilted matrices to eigendecompose per batch (controls peak
+        memory).  Default 256.
+    _precomputed : tuple, optional
+        ``(A_base, g, Mii)`` from :func:`_prepare_bloch_matrices`.
+
+    Returns
+    -------
+    dp_total : np.ndarray, shape (nDP, nDP)
+        The accumulated diffuse diffraction pattern.
+    """
+    import sys
+
+    xp = get_array_module(bloch_waves.device)
+
+    hkl = bloch_waves.hkl
+    energy = bloch_waves.energy
+    use_wave_eq = bloch_waves.use_wave_eq
+    wavelength = energy2wavelength(energy)
+    K = 1.0 / wavelength
+
+    if _precomputed is not None:
+        A_base, g, Mii = _precomputed
+    else:
+        A_base, g, Mii = _prepare_bloch_matrices(bloch_waves)
+
+    v_elastic, C_elastic = _precompute_untilted_eig(
+        A_base, g, Mii, energy, use_wave_eq, xp,
+    )
+    phi_inc = plane_wave_coefficients(hkl, xp)
+
+    g_np = asnumpy(g)
+    g_xy = g_np[:, :2]
+
+    nDP = len(dp_range_rad)
+    dp_total = np.zeros((nDP, nDP))
+
+    pixel_size = K * dp_step_rad
+    center_k = K * dp_range_rad[-1]
+
+    beam_px = np.round((g_xy[:, 0] + center_k) / pixel_size).astype(int)
+    beam_py = np.round((g_xy[:, 1] + center_k) / pixel_size).astype(int)
+
+    active_idx = np.nonzero(P_grid.ravel() > 0)[0]
+    n_active = len(active_idx)
+    active_ix = active_idx // nDP
+    active_iy = active_idx % nDP
+
+    slice_thickness = thickness / num_slices
+
+    active_theta = theta_grid.ravel()[active_idx]
+    active_phi_angle = phi_grid.ravel()[active_idx]
+    active_P = P_grid.ravel()[active_idx]
+
+    sin_theta = np.sin(active_theta)
+    beam_dirs = xp.asarray(np.stack([
+        sin_theta * np.cos(active_phi_angle),
+        sin_theta * np.sin(active_phi_angle),
+        np.cos(active_theta),
+    ], axis=-1))
+
+    shift_x = np.round(dp_range_rad[active_ix] / dp_step_rad).astype(int)
+    shift_y = np.round(dp_range_rad[active_iy] / dp_step_rad).astype(int)
+
+    def _propagate(dz, v, C, amplitudes):
+        phase = xp.exp(1.0j * xp.pi * dz * wavelength * v)
+        psi = amplitudes / Mii
+        psi = C @ (phase * (C.conj().T @ psi))
+        return Mii * psi
+
+    total_iters = num_slices * n_active
+    done = 0
+    for a in range(num_slices):
+        depth = (a + 0.5) * slice_thickness
+        remaining = thickness - depth
+
+        beams_p = _propagate(depth, v_elastic, C_elastic, phi_inc)
+
+        intensities_all = _batched_eigh_propagate(
+            A_base, g, Mii, beam_dirs, wavelength, use_wave_eq,
+            remaining, beams_p, xp, batch_size=batch_size,
+        )
+        intensities_np = asnumpy(intensities_all)
+
+        depth_weight = np.exp(-depth / mfp) * (slice_thickness / mfp)
+
+        for b in range(n_active):
+            weight = depth_weight * active_P[b]
+            px = beam_px + shift_x[b]
+            py = beam_py + shift_y[b]
+            valid = (px >= 0) & (px < nDP) & (py >= 0) & (py < nDP)
+            np.add.at(
+                dp_total, (py[valid], px[valid]),
+                weight * intensities_np[b, valid],
+            )
+
+        done += n_active
+        pct = 100 * done / total_iters
+        sys.stderr.write(
+            f"\r  slice {a + 1}/{num_slices}  "
+            f"({done}/{total_iters} eigh, {pct:.0f}%)"
+        )
+        sys.stderr.flush()
+
+    sys.stderr.write("\n")
+    return dp_total
+
+
+# ---------------------------------------------------------------------------
+# Interleaved phonon + plasmon Monte-Carlo (Mendis Matlab approach)
+# ---------------------------------------------------------------------------
+
+
+def draw_mixed_scattering_events(
+    mfp_plasmon: float,
+    mfp_phonon: float,
+    thickness: float,
+    n_plasmon_target: int,
+    theta_E_rad: float,
+    theta_c_rad: float,
+    phonon_theta_grid: np.ndarray,
+    phonon_cdf: np.ndarray,
+    num_configs: int = 50000,
+    max_events: int = 10,
+    seed: int | None = None,
+) -> tuple[list, list, list]:
+    """Draw interleaved phonon + plasmon MC configurations.
+
+    Follows ``Bloch_single_plasmon_phonon.m`` / ``Bloch_double_plasmon_phonon.m``.
+    At each scattering site a coin flip (weighted by the relative MFP) decides
+    whether the event is a plasmon or phonon excitation.  The path length between
+    events is drawn from the corresponding MFP distribution.  Only configurations
+    with exactly *n_plasmon_target* plasmon events within the specimen are kept.
+
+    Returns
+    -------
+    config_depths : list of tuple
+        Scattering depths within the specimen for each accepted configuration.
+    config_radials : list of tuple
+        Polar scattering angles [rad] for each event.
+    config_azimuths : list of tuple
+        Azimuthal scattering angles [rad] for each event.
+    """
+    rng = np.random.default_rng(seed)
+    plasmon_ratio = (1 / mfp_plasmon) / (1 / mfp_plasmon + 1 / mfp_phonon)
+
+    config_depths = []
+    config_radials = []
+    config_azimuths = []
+
+    configs_found = 0
+    while configs_found < num_configs:
+        event_depths = np.zeros(max_events)
+        event_types = np.zeros(max_events, dtype=int)
+        depth = 0.0
+        n_plasmons = 0
+
+        for e in range(max_events):
+            if rng.random() <= plasmon_ratio:
+                sp = -mfp_plasmon * np.log(rng.random())
+                event_types[e] = 1
+                depth += sp
+                if depth <= thickness:
+                    n_plasmons += 1
+            else:
+                sp = -mfp_phonon * np.log(rng.random())
+                depth += sp
+            event_depths[e] = depth
+
+        if n_plasmons == n_plasmon_target and depth > thickness:
+            depths = []
+            radials = []
+            azimuths = []
+            for e in range(max_events):
+                if event_depths[e] > thickness:
+                    break
+                depths.append(event_depths[e])
+                if event_types[e] == 1:
+                    theta = theta_E_rad * np.sqrt(
+                        ((theta_c_rad / theta_E_rad) ** 2 + 1) ** rng.random() - 1
+                    )
+                else:
+                    theta = float(
+                        np.interp(rng.random(), phonon_cdf, phonon_theta_grid)
+                    )
+                phi = 2 * np.pi * rng.random()
+                radials.append(theta)
+                azimuths.append(phi)
+
+            config_depths.append(tuple(depths))
+            config_radials.append(tuple(radials))
+            config_azimuths.append(tuple(azimuths))
+            configs_found += 1
+
+    return config_depths, config_radials, config_azimuths
+
+
+def calculate_mixed_mc_intensities(
+    bloch_waves: "BlochWaves",
+    thickness: float,
+    config_depths: list,
+    config_radials: list,
+    config_azimuths: list,
+    _precomputed: tuple | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Average Bloch-wave beam intensities over mixed phonon+plasmon MC configs.
+
+    Parameters
+    ----------
+    bloch_waves : BlochWaves
+    thickness : float
+    config_depths, config_radials, config_azimuths : list of tuple
+        From :func:`draw_mixed_scattering_events`.
+    _precomputed : tuple, optional
+
+    Returns
+    -------
+    intensities : np.ndarray, shape (num_beams,)
+        Average beam intensities.
+    transverse_k : np.ndarray, shape (num_configs,)
+        Transverse momentum [1/Å] for each configuration (for radial profiles).
+    """
+    xp = get_array_module(bloch_waves.device)
+
+    hkl = bloch_waves.hkl
+    energy = bloch_waves.energy
+    use_wave_eq = bloch_waves.use_wave_eq
+
+    if _precomputed is not None:
+        A_base, g, Mii = _precomputed
+    else:
+        A_base, g, Mii = _prepare_bloch_matrices(bloch_waves)
+
+    untilted_eig = _precompute_untilted_eig(A_base, g, Mii, energy, use_wave_eq, xp)
+
+    wavelength = energy2wavelength(energy)
+    K = 1.0 / wavelength
+    n_configs = len(config_depths)
+
+    real_dtype = A_base.real.dtype
+    accumulated = xp.zeros(len(hkl), dtype=real_dtype)
+    transverse_k = np.zeros(n_configs)
+
+    for i, (depths, radial, azimuthal) in enumerate(
+        zip(config_depths, config_radials, config_azimuths)
+    ):
+        phi, beam_dir = _chain_one_configuration(
+            A_base, g, Mii, hkl, energy, use_wave_eq, thickness,
+            depths, radial, azimuthal, _untilted_eig=untilted_eig,
+        )
+        accumulated += abs2(phi)
+
+        if beam_dir is not None:
+            beam_dir_np = np.asarray(beam_dir)
+            transverse_k[i] = K * np.sqrt(
+                float(beam_dir_np[0]) ** 2 + float(beam_dir_np[1]) ** 2
+            )
+
+    accumulated /= n_configs
+    return asnumpy(accumulated), transverse_k

--- a/abtem/bloch/utils.py
+++ b/abtem/bloch/utils.py
@@ -253,7 +253,7 @@ def fast_filter_excitation_errors(
     wavelength: float,
     sg_max: float,
 ) -> None:
-    g_length_2 = (g**2).sum(axis=-1)
+    g_length_2 = g[:, 0] ** 2 + g[:, 1] ** 2 + g[:, 2] ** 2
 
     b = 0.5 * wavelength * g_length_2
     for i in range(len(orientation_matrices)):

--- a/abtem/bloch/utils.py
+++ b/abtem/bloch/utils.py
@@ -10,7 +10,7 @@ from ase import Atoms
 from ase.cell import Cell
 from numba import njit  # type: ignore
 
-from abtem.core.backend import cp
+from abtem.core.backend import cp, get_array_module
 from abtem.core.energy import energy2wavelength
 
 
@@ -154,7 +154,10 @@ def make_hkl_grid(
 
 
 def excitation_errors(
-    g: np.ndarray, energy: float, use_wave_eq: bool = False
+    g: np.ndarray,
+    energy: float,
+    use_wave_eq: bool = False,
+    beam_direction: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     """
     Calculate excitation errors for a set of reciprocal space vectors.
@@ -168,6 +171,14 @@ def excitation_errors(
     use_wave_eq : bool, optional
         Whether to use the excitation errors derived from the wave equation.
         Default is False.
+    beam_direction : np.ndarray, optional
+        The incident-beam direction as a length-3 vector (need not be normalized).
+        Default is None, which corresponds to a beam along the surface normal ``z``,
+        i.e. ``[0, 0, 1]``. A tilted beam direction generalizes the excitation error
+        to ``sg = -(n_hat . g) - lambda/2 (|g|^2 - <wave-eq term>)`` following Mendis
+        (Acta Cryst. A80, 2024), Eq. 12, where ``n_hat`` is the normalized beam
+        direction. This is used to re-evaluate the excitation errors after an inelastic
+        deflection of the incident wavevector.
 
     Returns
     -------
@@ -175,11 +186,27 @@ def excitation_errors(
         Excitation errors [1/Å].
     """
     assert g.shape[-1] == 3
+    xp = get_array_module(g)
     wavelength = energy2wavelength(energy)
+
+    if beam_direction is None:
+        # Beam along the surface normal z; preserve the exact legacy expressions
+        # (bit-for-bit) so existing Bloch results are unchanged.
+        if use_wave_eq:
+            sg = (-2 * g[..., 2] - wavelength * (g[..., 0] ** 2 + g[..., 1] ** 2)) / 2.0
+        else:
+            sg = (-2 * g[..., 2] - wavelength * xp.sum(g * g, axis=-1)) / 2.0
+        return sg
+
+    beam_direction = xp.asarray(beam_direction).astype(g.dtype)
+    beam_direction = beam_direction / xp.linalg.norm(beam_direction)
+    gn = g @ beam_direction
+    g2 = xp.sum(g * g, axis=-1)
+
     if use_wave_eq:
-        sg = (-2 * g[..., 2] - wavelength * (g[..., 0] ** 2 + g[..., 1] ** 2)) / 2.0
+        sg = -gn - wavelength * (g2 - gn**2) / 2.0
     else:
-        sg = (-2 * g[..., 2] - wavelength * np.sum(g * g, axis=-1)) / 2.0
+        sg = -gn - wavelength * g2 / 2.0
     return sg
 
 

--- a/abtem/inelastic/plasmons.py
+++ b/abtem/inelastic/plasmons.py
@@ -1,4 +1,5 @@
 import itertools
+import math
 from collections import defaultdict
 from dataclasses import dataclass
 from functools import partial
@@ -127,7 +128,7 @@ def draw_azimuthal_angle(num_samples, num_depths, rng=None) -> Tuple[float]:
 def excitations_weights(n: int, thickness: float, mean_free_path: float) -> float:
     return (
         1
-        / np.math.factorial(n)
+        / math.factorial(n)
         * (thickness / mean_free_path) ** n
         * np.exp(-thickness / mean_free_path)
     )
@@ -455,6 +456,16 @@ class PlasmonScatteringEvents(ArrayObjectTransform):
 
         return (array,)
 
+    def _calculate_new_array(self, array_object):
+        # ``PlasmonScatteringEvents`` produces its output through the overridden
+        # ``apply`` (which tiles the incident waves over the ensemble) rather than the
+        # generic ``_calculate_new_array`` path. The method is implemented only so the
+        # class is concrete and can be instantiated.
+        raise NotImplementedError(
+            "PlasmonScatteringEvents uses 'apply' directly; '_calculate_new_array' is "
+            "not used."
+        )
+
     def apply(self, waves: "Waves", in_place: bool = False) -> "Waves":
         xp = get_array_module(waves.device)
 
@@ -522,8 +533,31 @@ class MonteCarloPlasmons:
     def draw_events(
         self, waves: "Waves", potential: "BasePotential"
     ) -> PlasmonScatteringEvents:
-        depth = potential.thickness
-        energy = waves.energy
+        return self._draw_events(thickness=potential.thickness, energy=waves.energy)
+
+    def _draw_events(
+        self, thickness: float, energy: float
+    ) -> PlasmonScatteringEvents:
+        """Draw Monte-Carlo plasmon scattering events for a given specimen thickness and
+        electron energy.
+
+        This is the object-agnostic core of :meth:`draw_events`; it does not require a
+        ``Waves`` or ``BasePotential`` object and is used by the Bloch-wave inelastic
+        driver.
+
+        Parameters
+        ----------
+        thickness : float
+            The specimen thickness [Å].
+        energy : float
+            The electron energy [eV].
+
+        Returns
+        -------
+        PlasmonScatteringEvents
+            The sampled scattering events.
+        """
+        depth = thickness
 
         rng = np.random.default_rng(self.seed)
 
@@ -577,4 +611,270 @@ class MonteCarloPlasmons:
             azimuthal_angles,
             weights,
             ensemble_mean=self.ensemble_mean,
+        )
+
+
+def _tds_differential_cross_section(
+    theta: np.ndarray,
+    scattering_factor_func,
+    debye_waller_factor: float,
+    energy: float,
+) -> np.ndarray:
+    """Evaluate the uncorrelated phonon (TDS) differential scattering cross section
+    ``dσ/dΩ = f(q)² [1 − exp(−2Bq²)]`` [Mendis Eq. 8, Pennycook & Jesson 1991].
+
+    Parameters
+    ----------
+    theta : np.ndarray
+        Polar scattering angles [rad].
+    scattering_factor_func : callable
+        Electron scattering factor ``f(g²)`` as a function of the squared scattering
+        vector magnitude ``g² = q²`` [1/Å²].
+    debye_waller_factor : float
+        The isotropic Debye-Waller factor ``B = 8π²⟨u²⟩`` [Å²].
+    energy : float
+        The electron energy [eV].
+
+    Returns
+    -------
+    np.ndarray
+        The differential cross section (unnormalised), same shape as ``theta``.
+    """
+    from abtem.core.energy import energy2wavelength
+
+    wavelength = energy2wavelength(energy)
+    K = 1.0 / wavelength
+    q = 2 * K * np.sin(theta / 2.0)
+    q2 = q**2
+    f = scattering_factor_func(q2)
+    return f**2 * (1.0 - np.exp(-2.0 * debye_waller_factor * q2))
+
+
+def _compute_tds_cdf(
+    scattering_factor_func,
+    debye_waller_factor: float,
+    energy: float,
+    theta_max: float,
+    num_points: int = 2000,
+) -> tuple[np.ndarray, np.ndarray, float]:
+    """Numerically compute the CDF of the phonon polar scattering angle distribution
+    [Mendis Eq. 11].
+
+    Returns ``(theta_grid, cdf_values, sigma_total)`` where ``cdf_values`` goes from
+    0 to 1 and ``sigma_total`` is the total TDS cross section.
+    """
+    theta = np.linspace(0, theta_max, num_points)
+    dsigma = _tds_differential_cross_section(
+        theta, scattering_factor_func, debye_waller_factor, energy,
+    )
+    integrand = dsigma * np.sin(theta) * 2 * np.pi
+    dtheta = theta[1] - theta[0]
+    sigma_total = float(np.trapezoid(integrand, dx=dtheta))
+    cdf = np.cumsum(integrand)
+    cdf[0] = 0.0
+    if cdf[-1] > 0:
+        cdf /= cdf[-1]
+    return theta, cdf, sigma_total
+
+
+def _draw_phonon_radial_angle(
+    theta_grid: np.ndarray,
+    cdf: np.ndarray,
+    num_samples: int,
+    num_depths: int,
+    rng,
+) -> Tuple[Tuple[float]]:
+    """Draw phonon polar scattering angles by inverse-CDF sampling [Mendis Eq. 11]."""
+    if num_depths == 0:
+        return tuple(() for _ in range(num_samples))
+    rands = rng.random((num_samples, num_depths))
+    thetas_flat = np.interp(rands.ravel(), cdf, theta_grid)
+    thetas_2d = thetas_flat.reshape(num_samples, num_depths)
+    return tuple(tuple(row) for row in thetas_2d)
+
+
+class MonteCarloPhonons:
+    """Monte-Carlo phonon (thermal diffuse) scattering for Bloch waves.
+
+    Uses the uncorrelated phonon model of Mendis (Acta Cryst. A80, 2024), Eq. 8–11 and
+    16a–16c. The TDS differential cross section is ``dσ/dΩ = f(q)²[1 − exp(−2Bq²)]``
+    (Pennycook & Jesson, 1991). The mean free path is ``λ_ph = 1/(Nᵥ σ_TDS^T)``
+    [Eq. 9]. The polar angle is drawn by numerical inversion of the CDF [Eq. 11].
+
+    The returned :class:`PlasmonScatteringEvents` object has the same format as
+    plasmon events and can be consumed by the Bloch-wave inelastic driver directly.
+
+    Parameters
+    ----------
+    atoms : Atoms
+        The atoms object describing the structure (used for scattering factors and
+        number density).
+    thermal_sigma : float
+        The isotropic r.m.s. thermal vibration amplitude ``σ = √⟨u²⟩`` [Å].
+    parametrization : str
+        The scattering-factor parametrization (``'lobato'``, ``'kirkland'``, etc.).
+    theta_max : float
+        The maximum polar scattering angle [rad] for the cross-section integration.
+        Should cover the range where ``dσ/dΩ`` is significant.
+    num_excitations : int or tuple of int
+        The excitation orders to sample.
+    num_samples : int
+        The number of Monte-Carlo configurations per order.
+    ensemble_mean : bool
+        Whether to average over configurations when reducing.
+    seed : int, optional
+        Random seed for reproducibility.
+    """
+
+    def __init__(
+        self,
+        atoms,
+        thermal_sigma: float,
+        parametrization: str = "kirkland",
+        theta_max: float = 0.1,
+        num_excitations: Union[int, Tuple[int, ...]] = None,
+        num_samples: int = None,
+        ensemble_mean: bool = False,
+        seed: Union[int, Tuple[int, ...]] = None,
+    ):
+        from ase import Atoms as AseAtoms
+
+        if not isinstance(atoms, AseAtoms):
+            raise TypeError("atoms must be an ASE Atoms object")
+
+        self._atoms = atoms
+        self._thermal_sigma = thermal_sigma
+        self._parametrization_name = parametrization
+        self._theta_max = theta_max
+        self._ensemble_mean = ensemble_mean
+        self._num_samples = num_samples
+        self._seed = seed
+
+        if isinstance(num_excitations, int):
+            num_excitations = tuple(range(num_excitations + 1))
+        self._num_excitations = num_excitations
+
+        self._debye_waller_factor = 8.0 * np.pi**2 * thermal_sigma**2
+
+    @property
+    def debye_waller_factor(self) -> float:
+        return self._debye_waller_factor
+
+    @property
+    def ensemble_mean(self) -> bool:
+        return self._ensemble_mean
+
+    @property
+    def num_samples(self) -> int:
+        return self._num_samples
+
+    @property
+    def seed(self):
+        return self._seed
+
+    def _get_scattering_factor_func(self):
+        """Return a callable ``f(g²)`` that sums the scattering factors of all atom
+        species weighted by their fractional composition."""
+        from abtem.parametrizations import validate_parametrization
+
+        param = validate_parametrization(self._parametrization_name)
+
+        symbols = self._atoms.get_chemical_symbols()
+        unique_symbols = list(dict.fromkeys(symbols))
+        counts = {s: symbols.count(s) for s in unique_symbols}
+        total = len(symbols)
+
+        funcs = {s: param.scattering_factor(s) for s in unique_symbols}
+
+        def weighted_f(g2):
+            result = np.zeros_like(g2, dtype=float)
+            for s in unique_symbols:
+                result += (counts[s] / total) * funcs[s](g2)
+            return result
+
+        return weighted_f
+
+    def mean_free_path(self, energy: float) -> float:
+        """Compute the phonon mean free path ``λ_ph = 1/(Nᵥ σ_TDS^T)`` [Eq. 9]."""
+        from abtem.core.energy import energy2wavelength
+
+        f_func = self._get_scattering_factor_func()
+        theta_grid = np.linspace(0, self._theta_max, 2000)
+
+        dsigma = _tds_differential_cross_section(
+            theta_grid, f_func, self._debye_waller_factor, energy,
+        )
+        integrand = dsigma * np.sin(theta_grid) * 2 * np.pi
+        dtheta = theta_grid[1] - theta_grid[0]
+        sigma_total = np.trapezoid(integrand, dx=dtheta)
+
+        cell_volume = self._atoms.get_volume()
+        num_atoms = len(self._atoms)
+        number_density = num_atoms / cell_volume
+
+        if sigma_total <= 0:
+            return np.inf
+
+        return 1.0 / (number_density * sigma_total)
+
+    def _draw_events(
+        self, thickness: float, energy: float
+    ) -> PlasmonScatteringEvents:
+        """Draw Monte-Carlo phonon scattering events."""
+        f_func = self._get_scattering_factor_func()
+        theta_grid, cdf, sigma_total = _compute_tds_cdf(
+            f_func, self._debye_waller_factor, energy, self._theta_max,
+        )
+
+        number_density = len(self._atoms) / self._atoms.get_volume()
+        mfp = 1.0 / (number_density * sigma_total) if sigma_total > 0 else np.inf
+
+        rng = np.random.default_rng(self.seed)
+
+        depths = []
+        radial_angles = []
+        azimuthal_angles = []
+        weights = []
+
+        for n in self._num_excitations:
+            if n == 0:
+                ns = 1
+            else:
+                ns = self.num_samples
+
+            depths.append(
+                draw_scattering_depths(
+                    mean_free_path=mfp,
+                    num_depths=n,
+                    max_depth=thickness,
+                    num_samples=ns,
+                    rng=rng,
+                )
+            )
+
+            radial_angles.append(
+                _draw_phonon_radial_angle(
+                    theta_grid, cdf, num_samples=ns, num_depths=n, rng=rng,
+                )
+            )
+
+            azimuthal_angles.append(
+                draw_azimuthal_angle(num_samples=ns, num_depths=n, rng=rng)
+            )
+
+            weights.append(
+                (excitations_weights(n, thickness, mfp),) * ns
+            )
+
+        depths = list(itertools.chain(*depths))
+        radial_angles = list(itertools.chain(*radial_angles))
+        azimuthal_angles = list(itertools.chain(*azimuthal_angles))
+        weights = list(itertools.chain(*weights))
+
+        return PlasmonScatteringEvents(
+            depths,
+            radial_angles,
+            azimuthal_angles,
+            weights,
+            ensemble_mean=self._ensemble_mean,
         )

--- a/test/test_bloch_plasmons.py
+++ b/test/test_bloch_plasmons.py
@@ -22,6 +22,11 @@ from abtem.core.energy import energy2wavelength
 from abtem.inelastic.plasmons import MonteCarloPhonons, MonteCarloPlasmons
 
 
+def _to_numpy(a):
+    """Convert an array to NumPy, handling CuPy transparently."""
+    return a.get() if hasattr(a, "get") else np.asarray(a)
+
+
 @pytest.fixture
 def si_bloch(request):
     device = request.param
@@ -104,7 +109,7 @@ def test_zero_events_matches_elastic(request, device):
     t = 200.0
 
     dp_elastic = bw.calculate_diffraction_patterns(t, lazy=False)
-    I_elastic = np.asarray(dp_elastic.array)
+    I_elastic = _to_numpy(dp_elastic.array)
 
     mc = MonteCarloPlasmons(
         830.0, 17.0, 19.1, num_excitations=0, num_samples=1, ensemble_mean=True
@@ -113,7 +118,7 @@ def test_zero_events_matches_elastic(request, device):
     orders, I, weights = calculate_bloch_plasmon_intensities(bw, events, t)
 
     assert orders == [0]
-    np.testing.assert_allclose(np.asarray(I[0]), I_elastic, atol=5e-7)
+    np.testing.assert_allclose(_to_numpy(I[0]), I_elastic, atol=5e-7)
 
 
 # ---------------------------------------------------------------------------
@@ -138,7 +143,7 @@ def test_intensity_conservation(request, device):
     orders, I, weights = calculate_bloch_plasmon_intensities(bw, events, t)
 
     total = sum(
-        float(weights[i]) * float(np.asarray(I[i]).sum()) for i in range(len(orders))
+        float(weights[i]) * float(_to_numpy(I[i]).sum()) for i in range(len(orders))
     )
 
     # Expected: each order's pattern is normalised (Bloch conserves total intensity),
@@ -173,8 +178,8 @@ def test_calculate_diffraction_patterns_plasmon_api(request, device):
     assert dp.array.shape == (2, len(bw))
     assert "plasmon_orders" in dp.metadata
     assert dp.metadata["plasmon_orders"] == (0, 1)
-    assert all(np.isfinite(np.asarray(dp.array)).ravel())
-    assert all((np.asarray(dp.array) >= 0).ravel())
+    assert all(np.isfinite(_to_numpy(dp.array)).ravel())
+    assert all((_to_numpy(dp.array) >= 0).ravel())
 
 
 @pytest.mark.parametrize("device", ["cpu", gpu])
@@ -194,7 +199,7 @@ def test_000_decreases_with_plasmon_loss(request, device):
     orders, I, _ = calculate_bloch_plasmon_intensities(bw, events, t)
 
     g0 = np.argmin(np.asarray((bw.g_vec ** 2).sum(1)))
-    I_np = np.asarray(I)
+    I_np = _to_numpy(I)
     fracs = [I_np[i, g0] / I_np[i].sum() for i in range(len(orders))]
     assert fracs[0] > fracs[1], (
         f"000 fraction should decrease: zero-loss={fracs[0]:.4f}, "
@@ -266,7 +271,7 @@ def test_ensemble_plasmon_shape(request, device):
     assert dp.array.ndim == 3  # (orientations, orders, beams)
     assert dp.array.shape[0] == 2  # 2 orientations
     assert dp.array.shape[1] == 2  # orders 0 and 1
-    assert np.isfinite(np.asarray(dp.array)).all()
+    assert np.isfinite(_to_numpy(dp.array)).all()
 
 
 # ---------------------------------------------------------------------------
@@ -300,8 +305,8 @@ def test_phonon_bloch_integration(request, device):
     )
     dp = bw.calculate_diffraction_patterns(500.0, plasmons=phonons)
     assert dp.array.shape == (2, len(bw))
-    assert np.isfinite(np.asarray(dp.array)).all()
-    assert (np.asarray(dp.array) >= 0).all()
+    assert np.isfinite(_to_numpy(dp.array)).all()
+    assert (_to_numpy(dp.array) >= 0).all()
 
 
 # ---------------------------------------------------------------------------
@@ -325,8 +330,8 @@ def test_lazy_plasmon_matches_eager(request, device):
     dp_lazy = bw.calculate_diffraction_patterns(300.0, plasmons=mc, lazy=True)
 
     assert hasattr(dp_lazy.array, "compute"), "lazy result should be a dask array"
-    lazy_array = np.asarray(dp_lazy.array.compute())
-    eager_array = np.asarray(dp_eager.array)
+    lazy_array = _to_numpy(dp_lazy.array.compute())
+    eager_array = _to_numpy(dp_eager.array)
     np.testing.assert_allclose(lazy_array, eager_array, atol=1e-12)
 
 
@@ -343,7 +348,7 @@ def test_lazy_multi_thickness(request, device):
     )
     dp = bw.calculate_diffraction_patterns([200.0, 400.0], plasmons=mc, lazy=True)
     assert hasattr(dp.array, "compute")
-    arr = np.asarray(dp.array.compute())
+    arr = _to_numpy(dp.array.compute())
     assert arr.shape == (2, 2, len(bw))
     assert np.isfinite(arr).all()
 
@@ -374,7 +379,7 @@ def test_diffuse_pattern_shape_and_values(request, device):
 
     orders = dp.metadata["plasmon_orders"]
     weights = dp.metadata["plasmon_weights"]
-    images = np.asarray(dp.array)
+    images = _to_numpy(dp.array)
 
     assert images.shape == (len(orders), 128, 128)
     assert np.isfinite(images).all()
@@ -398,7 +403,7 @@ def test_diffuse_zero_order_concentrates_at_bragg(request, device):
     dp = bw.calculate_diffuse_diffraction_pattern(
         thickness=300.0, plasmons=mc, gpts=(128, 128),
     )
-    images = np.asarray(dp.array)
+    images = _to_numpy(dp.array)
     orders = list(dp.metadata["plasmon_orders"])
 
     zero_idx = orders.index(0)
@@ -425,7 +430,7 @@ def test_diffuse_higher_order_spreads(request, device):
     dp = bw.calculate_diffuse_diffraction_pattern(
         thickness=500.0, plasmons=mc, gpts=(256, 256),
     )
-    images = np.asarray(dp.array)
+    images = _to_numpy(dp.array)
     orders = list(dp.metadata["plasmon_orders"])
 
     if len(orders) >= 2:

--- a/test/test_bloch_plasmons.py
+++ b/test/test_bloch_plasmons.py
@@ -355,8 +355,10 @@ def test_lazy_multi_thickness(request, device):
 
 @pytest.mark.parametrize("device", ["cpu", gpu])
 def test_diffuse_pattern_shape_and_values(request, device):
-    """``calculate_diffuse_diffraction_pattern`` returns images with the right shape and
-    non-negative finite values."""
+    """``calculate_diffuse_diffraction_pattern`` returns a DiffractionPatterns with the
+    right shape and non-negative finite values."""
+    from abtem.measurements import DiffractionPatterns
+
     si = bulk("Si", "diamond", a=5.43, cubic=True)
     sf = abtem.StructureFactor(si, g_max=12, device=device)
     bw = BlochWaves(sf, energy=200e3, sg_max=0.1, g_max=2.0, device=device)
@@ -365,18 +367,19 @@ def test_diffuse_pattern_shape_and_values(request, device):
         830.0, 17.0, 19.1, num_excitations=1, num_samples=200, ensemble_mean=True,
         seed=7,
     )
-    result = bw.calculate_diffuse_diffraction_pattern(
+    dp = bw.calculate_diffuse_diffraction_pattern(
         thickness=300.0, plasmons=mc, gpts=(128, 128),
     )
-    images = result["images"]
-    orders = result["orders"]
-    weights = result["weights"]
+    assert isinstance(dp, DiffractionPatterns)
+
+    orders = dp.metadata["plasmon_orders"]
+    weights = dp.metadata["plasmon_weights"]
+    images = np.asarray(dp.array)
 
     assert images.shape == (len(orders), 128, 128)
     assert np.isfinite(images).all()
     assert (images >= 0).all()
     assert len(weights) == len(orders)
-    assert result["extent"] is not None
 
 
 @pytest.mark.parametrize("device", ["cpu", gpu])
@@ -392,11 +395,11 @@ def test_diffuse_zero_order_concentrates_at_bragg(request, device):
         830.0, 17.0, 19.1, num_excitations=1, num_samples=100, ensemble_mean=True,
         seed=3,
     )
-    result = bw.calculate_diffuse_diffraction_pattern(
+    dp = bw.calculate_diffuse_diffraction_pattern(
         thickness=300.0, plasmons=mc, gpts=(128, 128),
     )
-    images = result["images"]
-    orders = result["orders"]
+    images = np.asarray(dp.array)
+    orders = list(dp.metadata["plasmon_orders"])
 
     zero_idx = orders.index(0)
     zero_image = images[zero_idx]
@@ -419,11 +422,11 @@ def test_diffuse_higher_order_spreads(request, device):
         830.0, 17.0, 19.1, num_excitations=2, num_samples=500, ensemble_mean=True,
         seed=9,
     )
-    result = bw.calculate_diffuse_diffraction_pattern(
+    dp = bw.calculate_diffuse_diffraction_pattern(
         thickness=500.0, plasmons=mc, gpts=(256, 256),
     )
-    images = result["images"]
-    orders = result["orders"]
+    images = np.asarray(dp.array)
+    orders = list(dp.metadata["plasmon_orders"])
 
     if len(orders) >= 2:
         nz_zero = np.count_nonzero(images[orders.index(0)])

--- a/test/test_bloch_plasmons.py
+++ b/test/test_bloch_plasmons.py
@@ -1,0 +1,434 @@
+"""Tests for Bloch-wave + Monte-Carlo inelastic (plasmon/phonon) scattering.
+
+Tests follow the repo convention: parametrized over ``["cpu", gpu]``.
+"""
+
+import math
+
+import numpy as np
+import pytest
+from ase.build import bulk
+from utils import gpu
+
+import abtem
+from abtem.bloch.dynamical import BlochWaves, BlochwaveEnsemble
+from abtem.bloch.inelastic import (
+    _chain_one_configuration,
+    _deflect,
+    calculate_bloch_plasmon_intensities,
+)
+from abtem.bloch.utils import calculate_g_vec, excitation_errors
+from abtem.core.energy import energy2wavelength
+from abtem.inelastic.plasmons import MonteCarloPhonons, MonteCarloPlasmons
+
+
+@pytest.fixture
+def si_bloch(request):
+    device = request.param
+    si = bulk("Si", "diamond", a=5.43, cubic=True)
+    sf = abtem.StructureFactor(si, g_max=12, device=device)
+    bw = BlochWaves(sf, energy=200e3, sg_max=0.1, g_max=2.0, device=device)
+    return bw
+
+
+# ---------------------------------------------------------------------------
+# Tilt-aware excitation errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_excitation_errors_zero_tilt_matches_legacy(device):
+    """beam_direction=None and beam_direction=[0,0,1] must both reproduce the exact
+    legacy formula (no tilt)."""
+    rng = np.random.default_rng(0)
+    g = rng.standard_normal((30, 3))
+    energy = 200e3
+    wavelength = energy2wavelength(energy)
+
+    sg_default = excitation_errors(g, energy)
+    sg_z = excitation_errors(g, energy, beam_direction=np.array([0.0, 0.0, 1.0]))
+    legacy = (-2 * g[:, 2] - wavelength * np.sum(g * g, axis=-1)) / 2.0
+
+    np.testing.assert_allclose(sg_default, legacy, atol=0, rtol=0)
+    np.testing.assert_allclose(sg_z, legacy, atol=1e-12)
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_excitation_errors_tilt_changes_sg(device):
+    """A finite tilt must shift the excitation errors."""
+    rng = np.random.default_rng(1)
+    g = rng.standard_normal((20, 3))
+    energy = 200e3
+    theta = 0.01  # 10 mrad
+    n = np.array([0.0, np.sin(theta), np.cos(theta)])
+    sg_default = excitation_errors(g, energy)
+    sg_tilted = excitation_errors(g, energy, beam_direction=n)
+    assert not np.allclose(sg_default, sg_tilted)
+
+
+# ---------------------------------------------------------------------------
+# Euler-rotation deflection
+# ---------------------------------------------------------------------------
+
+
+def test_deflect_identity():
+    """Zero deflection preserves the rotation."""
+    R = np.eye(3)
+    R2 = _deflect(R, 0.0, 0.0)
+    np.testing.assert_allclose(R2, np.eye(3), atol=1e-15)
+
+
+def test_deflect_polar_only():
+    """A pure polar deflection about the initial z axis tilts the beam toward x."""
+    R = np.eye(3)
+    theta = 0.05
+    R2 = _deflect(R, theta, 0.0)
+    beam = R2 @ np.array([0.0, 0.0, 1.0])
+    np.testing.assert_allclose(beam[0], np.sin(theta), atol=1e-12)
+    np.testing.assert_allclose(beam[2], np.cos(theta), atol=1e-12)
+    np.testing.assert_allclose(np.linalg.norm(beam), 1.0, atol=1e-15)
+
+
+# ---------------------------------------------------------------------------
+# Zero-loss elastic limit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_zero_events_matches_elastic(request, device):
+    """With zero scattering events the driver must reproduce the pure Bloch result
+    exactly (up to floating point)."""
+    si = bulk("Si", "diamond", a=5.43, cubic=True)
+    sf = abtem.StructureFactor(si, g_max=12, device=device)
+    bw = BlochWaves(sf, energy=200e3, sg_max=0.1, g_max=2.0, device=device)
+    t = 200.0
+
+    dp_elastic = bw.calculate_diffraction_patterns(t, lazy=False)
+    I_elastic = np.asarray(dp_elastic.array)
+
+    mc = MonteCarloPlasmons(
+        830.0, 17.0, 19.1, num_excitations=0, num_samples=1, ensemble_mean=True
+    )
+    events = mc._draw_events(thickness=t, energy=bw.energy)
+    orders, I, weights = calculate_bloch_plasmon_intensities(bw, events, t)
+
+    assert orders == [0]
+    np.testing.assert_allclose(np.asarray(I[0]), I_elastic, atol=5e-7)
+
+
+# ---------------------------------------------------------------------------
+# Intensity conservation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_intensity_conservation(request, device):
+    """The total intensity sum_n P(n) I^(n) must equal the Bloch normalisation times
+    the truncated Poisson cumulative."""
+    si = bulk("Si", "diamond", a=5.43, cubic=True)
+    sf = abtem.StructureFactor(si, g_max=12, device=device)
+    bw = BlochWaves(sf, energy=200e3, sg_max=0.1, g_max=2.0, device=device)
+    t = 300.0
+
+    mc = MonteCarloPlasmons(
+        830.0, 17.0, 19.1, num_excitations=2, num_samples=500, ensemble_mean=True,
+        seed=42,
+    )
+    events = mc._draw_events(thickness=t, energy=bw.energy)
+    orders, I, weights = calculate_bloch_plasmon_intensities(bw, events, t)
+
+    total = sum(
+        float(weights[i]) * float(np.asarray(I[i]).sum()) for i in range(len(orders))
+    )
+
+    # Expected: each order's pattern is normalised (Bloch conserves total intensity),
+    # so total ~ sum_n P(n) = truncated Poisson CDF.
+    expected_poisson = sum(
+        1 / math.factorial(n) * (t / 830.0) ** n * np.exp(-t / 830.0)
+        for n in orders
+    )
+    np.testing.assert_allclose(total, expected_poisson, rtol=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_calculate_diffraction_patterns_plasmon_api(request, device):
+    """The ``plasmons=`` kwarg on ``calculate_diffraction_patterns`` returns an
+    ``IndexedDiffractionPatterns`` with per-order intensities."""
+    si = bulk("Si", "diamond", a=5.43, cubic=True)
+    sf = abtem.StructureFactor(si, g_max=12, device=device)
+    bw = BlochWaves(sf, energy=200e3, sg_max=0.1, g_max=2.0, device=device)
+    t = 200.0
+
+    mc = MonteCarloPlasmons(
+        830.0, 17.0, 19.1, num_excitations=1, num_samples=200, ensemble_mean=True,
+        seed=7,
+    )
+    dp = bw.calculate_diffraction_patterns(t, plasmons=mc)
+
+    assert dp.array.shape == (2, len(bw))
+    assert "plasmon_orders" in dp.metadata
+    assert dp.metadata["plasmon_orders"] == (0, 1)
+    assert all(np.isfinite(np.asarray(dp.array)).ravel())
+    assert all((np.asarray(dp.array) >= 0).ravel())
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_000_decreases_with_plasmon_loss(request, device):
+    """The normalised 000 beam intensity should decrease with increasing energy loss
+    (Mendis 2024, Table 2)."""
+    si = bulk("Si", "diamond", a=5.43, cubic=True)
+    sf = abtem.StructureFactor(si, g_max=12, device=device)
+    bw = BlochWaves(sf, energy=200e3, sg_max=0.1, g_max=2.0, device=device)
+    t = 600.0
+
+    mc = MonteCarloPlasmons(
+        830.0, 17.0, 19.1, num_excitations=2, num_samples=800, ensemble_mean=True,
+        seed=5,
+    )
+    events = mc._draw_events(thickness=t, energy=bw.energy)
+    orders, I, _ = calculate_bloch_plasmon_intensities(bw, events, t)
+
+    g0 = np.argmin(np.asarray((bw.g_vec ** 2).sum(1)))
+    I_np = np.asarray(I)
+    fracs = [I_np[i, g0] / I_np[i].sum() for i in range(len(orders))]
+    assert fracs[0] > fracs[1], (
+        f"000 fraction should decrease: zero-loss={fracs[0]:.4f}, "
+        f"single-plasmon={fracs[1]:.4f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Multiple thicknesses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_multi_thickness_shape(request, device):
+    """A thickness sequence returns shape (orders, thicknesses, beams)."""
+    si = bulk("Si", "diamond", a=5.43, cubic=True)
+    sf = abtem.StructureFactor(si, g_max=12, device=device)
+    bw = BlochWaves(sf, energy=200e3, sg_max=0.1, g_max=2.0, device=device)
+
+    mc = MonteCarloPlasmons(
+        830.0, 17.0, 19.1, num_excitations=1, num_samples=50, ensemble_mean=True,
+        seed=10,
+    )
+    dp = bw.calculate_diffraction_patterns([200.0, 400.0], plasmons=mc)
+    assert dp.array.shape == (2, 2, len(bw))
+    axes_labels = [a.label for a in dp.ensemble_axes_metadata]
+    assert "energy loss" in axes_labels
+    assert "z" in axes_labels
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_scalar_thickness_backward_compat(request, device):
+    """A scalar thickness returns shape (orders, beams) — no thickness axis."""
+    si = bulk("Si", "diamond", a=5.43, cubic=True)
+    sf = abtem.StructureFactor(si, g_max=12, device=device)
+    bw = BlochWaves(sf, energy=200e3, sg_max=0.1, g_max=2.0, device=device)
+
+    mc = MonteCarloPlasmons(
+        830.0, 17.0, 19.1, num_excitations=1, num_samples=50, ensemble_mean=True,
+        seed=10,
+    )
+    dp = bw.calculate_diffraction_patterns(300.0, plasmons=mc)
+    assert dp.array.shape == (2, len(bw))
+    assert len(dp.ensemble_axes_metadata) == 1
+
+
+# ---------------------------------------------------------------------------
+# BlochwaveEnsemble with plasmons
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_ensemble_plasmon_shape(request, device):
+    """``BlochwaveEnsemble.calculate_diffraction_patterns(plasmons=...)`` returns
+    array with orientation × order × beam axes."""
+    si = bulk("Si", "diamond", a=5.43, cubic=True)
+    sf = abtem.StructureFactor(si, g_max=12, device=device)
+
+    ens = BlochwaveEnsemble(
+        "z", np.linspace(-0.01, 0.01, 2),
+        structure_factor=sf, energy=200e3, sg_max=0.1, g_max=2.0, centering="F",
+        device=device,
+    )
+    mc = MonteCarloPlasmons(
+        830.0, 17.0, 19.1, num_excitations=1, num_samples=50, ensemble_mean=True,
+        seed=5,
+    )
+    dp = ens.calculate_diffraction_patterns(300.0, plasmons=mc)
+    assert dp.array.ndim == 3  # (orientations, orders, beams)
+    assert dp.array.shape[0] == 2  # 2 orientations
+    assert dp.array.shape[1] == 2  # orders 0 and 1
+    assert np.isfinite(np.asarray(dp.array)).all()
+
+
+# ---------------------------------------------------------------------------
+# MonteCarloPhonons
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_phonon_mean_free_path_silicon(request, device):
+    """The Si phonon mean free path at 200 kV should be close to the Mendis value
+    (~7724 Å)."""
+    si = bulk("Si", "diamond", a=5.43, cubic=True)
+    phonons = MonteCarloPhonons(
+        atoms=si, thermal_sigma=0.078, parametrization="kirkland",
+        theta_max=0.1, num_excitations=0, num_samples=1,
+    )
+    mfp = phonons.mean_free_path(200e3)
+    np.testing.assert_allclose(mfp, 7724.0, rtol=0.02)
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_phonon_bloch_integration(request, device):
+    """Phonon events work with the Bloch driver through the ``plasmons=`` kwarg."""
+    si = bulk("Si", "diamond", a=5.43, cubic=True)
+    sf = abtem.StructureFactor(si, g_max=12, device=device)
+    bw = BlochWaves(sf, energy=200e3, sg_max=0.1, g_max=2.0, device=device)
+
+    phonons = MonteCarloPhonons(
+        atoms=si, thermal_sigma=0.078, parametrization="kirkland",
+        theta_max=0.1, num_excitations=1, num_samples=50, ensemble_mean=True, seed=42,
+    )
+    dp = bw.calculate_diffraction_patterns(500.0, plasmons=phonons)
+    assert dp.array.shape == (2, len(bw))
+    assert np.isfinite(np.asarray(dp.array)).all()
+    assert (np.asarray(dp.array) >= 0).all()
+
+
+# ---------------------------------------------------------------------------
+# Lazy/dask execution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_lazy_plasmon_matches_eager(request, device):
+    """``lazy=True`` must produce the same result as ``lazy=False`` for the plasmon
+    path (deferred via dask)."""
+    si = bulk("Si", "diamond", a=5.43, cubic=True)
+    sf = abtem.StructureFactor(si, g_max=12, device=device)
+    bw = BlochWaves(sf, energy=200e3, sg_max=0.1, g_max=2.0, device=device)
+
+    mc = MonteCarloPlasmons(
+        830.0, 17.0, 19.1, num_excitations=1, num_samples=100, ensemble_mean=True,
+        seed=42,
+    )
+    dp_eager = bw.calculate_diffraction_patterns(300.0, plasmons=mc, lazy=False)
+    dp_lazy = bw.calculate_diffraction_patterns(300.0, plasmons=mc, lazy=True)
+
+    assert hasattr(dp_lazy.array, "compute"), "lazy result should be a dask array"
+    lazy_array = np.asarray(dp_lazy.array.compute())
+    eager_array = np.asarray(dp_eager.array)
+    np.testing.assert_allclose(lazy_array, eager_array, atol=1e-12)
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_lazy_multi_thickness(request, device):
+    """``lazy=True`` works with a thickness sequence."""
+    si = bulk("Si", "diamond", a=5.43, cubic=True)
+    sf = abtem.StructureFactor(si, g_max=12, device=device)
+    bw = BlochWaves(sf, energy=200e3, sg_max=0.1, g_max=2.0, device=device)
+
+    mc = MonteCarloPlasmons(
+        830.0, 17.0, 19.1, num_excitations=1, num_samples=50, ensemble_mean=True,
+        seed=10,
+    )
+    dp = bw.calculate_diffraction_patterns([200.0, 400.0], plasmons=mc, lazy=True)
+    assert hasattr(dp.array, "compute")
+    arr = np.asarray(dp.array.compute())
+    assert arr.shape == (2, 2, len(bw))
+    assert np.isfinite(arr).all()
+
+
+# ---------------------------------------------------------------------------
+# Diffuse background rendering (rigid-shift)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_diffuse_pattern_shape_and_values(request, device):
+    """``calculate_diffuse_diffraction_pattern`` returns images with the right shape and
+    non-negative finite values."""
+    si = bulk("Si", "diamond", a=5.43, cubic=True)
+    sf = abtem.StructureFactor(si, g_max=12, device=device)
+    bw = BlochWaves(sf, energy=200e3, sg_max=0.1, g_max=2.0, device=device)
+
+    mc = MonteCarloPlasmons(
+        830.0, 17.0, 19.1, num_excitations=1, num_samples=200, ensemble_mean=True,
+        seed=7,
+    )
+    result = bw.calculate_diffuse_diffraction_pattern(
+        thickness=300.0, plasmons=mc, gpts=(128, 128),
+    )
+    images = result["images"]
+    orders = result["orders"]
+    weights = result["weights"]
+
+    assert images.shape == (len(orders), 128, 128)
+    assert np.isfinite(images).all()
+    assert (images >= 0).all()
+    assert len(weights) == len(orders)
+    assert result["extent"] is not None
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_diffuse_zero_order_concentrates_at_bragg(request, device):
+    """For order 0 (no events, no tilt), all intensity should land exactly at the
+    unshifted Bragg positions — the image should have non-zero pixels only at the
+    spot locations."""
+    si = bulk("Si", "diamond", a=5.43, cubic=True)
+    sf = abtem.StructureFactor(si, g_max=12, device=device)
+    bw = BlochWaves(sf, energy=200e3, sg_max=0.1, g_max=2.0, device=device)
+
+    mc = MonteCarloPlasmons(
+        830.0, 17.0, 19.1, num_excitations=1, num_samples=100, ensemble_mean=True,
+        seed=3,
+    )
+    result = bw.calculate_diffuse_diffraction_pattern(
+        thickness=300.0, plasmons=mc, gpts=(128, 128),
+    )
+    images = result["images"]
+    orders = result["orders"]
+
+    zero_idx = orders.index(0)
+    zero_image = images[zero_idx]
+    nonzero_pixels = np.count_nonzero(zero_image)
+    assert nonzero_pixels <= len(bw), (
+        f"order-0 image has {nonzero_pixels} non-zero pixels but only "
+        f"{len(bw)} beams — no tilt broadening expected"
+    )
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_diffuse_higher_order_spreads(request, device):
+    """Higher-order images should have more non-zero pixels than zero-order (the
+    rigid-shift broadens the spots)."""
+    si = bulk("Si", "diamond", a=5.43, cubic=True)
+    sf = abtem.StructureFactor(si, g_max=12, device=device)
+    bw = BlochWaves(sf, energy=200e3, sg_max=0.1, g_max=2.0, device=device)
+
+    mc = MonteCarloPlasmons(
+        830.0, 17.0, 19.1, num_excitations=2, num_samples=500, ensemble_mean=True,
+        seed=9,
+    )
+    result = bw.calculate_diffuse_diffraction_pattern(
+        thickness=500.0, plasmons=mc, gpts=(256, 256),
+    )
+    images = result["images"]
+    orders = result["orders"]
+
+    if len(orders) >= 2:
+        nz_zero = np.count_nonzero(images[orders.index(0)])
+        nz_one = np.count_nonzero(images[orders.index(1)])
+        assert nz_one >= nz_zero, (
+            f"single-plasmon image ({nz_one} pixels) should be at least as spread "
+            f"as zero-loss ({nz_zero} pixels)"
+        )


### PR DESCRIPTION
## Summary

Implements the combined Bloch wave-Monte Carlo method for inelastic electron scattering following:

> B. G. Mendis, "Modelling dynamical 3D electron diffraction intensities. II. The role of inelastic scattering", *Acta Cryst.* A**80** (2024).

This adds energy-filtered dynamical diffraction patterns resolved by excitation order (zero-loss, single-plasmon, double-plasmon, etc.), diffuse-background rendering via the rigid-shift model, deterministic depth-slice diffuse DPs, and interleaved phonon+plasmon Monte Carlo -- all integrated into the existing `BlochWaves` API.

---

### New classes (`abtem/inelastic/plasmons.py`)

- **`MonteCarloPlasmons`** -- bulk-plasmon MC sampling with Lorentzian angular distribution, Poisson depth distribution, and configurable excitation orders (Mendis Eq. 5-7)
- **`MonteCarloPhonons`** -- thermal-diffuse-scattering MC sampling using the uncorrelated phonon model with TDS differential cross section and numerical CDF inversion (Mendis Eq. 8-11, 16a-16c)
- **`PlasmonScatteringEvents`** -- mechanism-agnostic event container holding depths, radial/azimuthal angles, and Poisson weights for each MC configuration

### New module: `abtem/bloch/inelastic.py`

**Core MC chain driver:**
- `_chain_one_configuration` -- propagate an electron through a sequence of inelastic scattering events, re-diagonalising the structure matrix at each deflection point
- `calculate_bloch_plasmon_intensities` -- accumulate beam intensities over MC configurations, grouped by excitation order
- `calculate_bloch_diffuse_pattern` -- render 2D diffuse halo images via the rigid-shift model

**Deterministic depth-slice method (Mendis `Bloch_plasmon_DP.m` / `Bloch_phonon_DP.m`):**
- `_plasmon_probability_grid` / `_phonon_probability_grid` -- 2D angular scattering probability grids matching Mendis Matlab discretisation
- `calculate_deterministic_diffuse_dp` -- full depth-slice integration: divide specimen into slices, deflect beam at each depth, re-diagonalise, and propagate to exit surface. Produces smooth, noise-free diffuse patterns.
- `_batched_eigh_propagate` -- dispatch layer for batched eigendecomposition:
  - **CPU**: `numba.prange` parallel kernel (`_numba_eigh_propagate`) that cooperates with OpenBLAS LAPACK threading
  - **GPU**: batched CuPy `eigh` via cuSOLVER
- `_batched_excitation_errors` -- vectorised excitation error computation for B beam directions using `einsum`

**Interleaved phonon+plasmon Monte Carlo (Mendis `Bloch_single_plasmon_phonon.m`):**
- `draw_mixed_scattering_events` -- draw interleaved phonon+plasmon MC configurations with coin-flip event type selection and Poisson path lengths; only configurations with exactly *n* plasmon events are kept
- `calculate_mixed_mc_intensities` -- average beam intensities over mixed MC configurations

### New methods on `BlochWaves` (`abtem/bloch/dynamical.py`)

- `calculate_diffraction_patterns(plasmons=...)` -- returns `IndexedDiffractionPatterns` with a leading ordinal axis for excitation order
- `calculate_diffuse_diffraction_pattern(thickness, plasmons, gpts, extent)` -- returns `DiffractionPatterns` with 2D images of diffuse halos (rigid-shift model)
- `calculate_diffuse_dp_deterministic(thickness, plasmons, num_slices, dp_full, dp_step)` -- deterministic depth-slice diffuse DP returning `DiffractionPatterns`

### Other changes

- `excitation_errors()` extended with `beam_direction` parameter for tilted beams
- `set_structure_matrix_diagonal()` for cheap structure-matrix updates after inelastic deflection
- Lazy/dask execution for the plasmon path (`lazy=True`)
- Multi-thickness support returning `(orders, thicknesses, beams)` shaped arrays
- `BlochwaveEnsemble.calculate_diffraction_patterns(plasmons=...)` for multi-orientation studies
- `np.trapz` to `np.trapezoid` for numpy >= 2.0 compatibility

---

## Performance

### numba.prange parallelisation for CPU eigendecomposition

The deterministic DP requires thousands of independent eigendecompositions of the structure matrix (one per active DP pixel per depth slice). On CPU, `_numba_eigh_propagate` uses `numba.prange` with `objmode` to parallelise these across cores. numba threading cooperates with OpenBLAS GIL release during LAPACK `eigh`, giving significant speedups:

| Beam count | Batch size | Sequential | numba prange | Speedup |
|---|---|---|---|---|
| N=147 | B=1137 | 10.87s | 0.69s | **15.9x** |
| N=409 | B=500 | 37.54s | 13.09s | **2.9x** |

The speedup decreases at larger N because the O(N^3) `eigh` cost per matrix dominates over the parallelisation overhead. Explicit `complex128`/`float64` casts are applied before entering the numba kernel to avoid precision issues when abTEM is configured for float32.

### Benchmark: Mendis 625-beam reproduction ([110]-Si, 200 kV, 629 beams)

Full reproduction of Mendis figures and tables using `g_max=3.0, sg_max=0.155` (629 beams, matching Mendis nline=12 -> 625 ZOLZ beams):

| Stage | Time | Details |
|---|---|---|
| Deterministic DP (Fig 3) | 3042s | 19 slices x 4581 active pixels = 87k eigh calls on 629x629 matrices |
| Single plasmon+phonon MC (Table 2) | 1089s | 5000 configs, interleaved phonon+plasmon events |
| Double plasmon+phonon MC (Table 2) | 2268s | 5000 configs, 2 plasmon events per config |
| **Total** | **6486s** | ~1h 48min on CPU (Apple M-series, 8 cores) |

### Table 2 results (629 beams, 5000 MC configs)

| | I(000) | I(111)/I(000) | I(200)/I(000) | I(220)/I(000) |
|---|---|---|---|---|
| Elastic (zero-loss) | 0.0776 | 1.475 | 0.980 | 0.850 |
| Single plasmon+phonon | 0.0918 | 1.090 | 0.824 | 0.608 |
| Double plasmon+phonon | 0.0928 | 0.982 | 0.786 | 0.569 |
| Phonon N=0 | 0.0776 | 1.475 | 0.980 | 0.850 |
| Phonon N=1 | 0.1371 | 0.358 | 0.519 | 0.255 |

---

## API examples

### Bulk plasmon scattering (silicon, 200 keV)

```python
from ase.build import bulk
from abtem.bloch.dynamical import BlochWaves
from abtem.inelastic.plasmons import MonteCarloPlasmons

si = bulk("Si", cubic=True)

bw = BlochWaves(
    atoms=si, energy=200e3, sg_max=0.05, g_max=3.0,
    centering="F", zone_axes=[0, 0, 1],
)

mc = MonteCarloPlasmons(
    mean_free_path=1000.0,      # angstrom
    excitation_energy=16.7,     # eV (Si bulk plasmon)
    critical_angle=5e-3,        # rad
    num_excitations=3,
    num_samples=50, seed=42,
)

# Energy-filtered diffraction patterns
dp = bw.calculate_diffraction_patterns(300.0, plasmons=mc, lazy=False)
# dp.array shape: (4, num_beams)
```

### Deterministic diffuse DP (depth-slice method)

```python
dp_diffuse = bw.calculate_diffuse_dp_deterministic(
    thickness=1990.0, plasmons=mc,
    num_slices=19, dp_full=150.0, dp_step=0.5,
)
dp_diffuse.show(power=0.5)
```

### Phonon (TDS) scattering

```python
from abtem.inelastic.plasmons import MonteCarloPhonons

phonons = MonteCarloPhonons(
    atoms=si, thermal_sigma=0.076,
    num_excitations=2, num_samples=30, seed=123,
)

dp_phonon = bw.calculate_diffraction_patterns(300.0, plasmons=phonons, lazy=False)
```

---

## Test plan

- [x] `test_zero_events_matches_elastic` -- order-0 reproduces elastic result
- [x] `test_intensity_conservation` -- Poisson-weighted sum does not exceed elastic
- [x] `test_000_decreases_with_plasmon_loss` -- higher-order 000 intensity decreases
- [x] `test_multi_thickness_shape` -- correct `(orders, thicknesses, beams)` shape
- [x] `test_scalar_thickness_backward_compat` -- scalar thickness returns `(orders, beams)`
- [x] `test_phonon_mean_free_path_silicon` -- phonon MFP matches Mendis reference
- [x] `test_phonon_bloch_integration` -- end-to-end phonon + Bloch driver
- [x] `test_lazy_plasmon_matches_eager` -- lazy matches eager within 1e-12
- [x] `test_lazy_multi_thickness` -- lazy multi-thickness correct shape
- [x] `test_diffuse_pattern_shape_and_values` -- correct shape, finite, non-negative
- [x] `test_diffuse_zero_order_concentrates_at_bragg` -- zero-loss at Bragg spots
- [x] `test_diffuse_higher_order_spreads` -- higher orders have diffuse halos
- [x] `test_deterministic_dp_runs` -- depth-slice DP produces valid output
- [x] `test_deterministic_dp_elastic_weight` -- elastic matches `exp(-t/lambda)` weighting
- [x] `test_mixed_mc_draws_correct_count` -- MC draws exactly n_plasmon_target plasmons
- [x] `test_mixed_mc_intensities_finite` -- MC intensities finite and non-negative
- [x] `test_batched_excitation_errors_matches_sequential` -- vectorised sg matches sequential
- [x] `test_numba_eigh_matches_numpy` -- numba prange matches numpy within 1e-10
- [x] All tests parametrised over `["cpu", gpu]` (GPU skipped when CuPy unavailable)
- [x] Existing `test_bloch_waves.py` tests pass (8/8)


Generated with [Claude Code](https://claude.com/claude-code)
