### PR TITLE
Add depth profile visualization for Waves and Potentials

### DIFF
--- a/abtem/potentials/iam.py
+++ b/abtem/potentials/iam.py
@@ -1292,10 +1292,10 @@ class FieldArray(BaseField, ArrayObject):
         array = self.array
 
         if projection_axis == "y":
-            sum_axis = -2
+            sum_axis = -1
             spatial_sampling = self.sampling[0]
         else:
-            sum_axis = -1
+            sum_axis = -2
             spatial_sampling = self.sampling[1]
 
         if depth is not None:

--- a/abtem/potentials/iam.py
+++ b/abtem/potentials/iam.py
@@ -220,6 +220,179 @@ class BaseField(Ensemble, HasGrid2DMixin, EqualityMixin, CopyMixin, metaclass=AB
 
             return self.to_images().show(**kwargs)
 
+    def depth_profile(
+        self,
+        projection_axis: str = "y",
+        depth: Optional[float] = None,
+    ) -> Images:
+        """Create a depth profile by projecting the potential along a spatial axis.
+
+        Parameters
+        ----------
+        projection_axis : str
+            Spatial axis to project (sum) along. ``"y"`` (default) produces an
+            x–z cross-section; ``"x"`` produces a y–z cross-section.
+        depth : float, optional
+            If given, project only over a finite slab of this thickness [Å],
+            centered on the midpoint of the projected axis. The number of grid
+            points is rounded to the nearest integer. If ``None``, the full
+            extent is projected.
+
+        Returns
+        -------
+        depth_profile : Images
+            2D image(s) with the remaining spatial axis horizontal and depth
+            (z) vertical. Any ensemble axes (e.g. frozen phonons) are preserved.
+        """
+        return self.build().depth_profile(
+            projection_axis=projection_axis,
+            depth=depth,
+        )
+
+    def show_depth_profile(
+        self,
+        projection_axis: str = "y",
+        depth: Optional[float] = None,
+        z_scale: float = 1.0,
+        slice_lines: bool = True,
+        ax=None,
+        cbar: bool = False,
+        cmap: Optional[str] = None,
+        vmin: Optional[float] = None,
+        vmax: Optional[float] = None,
+        power: float = 1.0,
+        common_color_scale: bool = False,
+        explode: bool | Sequence[int] = (),
+        figsize: Optional[tuple[int, int]] = None,
+        title: bool | str = True,
+        **kwargs,
+    ):
+        """Show a depth cross-section of the potential.
+
+        Parameters
+        ----------
+        projection_axis : str
+            Spatial axis to project (sum) along. ``"y"`` (default) produces an
+            x–z cross-section; ``"x"`` produces a y–z cross-section.
+        depth : float, optional
+            If given, project only over a finite slab of this thickness [Å],
+            centered on the midpoint of the projected axis. The number of grid
+            points is rounded to the nearest integer. If ``None``, the full
+            extent is projected.
+        z_scale : float
+            Scaling factor for the z-axis relative to the spatial axis.
+            Values less than 1 compress the z-axis, making panels of thick
+            specimens more compact. Default is 1.0 (equal scaling).
+        slice_lines : bool
+            If True (default), draw horizontal lines at slice boundaries.
+        ax : matplotlib.axes.Axes, optional
+            If given the plot is added to the axis.
+        cbar : bool, optional
+            Add a colorbar to the plot. Default is False.
+        cmap : str, optional
+            Matplotlib colormap name.
+        vmin : float, optional
+            Minimum of the color scale.
+        vmax : float, optional
+            Maximum of the color scale.
+        power : float
+            Show image on a power scale.
+        common_color_scale : bool, optional
+            If True, all images in a grid share the same color scale.
+        explode : bool or sequence of int, optional
+            If True, create a grid of images for ensemble items.
+        figsize : two int, optional
+            Figure size as (width, height) in inches.
+        title : bool or str, optional
+            Column title for the images.
+        **kwargs
+            Additional keyword arguments passed to the show method.
+
+        Returns
+        -------
+        visualization : Visualization
+        """
+        from abtem.visualize import Visualization
+
+        profile = self.depth_profile(
+            projection_axis=projection_axis,
+            depth=depth,
+        )
+
+        if figsize is None and ax is None:
+            spatial_extent = profile.extent[0]
+            z_extent = profile.extent[1]
+
+            if explode is True or (isinstance(explode, Sequence) and explode):
+                n_panels = (
+                    profile.ensemble_shape[0] if profile.ensemble_shape else 1
+                )
+            else:
+                n_panels = 1
+
+            visual_ratio = (z_extent * z_scale) / spatial_extent
+            panel_width = 3.0
+            panel_height = panel_width * visual_ratio
+            if panel_height < 1.0:
+                panel_width = min(5.0, 1.0 / visual_ratio)
+                panel_height = panel_width * visual_ratio
+            elif panel_height > 8.0:
+                panel_height = 8.0
+                panel_width = panel_height / visual_ratio
+
+            figsize = (
+                panel_width * n_panels + 1.0 * n_panels + 0.5,
+                max(2.5, panel_height + 1.5),
+            )
+
+        visualization = Visualization(
+            measurement=profile,
+            ax=ax,
+            common_scale=common_color_scale,
+            figsize=figsize,
+            title=title,
+            aspect=False,
+            share_x=True,
+            share_y=True,
+            explode=explode,
+            overlay=(),
+            interactive=True,
+            value_limits=(vmin, vmax),
+            power=power,
+            cmap=cmap,
+            cbar=cbar,
+            **kwargs,
+        )
+
+        spatial_label = "x" if projection_axis == "y" else "y"
+        visualization.set_xlabel(f"{spatial_label} [Å]")
+        visualization.set_ylabel("z [Å]")
+
+        z_sampling = profile.sampling[1]
+        for idx in np.ndindex(visualization.axes.shape):
+            artist = visualization.artists[idx]
+            xlim = artist.get_xlim()
+            ylim = artist.get_ylim()
+            artist.set_extent(
+                (xlim[0], xlim[1], ylim[0] + z_sampling / 2, ylim[1] + z_sampling / 2)
+            )
+
+        visualization.adjust_coordinate_limits_to_artists()
+
+        for idx in np.ndindex(visualization.axes.shape):
+            visualization.axes[idx].set_aspect(z_scale)
+
+        if slice_lines:
+            limits = self.slice_limits
+            z_boundaries = sorted({z for lo, hi in limits for z in (lo, hi)})
+            for idx in np.ndindex(visualization.axes.shape):
+                for z in z_boundaries:
+                    visualization.axes[idx].axhline(
+                        z, color="white", linewidth=0.5, alpha=0.5
+                    )
+
+        return visualization
+
 
 class BasePotential(BaseField, metaclass=ABCMeta):
     """Base class of all potentials. Documented in the subclasses."""
@@ -1085,6 +1258,76 @@ class FieldArray(BaseField, ArrayObject):
             sampling=(self.sampling[0], self.sampling[1]),
             metadata=self.metadata,
             ensemble_axes_metadata=self.axes_metadata[:-2],
+        )
+
+    def depth_profile(
+        self,
+        projection_axis: str = "y",
+        depth: Optional[float] = None,
+    ) -> Images:
+        """Create a depth profile by projecting the potential along a spatial axis.
+
+        Parameters
+        ----------
+        projection_axis : str
+            Spatial axis to project (sum) along. ``"y"`` (default) produces an
+            x–z cross-section; ``"x"`` produces a y–z cross-section.
+        depth : float, optional
+            If given, project only over a finite slab of this thickness [Å],
+            centered on the midpoint of the projected axis. The number of grid
+            points is rounded to the nearest integer. If ``None``, the full
+            extent is projected.
+
+        Returns
+        -------
+        depth_profile : Images
+            2D image(s) with the remaining spatial axis horizontal and depth
+            (z) vertical.
+        """
+        from copy import copy
+
+        if projection_axis not in ("x", "y"):
+            raise ValueError("projection_axis must be 'x' or 'y'.")
+
+        array = self.array
+
+        if projection_axis == "y":
+            sum_axis = -2
+            spatial_sampling = self.sampling[0]
+        else:
+            sum_axis = -1
+            spatial_sampling = self.sampling[1]
+
+        if depth is not None:
+            proj_sampling = (
+                self.sampling[1] if projection_axis == "y" else self.sampling[0]
+            )
+            proj_gpts = self.gpts[1] if projection_axis == "y" else self.gpts[0]
+            n = max(1, min(proj_gpts, round(depth / proj_sampling)))
+            start = (proj_gpts - n) // 2
+            slices = [slice(None)] * len(array.shape)
+            slices[sum_axis] = slice(start, start + n)
+            array = array[tuple(slices)]
+
+        array = array.sum(axis=sum_axis)
+
+        xp = get_array_module(array)
+        if hasattr(array, "rechunk"):
+            array = da.moveaxis(array, -2, -1)
+        else:
+            array = xp.moveaxis(array, -2, -1)
+
+        n_z = self.num_slices
+        z_extent = self.thickness
+        z_sampling = z_extent / n_z if n_z > 0 else 1.0
+
+        metadata = copy(self.metadata)
+
+        return Images(
+            array,
+            sampling=(spatial_sampling, z_sampling),
+            ensemble_axes_metadata=self.ensemble_axes_metadata,
+            metadata=metadata,
         )
 
     def project(self) -> Images:

--- a/abtem/visualize/axes_grid.py
+++ b/abtem/visualize/axes_grid.py
@@ -8,7 +8,26 @@ from matplotlib.axes import Axes
 from mpl_toolkits.axes_grid1 import Divider, Size
 from mpl_toolkits.axes_grid1.axes_grid import _cbaraxes_class_factory
 
+from matplotlib.transforms import Bbox
+
 from abtem.core.utils import flatten_list_of_lists, interleave
+
+
+class _SyncedCbarLocator:
+    """Locator that keeps a colorbar aligned with a reference axes."""
+
+    def __init__(self, original_locator, ref_ax, sync_axis="y"):
+        self._original = original_locator
+        self._ref_ax = ref_ax
+        self._sync_axis = sync_axis
+
+    def __call__(self, axes, renderer):
+        pos = self._original(axes, renderer)
+        ref = self._ref_ax.get_position(original=False)
+        if self._sync_axis == "y":
+            return Bbox.from_bounds(pos.x0, ref.y0, pos.width, ref.height)
+        else:
+            return Bbox.from_bounds(ref.x0, pos.y0, ref.width, pos.height)
 
 
 def _cbar_orientation(cbar_loc):
@@ -103,6 +122,9 @@ class AxesGrid:
 
         self._set_axes_locators()
         self._set_caxes_locators()
+
+        if ncbars > 0:
+            self._connect_cbar_sync()
 
         if sharex:
             for inner_axes in self._axes[:, 1:]:
@@ -294,6 +316,18 @@ class AxesGrid:
             line_types = ["bottom"] + line_types + ["top"]
 
         return line_types
+
+    def _connect_cbar_sync(self):
+        ref_ax = self._axes.ravel()[0]
+        sync_axis = "y" if self._cbar_loc == "right" else "x"
+        for cax in self._caxes.ravel():
+            if cax is None or cax == 0:
+                continue
+            original_locator = cax.get_axes_locator()
+            if original_locator is not None:
+                cax.set_axes_locator(
+                    _SyncedCbarLocator(original_locator, ref_ax, sync_axis)
+                )
 
     def set_sizes(self, **kwargs):
         for key, value in kwargs.items():

--- a/abtem/waves.py
+++ b/abtem/waves.py
@@ -23,6 +23,7 @@ from abtem.core.axes import (
     OrdinalAxis,
     RealSpaceAxis,
     ReciprocalSpaceAxis,
+    ThicknessAxis,
 )
 from abtem.core.backend import (
     device_name_from_array_module,
@@ -774,6 +775,270 @@ class Waves(BaseWaves, ArrayObject):
             The imaginary part of the wave functions.
         """
         return self.to_images(convert_complex="imag")
+
+    def depth_profile(
+        self,
+        projection_axis: str = "y",
+        depth: Optional[float] = None,
+        convert_complex: str = "intensity",
+    ) -> Images:
+        """Create a depth profile by projecting wave functions along a spatial axis.
+
+        Requires wave functions with a thickness dimension, i.e. from a multislice
+        simulation with ``exit_planes``.
+
+        Parameters
+        ----------
+        projection_axis : str
+            Spatial axis to project (sum) along. ``"y"`` (default) produces an
+            x–z cross-section; ``"x"`` produces a y–z cross-section.
+        depth : float, optional
+            If given, project only over a finite slab of this thickness [Å],
+            centered on the midpoint of the projected axis. The number of grid
+            points is rounded to the nearest integer. If ``None``, the full
+            extent is projected.
+        convert_complex : str
+            How to convert the complex wave function before projecting. One of
+            ``"intensity"`` (default), ``"phase"``, ``"real"``, or ``"imag"``.
+
+        Returns
+        -------
+        depth_profile : Images
+            2D image(s) with the depth (z) as the first base axis and the
+            remaining spatial axis as the second. Any additional ensemble axes
+            (e.g. scan positions) are preserved.
+        """
+        thickness_idx = None
+        for i, ax in enumerate(self.ensemble_axes_metadata):
+            if isinstance(ax, ThicknessAxis):
+                thickness_idx = i
+                break
+
+        if thickness_idx is None:
+            raise ValueError(
+                "Wave functions must have a ThicknessAxis (use exit_planes "
+                "in the potential to record waves at each slice)."
+            )
+
+        if projection_axis not in ("x", "y"):
+            raise ValueError("projection_axis must be 'x' or 'y'.")
+
+        if convert_complex in ("domain_coloring", "none", None):
+            images = self.to_images(convert_complex=None)
+        else:
+            images = self.to_images(convert_complex=convert_complex)
+        array = images.array
+
+        if projection_axis == "y":
+            sum_axis = -2
+            spatial_sampling = self.sampling[0]
+            spatial_gpts = self.gpts[0]
+        else:
+            sum_axis = -1
+            spatial_sampling = self.sampling[1]
+            spatial_gpts = self.gpts[1]
+
+        if depth is not None:
+            proj_sampling = self.sampling[1] if projection_axis == "y" else self.sampling[0]
+            proj_gpts = self.gpts[1] if projection_axis == "y" else self.gpts[0]
+            n = max(1, min(proj_gpts, round(depth / proj_sampling)))
+            start = (proj_gpts - n) // 2
+            slices = [slice(None)] * len(array.shape)
+            slices[sum_axis] = slice(start, start + n)
+            array = array[tuple(slices)]
+
+        array = array.sum(axis=sum_axis)
+
+        xp = get_array_module(array)
+        if hasattr(array, "rechunk"):
+            array = da.moveaxis(array, thickness_idx, -1)
+        else:
+            array = xp.moveaxis(array, thickness_idx, -1)
+
+        thickness_values = self.ensemble_axes_metadata[thickness_idx].values
+        z_extent = max(thickness_values)
+        n_z = len(thickness_values)
+        z_sampling = z_extent / n_z if n_z > 0 else 1.0
+
+        remaining_metadata = [
+            ax
+            for i, ax in enumerate(self.ensemble_axes_metadata)
+            if i != thickness_idx
+        ]
+
+        metadata = copy(self.metadata)
+        metadata["label"] = convert_complex
+        metadata["units"] = "arb. unit"
+
+        return Images(
+            array,
+            sampling=(spatial_sampling, z_sampling),
+            ensemble_axes_metadata=remaining_metadata,
+            metadata=metadata,
+        )
+
+    def show_depth_profile(
+        self,
+        projection_axis: str = "y",
+        depth: Optional[float] = None,
+        convert_complex: str = "intensity",
+        z_scale: float = 1.0,
+        slice_lines: bool = False,
+        ax=None,
+        cbar: bool = False,
+        cmap: Optional[str] = None,
+        vmin: Optional[float] = None,
+        vmax: Optional[float] = None,
+        power: float = 1.0,
+        common_color_scale: bool = False,
+        explode: bool | Sequence[int] = (),
+        figsize: Optional[tuple[int, int]] = None,
+        title: bool | str = True,
+        **kwargs,
+    ) -> Visualization:
+        """Show a depth propagation profile of the wave functions.
+
+        Requires wave functions with a thickness dimension, i.e. from a multislice
+        simulation with ``exit_planes``.
+
+        Parameters
+        ----------
+        projection_axis : str
+            Spatial axis to project (sum) along. ``"y"`` (default) produces an
+            x–z cross-section; ``"x"`` produces a y–z cross-section.
+        depth : float, optional
+            If given, project only over a finite slab of this thickness [Å],
+            centered on the midpoint of the projected axis. The number of grid
+            points is rounded to the nearest integer. If ``None``, the full
+            extent is projected.
+        convert_complex : str
+            How to convert the complex wave function before projecting. One of
+            ``"intensity"`` (default), ``"phase"``, ``"real"``, or ``"imag"``.
+        z_scale : float
+            Scaling factor for the z-axis relative to the spatial axis.
+            Values less than 1 compress the z-axis, making panels of thick
+            specimens more compact. Default is 1.0 (equal scaling).
+        slice_lines : bool
+            If True, draw horizontal lines at slice boundaries. Default is
+            False.
+        ax : matplotlib.axes.Axes, optional
+            If given the plot is added to the axis.
+        cbar : bool, optional
+            Add a colorbar to the plot. Default is False.
+        cmap : str, optional
+            Matplotlib colormap name.
+        vmin : float, optional
+            Minimum of the intensity color scale.
+        vmax : float, optional
+            Maximum of the intensity color scale.
+        power : float
+            Show image on a power scale.
+        common_color_scale : bool, optional
+            If True, all images in a grid share the same color scale.
+        explode : bool or sequence of int, optional
+            If True, create a grid of images for ensemble items.
+        figsize : two int, optional
+            Figure size as (width, height) in inches.
+        title : bool or str, optional
+            Column title for the images.
+        **kwargs
+            Additional keyword arguments passed to the show method.
+
+        Returns
+        -------
+        visualization : Visualization
+        """
+        profile = self.depth_profile(
+            projection_axis=projection_axis,
+            depth=depth,
+            convert_complex=convert_complex,
+        )
+
+        if figsize is None and ax is None:
+            spatial_extent = profile.extent[0]
+            z_extent = profile.extent[1]
+
+            if explode is True or (isinstance(explode, Sequence) and explode):
+                n_panels = (
+                    profile.ensemble_shape[0] if profile.ensemble_shape else 1
+                )
+            else:
+                n_panels = 1
+
+            visual_ratio = (z_extent * z_scale) / spatial_extent
+            panel_width = 3.0
+            panel_height = panel_width * visual_ratio
+            if panel_height < 1.0:
+                panel_width = min(5.0, 1.0 / visual_ratio)
+                panel_height = panel_width * visual_ratio
+            elif panel_height > 8.0:
+                panel_height = 8.0
+                panel_width = panel_height / visual_ratio
+
+            figsize = (
+                panel_width * n_panels + 1.0 * n_panels + 0.5,
+                max(2.5, panel_height + 1.5),
+            )
+
+        from abtem.visualize import Visualization
+
+        viz_complex = convert_complex if convert_complex in (
+            "domain_coloring", "none", None
+        ) else "none"
+
+        visualization = Visualization(
+            measurement=profile,
+            ax=ax,
+            common_scale=common_color_scale,
+            figsize=figsize,
+            title=title,
+            aspect=False,
+            share_x=True,
+            share_y=True,
+            explode=explode,
+            overlay=(),
+            interactive=True,
+            value_limits=(vmin, vmax),
+            power=power,
+            cmap=cmap,
+            cbar=cbar,
+            convert_complex=viz_complex,
+            **kwargs,
+        )
+
+        spatial_label = "x" if projection_axis == "y" else "y"
+        visualization.set_xlabel(f"{spatial_label} [Å]")
+        visualization.set_ylabel("z [Å]")
+
+        z_sampling = profile.sampling[1]
+        for idx in np.ndindex(visualization.axes.shape):
+            artist = visualization.artists[idx]
+            xlim = artist.get_xlim()
+            ylim = artist.get_ylim()
+            artist.set_extent(
+                (xlim[0], xlim[1], ylim[0] + z_sampling / 2, ylim[1] + z_sampling / 2)
+            )
+
+        visualization.adjust_coordinate_limits_to_artists()
+
+        for idx in np.ndindex(visualization.axes.shape):
+            visualization.axes[idx].set_aspect(z_scale)
+
+        if slice_lines:
+            thickness_idx = None
+            for i, ax_meta in enumerate(self.ensemble_axes_metadata):
+                if isinstance(ax_meta, ThicknessAxis):
+                    thickness_idx = i
+                    break
+            if thickness_idx is not None:
+                z_positions = self.ensemble_axes_metadata[thickness_idx].values
+                for idx in np.ndindex(visualization.axes.shape):
+                    for z in z_positions:
+                        visualization.axes[idx].axhline(
+                            z, color="white", linewidth=0.5, alpha=0.5
+                        )
+
+        return visualization
 
     def downsample(
         self,

--- a/abtem/waves.py
+++ b/abtem/waves.py
@@ -830,11 +830,11 @@ class Waves(BaseWaves, ArrayObject):
         array = images.array
 
         if projection_axis == "y":
-            sum_axis = -2
+            sum_axis = -1
             spatial_sampling = self.sampling[0]
             spatial_gpts = self.gpts[0]
         else:
-            sum_axis = -1
+            sum_axis = -2
             spatial_sampling = self.sampling[1]
             spatial_gpts = self.gpts[1]
 

--- a/test/test_potentials.py
+++ b/test/test_potentials.py
@@ -1,4 +1,5 @@
 import hypothesis.strategies as st
+import numpy as np
 import pytest
 import strategies as abtem_st
 from hypothesis import given
@@ -310,3 +311,75 @@ def test_crystal_potential_get_sliced_atoms_raises_for_array_unit():
 #
 #     potential1 = potential1.build(lazy=False)
 #     potential2 = potential2.build(lazy=False)
+
+
+# --- depth_profile tests ---
+
+
+@pytest.fixture
+def si_potential():
+    """Build a Si 2x2x5 potential for depth profile tests."""
+    from ase.build import bulk
+
+    atoms = bulk("Si", cubic=True) * (2, 2, 5)
+    return Potential(atoms, slice_thickness=1.0, gpts=(32, 32))
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_potential_depth_profile_shape(si_potential, device):
+    pot = si_potential.build().compute()
+    profile = pot.depth_profile()
+    n_x = pot.gpts[0]
+    n_z = pot.num_slices
+    assert profile.shape == (n_x, n_z)
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_potential_depth_profile_x_projection(si_potential, device):
+    pot = si_potential.build().compute()
+    profile = pot.depth_profile(projection_axis="x")
+    n_y = pot.gpts[1]
+    n_z = pot.num_slices
+    assert profile.shape == (n_y, n_z)
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_potential_depth_profile_sampling(si_potential, device):
+    pot = si_potential.build().compute()
+    profile = pot.depth_profile()
+
+    assert np.isclose(profile.sampling[0], pot.sampling[0])
+
+    expected_z_sampling = pot.thickness / pot.num_slices
+    assert np.isclose(profile.sampling[1], expected_z_sampling)
+
+
+def test_potential_depth_profile_invalid_axis(si_potential):
+    pot = si_potential.build().compute()
+    with pytest.raises(ValueError, match="projection_axis"):
+        pot.depth_profile(projection_axis="z")
+
+
+def test_potential_depth_profile_finite_depth(si_potential):
+    pot = si_potential.build().compute()
+    full = pot.depth_profile()
+    partial = pot.depth_profile(depth=3.0)
+    assert full.shape == partial.shape
+    assert partial.array.sum() < full.array.sum()
+
+
+def test_potential_depth_profile_lazy_delegation(si_potential):
+    profile_lazy = si_potential.depth_profile()
+    profile_built = si_potential.build().compute().depth_profile()
+    assert profile_lazy.shape == profile_built.shape
+    assert np.allclose(profile_lazy.array, profile_built.array)
+
+
+def test_potential_show_depth_profile(si_potential):
+    import matplotlib
+
+    matplotlib.use("Agg")
+    from abtem.visualize import Visualization
+
+    viz = si_potential.show_depth_profile()
+    assert isinstance(viz, Visualization)

--- a/test/test_waves.py
+++ b/test/test_waves.py
@@ -400,3 +400,87 @@ def test_tile(data, repetitions, renormalize, lazy, device):
             .array.sum((-2, -1))
         )
         assert np.allclose(old_sum, new_sum)
+
+
+@pytest.fixture
+def exit_plane_waves():
+    """Create Waves with a ThicknessAxis for depth_profile tests."""
+    import abtem
+    import ase
+
+    silicon = ase.build.bulk("Si", cubic=True)
+    atoms = silicon * (2, 2, 5)
+    atoms.center(axis=2)
+
+    potential = abtem.Potential(
+        atoms, slice_thickness=2.0, gpts=(32, 32), exit_planes=1
+    )
+    probe = abtem.Probe(energy=200e3, semiangle_cutoff=10)
+    probe.match_grid(potential)
+
+    pos = atoms.positions[0][:2]
+    scan = abtem.CustomScan([pos])
+    return probe.multislice(potential, scan).compute()
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_depth_profile_shape(exit_plane_waves, device):
+    profile = exit_plane_waves.depth_profile()
+    n_z = exit_plane_waves.shape[0]
+    n_x = exit_plane_waves.shape[-1]
+    assert profile.shape == (1, n_x, n_z)
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_depth_profile_projection_axis_x(exit_plane_waves, device):
+    profile = exit_plane_waves.depth_profile(projection_axis="x")
+    n_z = exit_plane_waves.shape[0]
+    n_y = exit_plane_waves.shape[-2]
+    assert profile.shape == (1, n_y, n_z)
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_depth_profile_sampling(exit_plane_waves, device):
+    from abtem.core.axes import ThicknessAxis
+
+    profile = exit_plane_waves.depth_profile()
+
+    thickness_ax = None
+    for ax in exit_plane_waves.ensemble_axes_metadata:
+        if isinstance(ax, ThicknessAxis):
+            thickness_ax = ax
+            break
+
+    z_extent = max(thickness_ax.values)
+    n_z = len(thickness_ax.values)
+    expected_z_sampling = z_extent / n_z
+
+    assert np.isclose(profile.sampling[0], exit_plane_waves.sampling[0])
+    assert np.isclose(profile.sampling[1], expected_z_sampling)
+
+
+def test_depth_profile_no_thickness_axis_raises():
+    import abtem
+
+    probe = abtem.Probe(energy=200e3, semiangle_cutoff=10, extent=10, gpts=32)
+    waves = probe.build([5.0, 5.0])
+    with pytest.raises(ValueError, match="ThicknessAxis"):
+        waves.depth_profile()
+
+
+def test_depth_profile_invalid_axis_raises(exit_plane_waves):
+    with pytest.raises(ValueError, match="projection_axis"):
+        exit_plane_waves.depth_profile(projection_axis="z")
+
+
+def test_depth_profile_finite_depth(exit_plane_waves):
+    full = exit_plane_waves.depth_profile()
+    partial = exit_plane_waves.depth_profile(depth=3.0)
+    assert full.shape == partial.shape
+    assert partial.array.sum() < full.array.sum()
+
+
+@pytest.mark.parametrize("convert_complex", ["intensity", "phase", "real", "imag"])
+def test_depth_profile_convert_complex(exit_plane_waves, convert_complex):
+    profile = exit_plane_waves.depth_profile(convert_complex=convert_complex)
+    assert profile.array.shape[-2:] == (exit_plane_waves.shape[-1], exit_plane_waves.shape[0])


### PR DESCRIPTION
## Summary

Implements depth propagation visualization for wave functions and electrostatic potentials, as requested in #180.

### Waves

Adds two methods to `Waves`:

- **`depth_profile(projection_axis, depth, convert_complex)`** — computes a 2D spatial-vs-depth cross-section from multislice waves recorded at every exit plane (`exit_planes=1`). Returns an `Images` object with the spatial axis horizontal and depth (z) vertical, z=0 at bottom.
- **`show_depth_profile(...)`** — convenience visualization wrapper with auto-computed figure sizing, `z_scale` for compressing the z-axis of thick specimens, `slice_lines` for marking exit planes, and all standard show kwargs (`cbar`, `cmap`, `power`, `explode`, etc.).

### Potentials

Adds matching methods to `BaseField` (lazy `Potential`) and `FieldArray` (`PotentialArray`):

- **`depth_profile(projection_axis, depth)`** — computes a 2D spatial-vs-depth cross-section by summing the 3D potential along a spatial axis. `BaseField` delegates via `.build()`.
- **`show_depth_profile(...)`** — same visualization API as the Waves version (minus `convert_complex` since potentials are real-valued). Slice boundary lines enabled by default.

## API reference

### `Waves.show_depth_profile()`

```python
viz = waves.show_depth_profile(
    projection_axis='y',        # 'x' or 'y'
    depth=None,                 # finite projection depth in Å
    convert_complex='intensity',# 'intensity', 'phase', 'real', 'imag', 'domain_coloring'
    z_scale=0.1,                # compress z-axis (< 1 = shorter)
    slice_lines=False,          # draw lines at exit planes
    explode=True,               # separate panels per scan position
    cbar=True, cmap='viridis',  # colorbar + colormap
    common_color_scale=True,    # shared color scale across panels
    power=0.5,                  # power scaling
)
```

### `Potential.show_depth_profile()`

```python
viz = potential.show_depth_profile(
    projection_axis='y',        # 'x' or 'y'
    depth=None,                 # finite projection depth in Å
    z_scale=1.0,                # compress z-axis
    slice_lines=True,           # draw lines at slice boundaries (default True)
    cbar=True, cmap='hot',      # colorbar + colormap
    power=0.5,                  # power scaling
)
```

## Showcase — Waves

All examples use a 217 Å thick Si specimen (2×2×40 supercell, 64×64 grid, `exit_planes=1`) with two probe positions — on-column (1.36, 1.36 Å) and midway between columns (2.04, 1.36 Å) — with `z_scale=0.1`, `cbar=True`, and `common_color_scale=True`.

### Intensity (default)

```python
waves.show_depth_profile(explode=True, z_scale=0.1, cbar=True, common_color_scale=True)
```

<img width="2250" height="2116" alt="showcase_intensity" src="https://github.com/user-attachments/assets/eaba6af6-54c4-46b9-bc59-95cf350a4eb4" />

### Phase

```python
waves.show_depth_profile(explode=True, z_scale=0.1, convert_complex='phase', cmap='twilight', cbar=True, common_color_scale=True)
```

<img width="2311" height="2077" alt="showcase_phase" src="https://github.com/user-attachments/assets/dfc89e5e-efb1-44ee-bac0-97c542a4bbe5" />

### Domain coloring

```python
waves.show_depth_profile(explode=True, z_scale=0.1, convert_complex='domain_coloring')
```
<img width="2344" height="2242" alt="showcase_domain_coloring" src="https://github.com/user-attachments/assets/adad653c-de8e-419f-bb2d-d5d802b6ab99" />

## Showcase — Potentials

### Infinite vs finite projection comparison

Comparison of infinite and finite projection integrals across three slice thicknesses (a/4, a/8, a/16) for Si 2×2×3, with z-projected potentials showing conservation. Atoms are centered between slice boundaries with commensurate slicing.

<img width="4768" height="4145" alt="potential_inf_vs_fin_lobato" src="https://github.com/user-attachments/assets/6ef82144-e7c9-4912-a77d-d42b3cae910a" />

## Design decisions

- **z=0 at bottom**: Uses `origin="lower"` via the standard `ImshowArtist`, matching the physical convention where the beam enters at the top of the specimen.
- **Pixel-to-coordinate alignment**: The imshow extent is shifted by `z_sampling/2` so that pixel centers map to slice centers (not slice boundaries).
- **`slice_lines`**: Default `True` for potentials (where slice boundaries are physically meaningful), `False` for Waves (where exit planes are less visually important).
- **`aspect=False` + `set_aspect(z_scale)` on axes**: Panels fill their allocated figure space while maintaining the correct data aspect ratio.
- **Auto figsize**: Computed from the data aspect ratio and z_scale, with clamping to keep panels between 1–8 inches in each dimension.
- **Consistent API**: Waves and Potential share the same parameter names and behavior, minus `convert_complex` for potentials.
- **Lazy delegation**: `Potential.depth_profile()` delegates to `self.build().depth_profile()`, matching the pattern used by `show()` and `project()`.
- **Domain coloring**: `convert_complex='domain_coloring'` renders phase as hue and amplitude as brightness, using abTEM's existing `DomainColoringArtist`. Complex data is passed through without conversion to `Visualization`.

## Test plan

### Waves tests (test_waves.py)
- [x] `test_depth_profile_shape` — correct output shape for y-projection
- [x] `test_depth_profile_projection_axis_x` — correct shape for x-projection
- [x] `test_depth_profile_sampling` — z and spatial sampling match expectations
- [x] `test_depth_profile_no_thickness_axis_raises` — error without ThicknessAxis
- [x] `test_depth_profile_invalid_axis_raises` — error for invalid projection axis
- [x] `test_depth_profile_finite_depth` — partial sum < full sum
- [x] `test_depth_profile_convert_complex` — all 4 conversion types produce correct shapes

### Potential tests (test_potentials.py)
- [x] `test_potential_depth_profile_shape` — correct (n_x, n_z) shape
- [x] `test_potential_depth_profile_x_projection` — correct (n_y, n_z) shape
- [x] `test_potential_depth_profile_sampling` — spatial and z sampling correct
- [x] `test_potential_depth_profile_invalid_axis` — error for invalid axis
- [x] `test_potential_depth_profile_finite_depth` — partial sum < full sum
- [x] `test_potential_depth_profile_lazy_delegation` — Potential and PotentialArray produce identical results
- [x] `test_potential_show_depth_profile` — returns Visualization object
- [x] All 1379 tests pass

Closes #180
