### PR TITLE
Fix order-2 Fourier propagator cross-term

### DIFF
--- a/abtem/multislice.py
+++ b/abtem/multislice.py
@@ -64,15 +64,15 @@ def _fresnel_propagator_array(
     kx, ky = spatial_frequencies(gpts, sampling, xp=xp)
     kx, ky = kx[:, None], ky[None]
 
-    f = complex_exponential(
-        -(kx**2) * np.pi * thickness * wavelength
-    ) * complex_exponential(-(ky**2) * np.pi * thickness * wavelength)
+    k2 = kx**2 + ky**2
+
+    f = complex_exponential(-k2 * np.pi * thickness * wavelength)
 
     # Propagator corrected in Fourier-space, only valid for order=2
     # Eq. (4) from Microscopy and Microanalysis (2020), 26, 1147-1157
     if order == 2:
         f = f * complex_exponential(
-            (-np.pi * thickness * wavelength**3) / 4.0 * (kx**4 + ky**4)
+            (-np.pi * thickness * wavelength**3) / 4.0 * k2**2
         )
     return f
 


### PR DESCRIPTION
## Summary

- The second-order propagator correction merged in https://github.com/abTEM/abTEM/issues/236 used the separable form `kx**4 + ky**4` instead of the correct radial form `(kx**2 + ky**2)**2`, missing the `2*kx**2*ky**2` cross-term. This caused phase errors of up to ~0.45 rad at the grid corners for typical parameters.
- Also consolidates the order-1 propagator from the separable product `exp(-iπΔzλkx²)·exp(-iπΔzλky²)` to a single `exp(-iπΔzλk⊥²)`, which is mathematically identical but consistent with the radial order-2 correction.

The fix changes `kx**4 + ky**4` → `k2**2` where `k2 = kx**2 + ky**2`, matching the formula in Eq. (4) of *Microscopy and Microanalysis* (2020), 26, 1147–1157.

No change to default behavior (order=1).

## Test plan

- [x] All `test_realspace_multislice.py` tests pass (38 passed, 9 GPU-skipped)
- [x] `test_fourier_order2_differs_from_order1` still passes (confirms order 2 is distinct)
- [x] `test_fourier_orders` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)