### PR TITLE
Add logscale display option for diffraction patterns and images

### DIFF
--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -1191,6 +1191,7 @@ class _BaseMeasurement2D(BaseMeasurements):
         vmin: Optional[float] = None,
         vmax: Optional[float] = None,
         power: float = 1.0,
+        logscale: bool = False,
         common_color_scale: bool = False,
         explode: bool | Sequence[int] = (),
         overlay: bool | Sequence[int] = (),
@@ -1222,7 +1223,10 @@ class _BaseMeasurement2D(BaseMeasurements):
             Maximum of the intensity color scale. Default is the maximum of the array
             values.
         power : float
-            Show image on a power scale.
+            Show image on a power scale. Cannot be used together with ``logscale``.
+        logscale : bool
+            If True, show image on a logarithmic intensity scale. Cannot be used
+            together with ``power != 1.0``.
         common_color_scale : bool, optional
             If True all images in an image grid are shown on the same colorscale, and a
             single colorbar is created (if it is requested). Default is False.
@@ -1272,6 +1276,7 @@ class _BaseMeasurement2D(BaseMeasurements):
             interactive=not interact and display,
             value_limits=(vmin, vmax),
             power=power,
+            logscale=logscale,
             cmap=cmap,
             cbar=cbar,
             units=units,
@@ -4143,6 +4148,7 @@ class PolarMeasurements(BaseMeasurements):
         vmin: Optional[float] = None,
         vmax: Optional[float] = None,
         power: float = 1.0,
+        logscale: bool = False,
         common_color_scale: bool = False,
         explode: bool | Sequence[bool] = (),
         overlay: bool | Sequence[int] = (),
@@ -4176,7 +4182,10 @@ class PolarMeasurements(BaseMeasurements):
             Maximum of the intensity color scale. Default is the maximum of the array
             values.
         power : float
-            Show image on a power scale.
+            Show image on a power scale. Cannot be used together with ``logscale``.
+        logscale : bool
+            If True, show image on a logarithmic intensity scale. Cannot be used
+            together with ``power != 1.0``.
         common_color_scale : bool, optional
             If True all images in an image grid are shown on the same colorscale, and a
             single colorbar is created (if it is requested). Default is False.
@@ -4223,6 +4232,7 @@ class PolarMeasurements(BaseMeasurements):
             vmin=vmin,
             vmax=vmax,
             power=power,
+            logscale=logscale,
             common_color_scale=common_color_scale,
             explode=explode,
             overlay=overlay,
@@ -4788,6 +4798,7 @@ class IndexedDiffractionPatterns(BaseMeasurements):
         vmin: Optional[float] = None,
         vmax: Optional[float] = None,
         power: float = 1.0,
+        logscale: bool = False,
         common_color_scale: bool = False,
         scale: float = 0.5,
         explode: bool | Sequence[bool] = (),
@@ -4820,7 +4831,11 @@ class IndexedDiffractionPatterns(BaseMeasurements):
             Maximum of the intensity color scale. Default is the maximum of the array
             values.
         power : float
-            Show diffraction spots intensities on a power scale.
+            Show diffraction spots intensities on a power scale. Cannot be used
+            together with ``logscale``.
+        logscale : bool
+            If True, show diffraction spots on a logarithmic intensity scale.
+            Cannot be used together with ``power != 1.0``.
         common_color_scale : bool, optional
             If True all images in an image grid are shown on the same colorscale, and a
             single colorbar is created (if it is requested). Default is False.
@@ -4878,6 +4893,7 @@ class IndexedDiffractionPatterns(BaseMeasurements):
             interactive=not interact and display,
             value_limits=(vmin, vmax),
             power=power,
+            logscale=logscale,
             cmap=cmap,
             cbar=cbar,
             scale=scale,

--- a/abtem/visualize/artists.py
+++ b/abtem/visualize/artists.py
@@ -36,9 +36,13 @@ def _get_norm(vmin=None, vmax=None, power=1.0, logscale=False):
     elif (power != 1.0) and (logscale is False):
         norm = colors.PowerNorm(gamma=power, vmin=vmin, vmax=vmax)
     elif (power == 1.0) and (logscale is True):
+        if vmin is not None and vmin <= 0:
+            vmin = None
         norm = colors.LogNorm(vmin=vmin, vmax=vmax)
     else:
-        raise ValueError("")
+        raise ValueError(
+            "Cannot use both power != 1.0 and logscale=True simultaneously."
+        )
 
     return norm
 
@@ -360,13 +364,19 @@ class Artist2D(Artist):
         norm.vmax = vmax
 
     @staticmethod
-    def _update_norm(old_norm, power, artist):
-        if (power != 1.0) and isinstance(old_norm, colors.PowerNorm):
+    def _update_norm(old_norm, power, artist, logscale=False):
+        if (
+            not logscale
+            and (power != 1.0)
+            and isinstance(old_norm, colors.PowerNorm)
+        ):
             old_norm.gamma = power
             artist.norm = old_norm
             old_norm._changed()
         else:
-            norm = _get_norm(vmin=old_norm.vmin, vmax=old_norm.vmax, power=power)
+            norm = _get_norm(
+                vmin=old_norm.vmin, vmax=old_norm.vmax, power=power, logscale=logscale
+            )
             artist.norm = norm
 
     @staticmethod
@@ -548,6 +558,10 @@ class ImageArtist(Artist2D):
 
     def set_power(self, power: float = 1.0):
         self._update_norm(self.norm, power, self.axes_image)
+
+    def set_logscale(self, logscale: bool = False):
+        power = self.get_power()
+        self._update_norm(self.norm, power, self.axes_image, logscale=logscale)
 
     def set_value_limits(self, value_limits: tuple[float, float] = None):
         self._set_vmin_vmax(self.norm, *value_limits)
@@ -953,6 +967,10 @@ class ScatterArtist(Artist2D):
 
     def set_power(self, power: float = 1.0):
         self._update_norm(self.norm, power, self._circles)
+
+    def set_logscale(self, logscale: bool = False):
+        power = self.get_power()
+        self._update_norm(self.norm, power, self._circles, logscale=logscale)
 
 
 class DomainColoringArtist(Artist2D):

--- a/abtem/visualize/visualizations.py
+++ b/abtem/visualize/visualizations.py
@@ -403,6 +403,9 @@ class Visualization:
     def set_power(self, power: float = 1.0):
         self.set_artists("power", power=power)
 
+    def set_logscale(self, logscale: bool = False):
+        self.set_artists("logscale", logscale=logscale)
+
     def set_common_value_limits(self, value_limits=(None, None)):
         value_limits = _get_value_limits(
             self._measurement.array, value_limits=value_limits


### PR DESCRIPTION
## Summary
- Adds `logscale: bool = False` parameter to `.show()` on `DiffractionPatterns`, `Images`, `PolarMeasurements`, and `IndexedDiffractionPatterns`
- Uses matplotlib `LogNorm` for color mapping (existing `_get_norm` backend already supported it, this threads it through the public API)
- Adds `Visualization.set_logscale()` for toggling log scale on an existing figure
- Improves error message when `power != 1.0` and `logscale=True` are combined

## Usage
```python
dp.show(logscale=True)

# or toggle on an existing visualization:
vis = dp.show()
vis.set_logscale(True)
```

## Test plan
- [x] `dp.show(logscale=True)` produces a LogNorm color scale
- [x] `dp.show(power=0.5)` still works (PowerNorm)
- [x] `dp.show()` default unchanged (Normalize)
- [x] `vis.set_logscale(True)` toggles an existing visualization
- [x] `dp.show(power=0.5, logscale=True)` raises ValueError

🤖 Generated with [Claude Code](https://claude.com/claude-code)