### PR TITLE
Focal series with incoherent waves

### DIFF
--- a/abtem/transfer.py
+++ b/abtem/transfer.py
@@ -969,7 +969,7 @@ class TemporalEnvelope(BaseTransferFunction):
     @property
     def ensemble_axes_metadata(self) -> list[AxisMetadata]:
         return self._get_axes_metadata_from_distributions(
-            focal_spread={"units": "mrad"}
+            focal_spread={"units": "Å"}
         )
 
     def _evaluate_from_angular_grid(

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1,7 +1,8 @@
 import numpy as np
 
 from abtem import distributions
-from abtem.waves import Probe
+from abtem.transfer import CTF
+from abtem.waves import PlaneWave, Probe
 
 
 def test_gaussian_distribution_normalized():
@@ -10,3 +11,70 @@ def test_gaussian_distribution_normalized():
     assert np.allclose(
         wave.build().diffraction_patterns().reduce_ensemble().array.sum().compute(), 1.0
     )
+
+
+def test_focal_series_with_incoherent_spread():
+    # Answers https://github.com/abTEM/abTEM/issues/168: a focal series (kept as
+    # its own axis) where each defocus step is itself an incoherent
+    # (temporal-coherence) average. Composing two apply_ctf() calls works because
+    # the defocus phase term is linear in defocus, so applying CTF twice with
+    # independent defocus distributions equals a single application with summed
+    # defocus.
+    #
+    # Both distributions use ensemble_mean=False and the incoherent spread axis is
+    # reduced with a plain .sum(): abTEM pre-multiplies the wave amplitude by the
+    # L2-normalized distribution weight (so I_i = w_i**2 * I(x_i) with sum w_i**2 =
+    # 1), which makes .sum() the correct incoherent average. This is the same
+    # reduction the partial-coherence tutorial performs by hand.
+    import ase
+
+    atoms = ase.build.mx2(vacuum=2)
+    exit_wave = PlaneWave(energy=80e3, sampling=0.1).multislice(atoms).compute()
+
+    focal_series_values = np.array([-100.0, 0.0, 100.0])
+    focal_series = distributions.from_values(
+        focal_series_values, ensemble_mean=False
+    )
+    spread = distributions.gaussian(
+        20.0, num_samples=7, sampling_limit=2, ensemble_mean=False
+    )
+
+    images = (
+        exit_wave.apply_ctf(CTF(energy=80e3, defocus=focal_series))
+        .apply_ctf(CTF(energy=80e3, defocus=spread))
+        .intensity()
+        .compute()
+    )
+
+    # locate the spread (7 values) and series (3 values) axes and reduce the spread
+    spread_axis = next(
+        i
+        for i, ax in enumerate(images.axes_metadata)
+        if getattr(ax, "values", None) is not None and len(ax.values) == 7
+    )
+    result = images.sum(spread_axis)
+    series_axis = next(
+        i
+        for i, ax in enumerate(result.axes_metadata)
+        if getattr(ax, "values", None) is not None and len(ax.values) == 3
+    )
+    reduced = np.moveaxis(result.array, series_axis, 0)
+
+    # brute-force reference: per focus step, weighted incoherent average over the
+    # spread (weights pre-multiplied as w_i**2, matching abTEM's convention)
+    raw = distributions.gaussian(20.0, num_samples=7, sampling_limit=2)
+    deltas, weights = np.array(raw.values), np.array(raw.weights)
+    ref = np.zeros((len(focal_series_values),) + exit_wave.array.shape)
+    for i, series_val in enumerate(focal_series_values):
+        acc = np.zeros(exit_wave.array.shape)
+        for delta, w in zip(deltas, weights):
+            acc += (w**2) * (
+                exit_wave.apply_ctf(CTF(energy=80e3, defocus=series_val + delta))
+                .intensity()
+                .compute()
+                .array
+            )
+        ref[i] = acc
+
+    assert reduced.shape[0] == 3  # focal series axis survives
+    assert np.allclose(reduced, ref, atol=1e-4)


### PR DESCRIPTION
## Summary

- **Units fix** (`transfer.py`): `TemporalEnvelope`'s `focal_spread` ensemble axis was labelled `"mrad"`. Focal spread is a defocus quantity, so the correct unit is `"Å"`.
- **Docs / regression test** (`test_distributions.py`): adds `test_focal_series_with_incoherent_spread`, demonstrating the solution to [abTEM/abTEM#168](https://github.com/abTEM/abTEM/issues/168) ("Focal series with incoherent waves") using existing machinery — no new API.

## Focal series with incoherent waves (#168)

A focal series where each defocus step is itself an incoherent (temporal-coherence) average can be built by chaining two `apply_ctf()` calls, because the defocus phase term is linear in defocus (`exp(iχ₁)·exp(iχ₂) = exp(i(χ₁+χ₂))`):

1. One `CTF` with a `from_values` distribution over the focal-series defocus values (the axis you keep).
2. One `CTF` with `distributions.gaussian(...)` for the temporal-coherence spread (the axis you reduce).

The spread axis is reduced with a plain `.sum()`. This is correct — not a coincidence — because abTEM already pre-multiplies each wave amplitude by the L2-normalized distribution weight, so `I_i = w_i²·I(x_i)` with `Σw_i² = 1`; summing therefore yields the properly weighted incoherent average. This is the same reduction the [partial-coherence tutorial](https://abtem.github.io/doc/user_guide/tutorials/partial_coherence.html) performs by hand. Verified in the test against a brute-force nested-loop reference (agreement to ~1e-5).

## Scope note

An earlier version of this PR also reworked `reduce_ensemble()` to make the reduction automatic (so the spread axis would collapse without a manual `.sum()`). That was dropped: abTEM currently uses two different weighting conventions across its transfer functions (the aberration path pre-multiplies amplitudes by the weights; the envelope/aperture paths do not), and a single `reduce_ensemble()` rule cannot serve both without either tagging each axis with its reduction rule or unifying the conventions. That is a deliberate design decision worth its own change — tracked in #305 — and shouldn't ride along on this fix. The manual-`.sum()` composition above works correctly today with no code change.

## Test plan

- [x] `test/test_distributions.py`, `test/test_ctf.py`, `test/test_measure.py` — 97 passed, 87 skipped
- [x] New `test_focal_series_with_incoherent_spread` verifies the composed focal-series + incoherent-spread pattern against a brute-force reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)
