### PR TITLE
Fix legacy zarr files failing to load for non-measurement classes

### DIFF
--- a/abtem/array.py
+++ b/abtem/array.py
@@ -2106,7 +2106,10 @@ def _from_zarr_legacy(root, chunks, decode_types):
         i += 1
 
     for i, cls_name in enumerate(types):
-        cls = getattr(abtem.measurements, cls_name)
+        # Legacy files (written by abTEM <= 1.0.9) may hold any ArrayObject
+        # subclass, e.g. Waves or PotentialArray, not just measurements; all
+        # of them are exported from the top-level abtem namespace.
+        cls = getattr(abtem, cls_name)
 
         packed_kwargs = decode_types(root.attrs[f"kwargs{i}"])
         kwargs = cls._unpack_kwargs(packed_kwargs)

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -237,6 +237,37 @@ def test_to_zarr_from_zarr_zip(data, has_array, url, lazy, device):
     assert has_array_from_zarr.to_cpu() == has_array.to_cpu()
 
 
+@given(data=st.data(), url=abtem_st.temporary_path(allow_none=False))
+@pytest.mark.parametrize(
+    "has_array",
+    [
+        abtem_st.images,
+        abtem_st.diffraction_patterns,
+        abtem_st.waves,
+        abtem_st.potential_array,
+    ],
+)
+def test_from_zarr_legacy_format(data, has_array, url):
+    # Files written by abTEM <= 1.0.9 store per-object "kwargs{i}"/"type{i}"
+    # attributes instead of the canonical "metadata{i}"; they may hold any
+    # ArrayObject subclass (e.g. Waves, PotentialArray), not just measurements.
+    import zarr
+
+    from abtem.array import from_zarr
+
+    has_array = data.draw(has_array(lazy=False, device="cpu"))
+
+    root = zarr.open(url, mode="w")
+    root.create_array(name="array0", data=has_array.array, chunks=has_array.shape)
+    root.attrs["kwargs0"] = has_array._pack_kwargs(
+        has_array._copy_kwargs(exclude=("array",))
+    )
+    root.attrs["type0"] = has_array.__class__.__name__
+
+    has_array_from_zarr = from_zarr(url).compute()
+    assert has_array_from_zarr == has_array
+
+
 @given(data=st.data())
 @pytest.mark.parametrize("lazy", [True, False])
 @pytest.mark.parametrize("device", ["cpu", gpu])


### PR DESCRIPTION
## Summary

Files written by abTEM ≤ 1.0.9 use the legacy zarr format (per-object `kwargs{i}`/`type{i}` attributes) and may hold any `ArrayObject` subclass. The legacy reader introduced alongside the canonical metadata format (#252) looks classes up on `abtem.measurements`, so legacy files containing `Waves` or `PotentialArray` objects fail to load:

```
AttributeError: module 'abtem.measurements' has no attribute 'Waves'
```

The 1.0.9 reader resolved classes from the top-level `abtem` namespace, which exports all writable classes (including `Waves` and `PotentialArray`). This PR restores that lookup.

## Changes

- `_from_zarr_legacy` resolves classes via `getattr(abtem, cls_name)` instead of `getattr(abtem.measurements, cls_name)`, matching the ≤ 1.0.9 reader exactly.
- Added `test_from_zarr_legacy_format`, which writes files in the legacy format (`kwargs0`/`type0` attributes) for `Images`, `DiffractionPatterns`, `Waves` and `PotentialArray` and round-trips them through `from_zarr`. The legacy path previously had no test coverage, which is how this slipped through.

## Testing

- Reproduced the failure with a hand-written legacy-format file before the fix; loads correctly after.
- `pytest test/test_array.py -k zarr`: 60 passed, 56 skipped (GPU parametrizations without CuPy).
- Full suite on dev passes (808 passed, 586 skipped).

Found while reviewing the 1.0.10 release diff — this should land before tagging so files written by 1.0.9 remain readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)