### PR TITLE
Fix GPU/CPU mismatch in finite-projection radial table lookup

### DIFF
--- a/abtem/core/_cuda.py
+++ b/abtem/core/_cuda.py
@@ -77,7 +77,17 @@ def _interpolate_radial_functions(
                 + (m * sampling[1] - positions[i, 1]) ** 2
             )
 
-            idx = int(math.log(r_interp / radial_gpts[0] + 1e-12) / dt)
+            # floor (not plain truncation) matches the CPU kernel
+            # (abtem/integrals.py:interpolate_radial_functions): for pixels
+            # inside the table's innermost radius the ratio is < 1 so the log
+            # is negative, and int() truncates toward zero rather than
+            # flooring. That mismatch flips the sign of idx for values in
+            # (-1, 0) -- e.g. -0.2 floors to -1 (correctly hits the idx < 0
+            # branch, clamping to the innermost tabulated value) but
+            # truncates to 0 (incorrectly falls into the interpolation
+            # branch below, extrapolating from the innermost table point
+            # instead of clamping to it).
+            idx = int(math.floor(math.log(r_interp / radial_gpts[0] + 1e-12) / dt))
 
             if idx < 0:
                 cuda.atomic.add(array, (k, m), radial_functions[i, 0])

--- a/test/test_potentials.py
+++ b/test/test_potentials.py
@@ -618,3 +618,45 @@ def test_potential_show_depth_profile(si_potential):
 
     viz = si_potential.show_depth_profile()
     assert isinstance(viz, Visualization)
+
+
+@pytest.mark.parametrize("device", [gpu])
+def test_finite_projection_gpu_matches_cpu_near_atom_core(device):
+    """Regression for a GPU/CPU mismatch in the radial-table index lookup
+    inside interpolate_radial_functions (abtem/core/_cuda.py): the CUDA
+    kernel used int() to derive the log-spaced table index, which truncates
+    toward zero, while the CPU kernel uses int(floor(...)). For pixels just
+    inside the table's innermost tabulated radius the argument is a small
+    negative number, and the two roundings disagree in sign for values in
+    (-1, 0) -- e.g. int(floor(-0.2)) == -1 (correctly clamps to the innermost
+    tabulated value) but int(-0.2) == 0 (incorrectly extrapolates from the
+    innermost table point instead). This only misfires for atoms whose
+    fractional pixel offset happens to place a disk pixel in that razor-thin
+    annulus, so a generic small structure may not trigger it; SrTiO3 (highly
+    symmetric fractional coordinates) reliably does.
+    """
+    from ase.spacegroup import crystal
+
+    sto = crystal(
+        ("Sr", "Ti", "O"),
+        basis=[(0, 0, 0), (0.5, 0.5, 0.5), (0.5, 0.5, 0)],
+        spacegroup=221,
+        cellpar=[3.905, 3.905, 3.905, 90, 90, 90],
+    )
+    atoms = sto * (2, 2, 2)
+
+    def build(dev):
+        pot = Potential(
+            atoms, sampling=0.05, slice_thickness=1.0, projection="finite",
+            device=dev,
+        )
+        array = pot.build(lazy=False).array
+        if hasattr(array, "get"):
+            array = array.get()
+        return np.asarray(array, dtype=np.float64)
+
+    cpu = build("cpu")
+    gpu_array = build(device)
+
+    max_dev = np.abs(gpu_array - cpu).max() / cpu.max()
+    assert max_dev < 1e-4, f"GPU vs CPU max relative deviation {max_dev:.3e}"


### PR DESCRIPTION
## Summary

`interpolate_radial_functions` (the CUDA kernel behind `Potential(..., projection="finite", device="gpu")`) derived the log-spaced radial table index as `int(math.log(...) / dt)`, while the CPU kernel (`abtem/integrals.py`) uses `int(np.floor(np.log(...) / dt))`. For a pixel inside the table's innermost tabulated radius, the ratio is < 1 so the log argument is negative; `int()` truncates toward zero rather than flooring, and the two disagree in *sign* for arguments in `(-1, 0)` — e.g. `floor(-0.2) = -1` correctly triggers the `idx < 0` branch (clamp to the innermost tabulated value), but `int(-0.2) = 0` incorrectly falls into the interpolation branch, linearly extrapolating from the innermost table point instead of clamping to it.

## How this was found

Found incidentally while validating the (unrelated) finite-projection speedup in #309: comparing GPU against CPU output for `Potential(..., projection="finite", device="gpu")` on SrTiO3 showed a **2.9e-3 max relative deviation**. Confirmed present on unmodified `dev` (i.e. pre-existing, unrelated to that PR) before digging further here.

Root-caused with a diagnostic run on a GPU workstation: only 96 of 5.28M pixels disagreed, and their coordinates repeated at the SrTiO3 lattice spacing (~3.9 Å) — consistent with a single Wyckoff site whose fractional pixel offset happens to fall in the affected annulus, replicated identically at every symmetry-equivalent copy across the crystal. That sparsity and periodicity ruled out an initial hypothesis (a CUDA-vs-Python `round()` tie-breaking mismatch, which would corrupt an atom's entire disk rather than a handful of pixels) before landing on the actual `int()`-vs-`floor()` bug — which had already been spotted by direct code comparison but initially looked too narrow (<1% of a pixel width) to be the sole explanation on its own. It fully explains the observed pattern once accounting for how it recurs identically at every unit cell for the specific atomic environment(s) it affects.

## Fix

Matches the CPU kernel exactly:
```python
idx = int(math.floor(math.log(r_interp / radial_gpts[0] + 1e-12) / dt))
```
`math.floor` was already usable in this device function (`math.sqrt`/`math.log` are used in the same kernel).

## Verification

- Regression test added: `test_finite_projection_gpu_matches_cpu_near_atom_core`, parametrized on the existing `gpu` marker (skips without CuPy, runs automatically on a GPU workstation) — reproduces the same SrTiO3 geometry that exposed the bug.
- **Verified on GPU hardware**: the deviation threshold in the diagnostic script was lowered to 1e-6 (five orders of magnitude tighter than the original 2.9e-3 discrepancy) and no pixels exceed it; the pytest regression test passes.

## Scope

CPU-only workflows are entirely unaffected (they already used the correct floor logic). This only changes GPU output for `projection="finite"` potentials, and only for the rare pixels that were affected by the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
