### PR TITLE
Fix NumbaPerformanceWarning filter not matching due to ANSI codes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ filterwarnings = [
     "ignore:Passing storage-related arguments:FutureWarning",
     "ignore:FNV hashing is not implemented in Numba:UserWarning",
     "ignore:ensemble_mean=False returns the full frozen-phonon ensemble:UserWarning",
-    "ignore:Grid size.*will likely result in GPU under-utilization:numba.core.errors.NumbaPerformanceWarning"
+    "ignore:.*Grid size.*will likely result in GPU under-utilization:numba.core.errors.NumbaPerformanceWarning"
 ]
 
 [tool.numpydoc_validation]


### PR DESCRIPTION
## Summary

Fixes the intermittently-failing `NumbaPerformanceWarning: Grid size ... will likely result in GPU under-utilization` test failure.

## Root cause

`numba.core.errors.NumbaPerformanceWarning` wraps its message in ANSI bold escape codes:

```python
>>> str(NumbaPerformanceWarning("Grid size 120 will likely result in GPU under-utilization due to low occupancy."))
'\x1b[1mGrid size 120 will likely result in GPU under-utilization due to low occupancy.\x1b[0m'
```

The pytest ini `filterwarnings` entry for this warning is a regex tested with `re.match` (anchored at position 0): `"Grid size.*will likely result in GPU under-utilization"`. Since the actual message starts with the escape sequence rather than literally "Grid size", the filter never matches, the warning falls through to the `"error"` default, and the test fails.

Numba appears to only emit the ANSI codes when attached to a real terminal (color/highlighting is typically TTY-gated), which is consistent with this showing up in interactive `pytest` runs on a GPU workstation but not necessarily in CI's captured, non-TTY output — matching the "often crops up" pattern reported.

## Fix

Prefix the message pattern with `.*` so the filter matches regardless of leading escape codes:
```diff
-    "ignore:Grid size.*will likely result in GPU under-utilization:numba.core.errors.NumbaPerformanceWarning"
+    "ignore:.*Grid size.*will likely result in GPU under-utilization:numba.core.errors.NumbaPerformanceWarning"
```

## Verification

- Confirmed the bug: wrote a minimal test inside `test/` that calls `warnings.warn(NumbaPerformanceWarning(...))` with the exact message text from the bug report, ran it under the project's actual `pyproject.toml` config (not just the regex in isolation) — failed before the fix, passes after.
- Checked the other numba-related filter entry (`FNV hashing is not implemented in Numba`, a plain `UserWarning`) is unaffected — it's raised via plain `warnings.warn(msg, UserWarning)`, not through numba's own colorized `Warning.__str__`, so no ANSI wrapping applies there.
- `test/test_potentials.py` passes locally (42 passed, 18 skipped — GPU parametrizations without CuPy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
