### PR TITLE
Pin minimum zarr version to 3.1 (create_array(data=...) requires it)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "numba",
     "dask>=2022.12.1,!=2025.12.*,!=2026.1.0,!=2026.1.1",
     "distributed",
-    "zarr",
+    "zarr>=3.1",  # create_array(data=...) requires the 3.1 API
     "ase",
     "threadpoolctl",
     "tabulate",


### PR DESCRIPTION
## Summary

`abtem/array.py`'s `to_zarr()` writes arrays via `root.create_array(..., data=computed_array, ...)`, but the `data` (and `write_data`) keyword arguments to `zarr.Group.create_array` were only added in zarr **3.1** — zarr 3.0.x raises `TypeError: Group.create_array() got an unexpected keyword argument 'data'`, and zarr 2.x is further broken since `create_array` doesn't exist at all on that API (Zarr 3's `Group` class replaced Zarr 2's).

`pyproject.toml` declared the dependency as unbounded `"zarr"`, so nothing prevented `pip`/`conda` from resolving an old, incompatible zarr into an environment — found via two local conda environments running Python 3.11 and 3.12, with zarr 3.0.7 and 2.18.7 respectively (both predating the Zarr-3 zip-container work from #252).

## Fix

```diff
-    "zarr",
+    "zarr>=3.1",  # create_array(data=...) requires the 3.1 API
```

## Verification

Reproduced against both stale environments before the fix, all 60 zarr-related tests failing:
- `abtem-py3.12` (zarr 2.18.7): `AttributeError` — `zarr.hierarchy.Group` (the v2 API) has no `create_array` at all.
- `abtem-py3.11` (zarr 3.0.7): `TypeError: Group.create_array() got an unexpected keyword argument 'data'` — confirmed via direct signature inspection that `data`/`write_data` were added between 3.0.7 and 3.1.x.

After upgrading both environments to zarr >= 3.1 (and the rest of their dependencies) and re-running the full suite:

| environment | before | after |
|---|---|---|
| Python 3.11 | 60 failed, 751 passed | **811 passed, 0 failed** |
| Python 3.12 | 60 failed, 751 passed | **811 passed, 0 failed** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
