### PR TITLE
Remove unused rich dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
     "ipywidgets",
     "ipympl",
     "tqdm",
-    "rich", # Required for supporting Zarr zip storage
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Summary

Removes the `rich` dependency, which was added in #252 (Zarr 3 zip container support) with the comment "Required for supporting Zarr zip storage" but is not actually used anywhere.

## Verification

- Recursive, case-insensitive search across the whole `abtem/` package for any `rich` import or usage: zero matches.
- Not a dependency of zarr itself — `pip show zarr` lists `donfig, google-crc32c, numcodecs, numpy, packaging, typing-extensions`, no `rich`.
- Fully uninstalled `rich` and exercised the exact functionality the comment references: `Images.to_zarr(url, ...)` / `Images.from_zarr(url)` round-tripped cleanly through a `.zip` store, `import abtem` works fine, and the full test suite passes: **817 passed, 0 failed** (587 skipped — GPU parametrizations, no CuPy on this machine).

Found while auditing dependencies for gaps similar to #316 (the zarr minimum-version fix) — this one turned out to be the opposite problem, an unnecessary dependency rather than a missing version bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
