### PR TITLE
Fix Bullseye aperture docstring and validate ring_width/spoke_width

### DIFF
--- a/abtem/transfer.py
+++ b/abtem/transfer.py
@@ -416,17 +416,27 @@ class Bullseye(BaseAperture):
     The aperture is divided radially into `num_rings` periods, each consisting of an
     open annulus followed by an opaque gap; `ring_width` is the open fraction of each
     period. The open annulus width is
-    ``semiangle_cutoff * ring_width / (ring_width + num_rings - 1)``, and a
-    `ring_width` of 1 gives a fully open disk. Opaque spokes of width
-    ``spoke_width * open annulus width`` cross all rings except the central disk.
+    ``ds = semiangle_cutoff * ring_width / (ring_width + num_rings - 1)``, and a
+    `ring_width` of 1 gives a fully open disk. Opaque spokes cross all rings except
+    the central disk; each spoke is a straight bar of constant linear width
+    ``spoke_width * ds`` (in the same reciprocal-angle units as `ds`), not a wedge of
+    constant angular width. Consequently `spoke_width` has no meaningful upper bound
+    of 1 the way `ring_width` does: a fixed `spoke_width` blocks a larger angular
+    fraction of rings closer to the center than rings farther out, so increasing it
+    reduces transmission monotonically but not linearly, with rings saturating to
+    fully blocked from the center outward. The central disk is never affected by
+    spokes, so transmission approaches (but never reaches) "central disk only" as
+    `spoke_width` grows.
 
     Parameters
     ----------
     num_spokes : int
         Number of spokes.
     spoke_width : float
-        Width of the opaque spokes as a fraction of the open ring width. Must be
-        non-negative.
+        Width of the opaque spokes, as a multiple of the open annulus width `ds`
+        (see above) rather than an angular fraction. Must be non-negative; unlike
+        `ring_width`, values greater than 1 are valid and simply widen the spokes
+        further.
     num_rings : int
         Number of rings.
     ring_width : float
@@ -495,7 +505,7 @@ class Bullseye(BaseAperture):
 
     @property
     def spoke_width(self) -> float:
-        """Width of the opaque spokes as a fraction of the open ring width."""
+        """Width of the opaque spokes as a multiple of the open annulus width."""
         return self._spoke_width
 
     @property

--- a/abtem/transfer.py
+++ b/abtem/transfer.py
@@ -413,16 +413,25 @@ class Bullseye(BaseAperture):
     """
     Bullseye aperture.
 
+    The aperture is divided radially into `num_rings` periods, each consisting of an
+    open annulus followed by an opaque gap; `ring_width` is the open fraction of each
+    period. The open annulus width is
+    ``semiangle_cutoff * ring_width / (ring_width + num_rings - 1)``, and a
+    `ring_width` of 1 gives a fully open disk. Opaque spokes of width
+    ``spoke_width * open annulus width`` cross all rings except the central disk.
+
     Parameters
     ----------
     num_spokes : int
         Number of spokes.
     spoke_width : float
-        Width of spokes [deg].
+        Width of the opaque spokes as a fraction of the open ring width. Must be
+        non-negative.
     num_rings : int
         Number of rings.
     ring_width : float
-        Width of rings [mrad].
+        Open fraction of each radial ring period. Must be in the interval (0, 1],
+        where 1 gives a fully open disk.
     semiangle_cutoff : float
         The cutoff semiangle of the aperture [mrad].
     energy : float, optional
@@ -455,6 +464,10 @@ class Bullseye(BaseAperture):
         edge_softness: float = 0.0,
         corner_radius: float = 0.0,
     ):
+        if not 0.0 < ring_width <= 1.0:
+            raise ValueError("ring_width must be in the interval (0, 1]")
+        if spoke_width < 0.0:
+            raise ValueError("spoke_width must be non-negative")
         self._spoke_num = num_spokes
         self._spoke_width = spoke_width
         self._num_rings = num_rings
@@ -469,7 +482,7 @@ class Bullseye(BaseAperture):
             gpts=gpts,
             sampling=sampling,
         )
-    
+
     @property
     def soft(self) -> bool:
         """True if the aperture has a soft edge"""
@@ -482,7 +495,7 @@ class Bullseye(BaseAperture):
 
     @property
     def spoke_width(self) -> float:
-        """Width of spokes [deg]."""
+        """Width of the opaque spokes as a fraction of the open ring width."""
         return self._spoke_width
 
     @property
@@ -492,8 +505,9 @@ class Bullseye(BaseAperture):
 
     @property
     def ring_width(self) -> float:
-        """Width of rings [mrad]."""
+        """Open fraction of each radial ring period."""
         return self._ring_width
+
     @property
     def edge_softness(self) -> float:
         """Edge softness [mrads]"""


### PR DESCRIPTION
## Summary
- PR #266 redesigned `Bullseye` to use relative `ring_width`/`spoke_width` parameters, but the docstring still documented the old absolute units (`[deg]`/`[mrad]`). Updated the class and property docstrings to describe the actual semantics, including the `ds` open-annulus-width formula and that `ring_width=1.0` gives a fully open disk.
- Added `__init__` validation: `ring_width` must be in `(0, 1]` and `spoke_width` must be `>= 0`, raising `ValueError` otherwise. Previously, old-style values (e.g. `spoke_width=10`) silently produced a solid disk of radius `semiangle_cutoff / num_rings` instead of an error.
- Clarified that `ring_width` and `spoke_width` are not analogous: `ring_width` is a bounded `(0, 1]` fraction with a clean "1.0 = fully open" endpoint, while `spoke_width` is an unbounded multiple of the open annulus width `ds` describing a straight bar of constant linear (not angular) width. Confirmed numerically that increasing `spoke_width` reduces transmission monotonically but non-linearly, blocking inner rings before outer ones, and never fully closes the aperture since the central disk is untouched by spokes.

Should land before 1.0.10 since the API reference is generated from this docstring.

## Test plan
- [x] Constructed `Bullseye` with valid fractional params and confirmed it evaluates without error
- [x] Confirmed `ring_width=1.0` (fully open disk) is accepted
- [x] Confirmed `ring_width=0`, `ring_width=1.5`, and `spoke_width=-1` each raise `ValueError` with a clear message
- [x] Numerically verified `ring_width` vs. `spoke_width` transmitted-area behavior (linear/bounded vs. non-linear/unbounded) to validate the docstring's claims
- [x] Searched the repo for other `Bullseye` usages — none found, so no other call sites are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
