### PR TITLE
Declare sympy as optional dependency for core-loss EELS

### DIFF
--- a/abtem/inelastic/core_loss.py
+++ b/abtem/inelastic/core_loss.py
@@ -571,7 +571,14 @@ class TransitionPotential(BaseTransitionPotential):
         return interp1d(radial_grid, integral)(k)
 
     def _calculate_form_factor(self, bound, excited, k, phi, theta):
-        from sympy.physics.wigner import wigner_3j
+        try:
+            from sympy.physics.wigner import wigner_3j
+        except ImportError as e:
+            raise ImportError(
+                "Calculating core-loss EELS form factors requires sympy. "
+                "Install it with `pip install abtem[core-loss]` or "
+                "`pip install sympy`."
+            ) from e
 
         Hn0 = np.zeros_like(k, dtype=complex)
         l = bound.l

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ extra = [
     "dask-labextension",
     "bokeh",
 ]
+core-loss = [
+    "sympy",
+]
 
 [dependency-groups]
 dev = [
@@ -73,6 +76,7 @@ test = [
     "jupyter-client>=8.8.0",
     "py>=1.11.0",
     "pytest-cov>=7.0.0",
+    "sympy",
     "tox>=4.34.1",
 ]
 


### PR DESCRIPTION
## Summary
- TransitionPotential._calculate_form_factor imports wigner_3j from sympy.physics.wigner inline, but sympy was never declared as a dependency anywhere in pyproject.toml, so users running core-loss EELS without sympy installed hit a bare ModuleNotFoundError, and CI would fail on any test exercising this path.
- Adds a core-loss optional-dependency extra containing sympy, and adds sympy to the test dependency group (the ionization test suite exercises this path).
- Wraps the import in try/except, raising a clear ImportError telling users to pip install abtem[core-loss] (or pip install sympy) if it is missing.

## Test plan
- [x] pytest test/test_ionization.py passes (9 passed, 7 skipped for missing GPU)
- [x] Verified pyproject.toml parses correctly with tomllib
- [x] Simulated a missing-sympy environment (patched __import__) and confirmed the new clear ImportError fires instead of a bare ModuleNotFoundError

Generated with Claude Code