### PR TITLE
Unify task-progress config key on diagnostics.task_progress

### DIFF
--- a/abtem/bloch/dynamical.py
+++ b/abtem/bloch/dynamical.py
@@ -2196,7 +2196,7 @@ class BlochwaveEnsemble(Ensemble, CopyMixin):
         """
 
         if pbar is None:
-            pbar = config.get("local_diagnostics.task_level_progress", False)
+            pbar = config.get("diagnostics.task_progress", False)
 
         if isinstance(thicknesses, (float, int)):
             ensemble_axes_metadata = []
@@ -2407,7 +2407,7 @@ class BlochwaveEnsemble(Ensemble, CopyMixin):
         """
 
         if pbar is None:
-            pbar = config.get("local_diagnostics.task_level_progress", False)
+            pbar = config.get("diagnostics.task_progress", False)
 
         if extent is None:
             base_cell = np.array(self._structure_factor.cell)

--- a/abtem/core/diagnostics.py
+++ b/abtem/core/diagnostics.py
@@ -20,7 +20,7 @@ class TqdmWrapper:
     ----------
     enabled : bool, optional
         A flag indicating if the wrapper is enabled. If None, the value from the
-        configuration key "local_diagnostics.task_level_progress" is used.
+        configuration key "diagnostics.task_progress" is used.
     *args
         Variable length argument list for tqdm.
     **kwargs
@@ -34,7 +34,7 @@ class TqdmWrapper:
 
     def __init__(self, *args, enabled: Optional[bool] = None, **kwargs: Any):
         if enabled is None:
-            enabled = config.get("local_diagnostics.task_level_progress", False)
+            enabled = config.get("diagnostics.task_progress", False)
 
         self._pbar: Optional[tqdm_asyncio] = None
 


### PR DESCRIPTION
## Summary
- `abtem/core/diagnostics.py` and `abtem/bloch/dynamical.py` were reading the undeclared config key `local_diagnostics.task_level_progress`, while `abtem/multislice.py` and `abtem/prism/s_matrix.py` read the declared key `diagnostics.task_progress` (see `abtem/core/abtem.yaml`). This meant the progress bar setting had no effect for the bloch/diagnostics code paths.
- Updated both call sites (and the docstring in `diagnostics.py`) to use `diagnostics.task_progress`.
- Confirmed no remaining references to `local_diagnostics` anywhere in the repo.

## Test plan
- [x] `pytest test/test_bloch_waves.py -q` — 8 passed