### PR TITLE
Fix docstring RST formatting causing Sphinx build errors/warnings

### DIFF
--- a/abtem/array.py
+++ b/abtem/array.py
@@ -232,6 +232,7 @@ class ComputableList(list):
         **kwargs: Any,
     ):
         """Write data to a zarr file.
+
         Parameters
         ----------
         url : str
@@ -1297,7 +1298,7 @@ class ArrayObject(Ensemble, EqualityMixin, CopyMixin, metaclass=ABCMeta):
         resource_profiler: bool = False,
         **kwargs,
     ) -> Self | tuple[Self, tuple]:
-        """Turn a lazy *ab*TEM object into its in-memory equivalent.
+        """Turn a lazy abTEM object into its in-memory equivalent.
 
         Parameters
         ----------

--- a/abtem/detectors.py
+++ b/abtem/detectors.py
@@ -919,17 +919,18 @@ class PixelatedDetector(BaseDetector):
     max_angle : float or {'cutoff', 'valid', 'full'}
         The diffraction patterns will be detected up to this angle [mrad].
         If str, it must be one of:
-            ``cutoff`` :
-                The maximum scattering angle will be the cutoff of the antialiasing
-                aperture.
-            ``valid`` :
-                The maximum scattering angle will be the largest rectangle that fits
-                inside the circular antialiasing aperture (default).
-            ``full`` :
-                Diffraction patterns will not be cropped and will include angles outside
-                the antialiasing aperture.
+
+        ``cutoff``
+            The maximum scattering angle will be the cutoff of the antialiasing
+            aperture.
+        ``valid``
+            The maximum scattering angle will be the largest rectangle that fits
+            inside the circular antialiasing aperture (default).
+        ``full``
+            Diffraction patterns will not be cropped and will include angles outside
+            the antialiasing aperture.
     resample : str or False
-        If 'uniform', the diffraction patterns from rectangular cells will be ¨
+        If 'uniform', the diffraction patterns from rectangular cells will be
         downsampled to a uniform angular sampling.
     reciprocal_space : bool, optional
         If True (default), the diffraction pattern intensities are detected, otherwise

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -668,6 +668,7 @@ def integrate_disc(
     border : str
         Specify how to treat integration regions that cross the image border. The valid
         values and their behaviours are:
+
         'wrap'
             The measurement is extended by wrapping around to the opposite edge.
         'raise'


### PR DESCRIPTION
## Summary
- Fixes 3 Sphinx "Unexpected indentation" errors caused by missing blank lines before numpydoc `Parameters`/definition-list blocks: `ComputableList.to_zarr` (array.py), `PixelatedDetector` (detectors.py), `integrate_disc` (measurements.py)
- Fixes ~45 repeated "Inline emphasis start-string without end-string" warnings across every autosummary page: `ArrayObject.compute`'s docstring used `*ab*TEM` (unbalanced asterisks parsed as unterminated RST emphasis) instead of plain `abTEM`
- Also dedents the `PixelatedDetector.max_angle` definition list (was nested under the parent bullet, causing the indentation error) and drops a stray `¨` typo in its docstring

## Test plan
- [x] Ran a full `jupyter-book build` (Sphinx) of the docs repo against these changes — build succeeded with no errors
- [x] Parsed each fixed docstring through napoleon's `NumpyDocstring` → docutils RST parser directly — zero warnings/errors (previously reproduced the exact reported errors)