### PR TITLE
Fix GPAWPotential for new-style GPAW calculator API (GPAW 26+)

### DIFF
--- a/abtem/inelastic/core_loss.py
+++ b/abtem/inelastic/core_loss.py
@@ -11,25 +11,17 @@ from ase import Atom, Atoms, units
 from ase.data import chemical_symbols
 from numba import jit
 from scipy.interpolate import interp1d
+from scipy.special import spherical_jn
 
-# ---------
-# This is a version check for scipy >=v1.17.0
-from importlib.metadata import version, PackageNotFoundError
-from packaging.version import Version
 try:
-    import scipy
-    _SCIPY_VERSION = Version(version("scipy"))
-except PackageNotFoundError:
-    scipy = None
-    _SCIPY_VERSION = None
+    # sph_harm_y is the non-deprecated replacement for sph_harm, available
+    # since scipy 1.15; sph_harm itself is removed in scipy 1.17.
+    from scipy.special import sph_harm_y
+except ImportError:
+    from scipy.special import sph_harm
 
-if _SCIPY_VERSION is not None and _SCIPY_VERSION >= Version("1.17.0"):
-    from scipy.special import spherical_jn, sph_harm_y
-else:
-    from scipy.special import spherical_jn, sph_harm
     def sph_harm_y(n, m, theta, phi):
         return sph_harm(m, n, phi, theta)
-# ---------
 
 
 from abtem.array import ArrayObject

--- a/abtem/potentials/_poisson.py
+++ b/abtem/potentials/_poisson.py
@@ -2,25 +2,17 @@ from numbers import Number
 
 import numpy as np
 from ase import units
+from scipy.special import spherical_jn
 
-# ---------
-# This is a version check for scipy >=v1.17.0
-from importlib.metadata import version, PackageNotFoundError
-from packaging.version import Version
 try:
-    import scipy
-    _SCIPY_VERSION = Version(version("scipy"))
-except PackageNotFoundError:
-    scipy = None
-    _SCIPY_VERSION = None
+    # sph_harm_y is the non-deprecated replacement for sph_harm, available
+    # since scipy 1.15; sph_harm itself is removed in scipy 1.17.
+    from scipy.special import sph_harm_y
+except ImportError:
+    from scipy.special import sph_harm
 
-if _SCIPY_VERSION is not None and _SCIPY_VERSION >= Version("1.17.0"):
-    from scipy.special import spherical_jn, sph_harm_y
-else:
-    from scipy.special import spherical_jn, sph_harm
     def sph_harm_y(n, m, theta, phi):
         return sph_harm(m, n, phi, theta)
-# ---------
 
 from abtem.potentials.gpaw import unpack2
 

--- a/abtem/potentials/gpaw.py
+++ b/abtem/potentials/gpaw.py
@@ -82,15 +82,21 @@ class _DummyGPAW:
         atoms = gpaw.atoms.copy()
         atoms.calc = None
 
+        # GPAW's new-style calculator (default since GPAW 26) renames the
+        # compensation charge coefficients from Q_aL to ccc_aL.
+        Q_aL = getattr(gpaw.density, "Q_aL", None)
+        if Q_aL is None:
+            Q_aL = gpaw.density.ccc_aL
+
         kwargs = {
-            "setup_mode": gpaw.parameters["mode"],
-            "setup_xc": gpaw.parameters["xc"],
+            "setup_mode": gpaw.parameters.mode,
+            "setup_xc": gpaw.parameters.xc,
             "nt_sG": gpaw.density.nt_sG.copy(),
             "gd": gpaw.density.gd.new_descriptor(comm=SerialCommunicator()),
             "D_asp": dict(gpaw.density.D_asp),
             "atoms": atoms,
             "valence_potential": gpaw.get_electrostatic_potential(),
-            "Q_aL": dict(gpaw.density.Q_aL),
+            "Q_aL": dict(Q_aL),
         }
 
         return cls(**kwargs)

--- a/test/test_ionization.py
+++ b/test/test_ionization.py
@@ -11,6 +11,8 @@ with CuPy installed the GPU code paths in ``fast_roll`` /
 ``gpu`` is a ``pytest.param`` defined in ``test/utils.py`` that skips when
 CuPy isn't present.
 """
+import sys
+
 import ase
 import numpy as np
 import pytest
@@ -24,6 +26,11 @@ try:
     import cupy as cp
 except ImportError:
     cp = None
+
+try:
+    import gpaw  # noqa: F401
+except ImportError:
+    pass
 
 from utils import gpu  # noqa: E402  -- pytest.param('gpu', skipif no cupy)
 
@@ -347,5 +354,48 @@ def test_transition_potential_crystal_dedup_collapses_slice_cache():
         f"got {len(unique)} — CrystalPotential.generate_slices tile cache may "
         "have regressed"
     )
+
+
+@pytest.mark.skipif("gpaw" not in sys.modules, reason="requires gpaw")
+def test_subshell_transitions_real_gpaw_pipeline():
+    """End-to-end regression test using GPAW's real atomic all-electron
+    solvers (``gpaw.atom.all_electron.AllElectron`` and
+    ``gpaw.atom.aeatom.AllElectronAtom``, wired up through
+    ``SubshellTransitions``), instead of the synthetic
+    ``TransitionPotentialArray`` the other tests in this module use to
+    exercise the scan machinery without depending on GPAW.
+
+    This is a different GPAW entry point than the periodic crystal
+    calculator used by ``GPAWPotential`` (see ``abtem/potentials/gpaw.py``
+    and ``test/test_gpaw.py``), so a GPAW upgrade breaking one gives no
+    guarantee about the other -- this needs its own coverage.
+    """
+    from abtem.inelastic.core_loss import SubshellTransitions
+
+    atoms = ase.build.bulk("Si", cubic=True)
+    potential = abtem.Potential(atoms, gpts=32, slice_thickness=2.7)
+
+    transitions = SubshellTransitions(Z=14, n=2, l=1, order=1, epsilon=1.0, xc="PBE")
+    assert len(transitions) > 0
+
+    transition_potentials = transitions.get_transition_potentials(
+        extent=potential.extent, gpts=potential.gpts, energy=100e3
+    )
+    assert len(transition_potentials) == len(transitions)
+
+    probe = abtem.Probe(energy=100e3, semiangle_cutoff=20)
+    probe.grid.match(potential)
+
+    detector = abtem.AnnularDetector(inner=0, outer=40)
+    result = probe.transition_potential_scan(
+        potential=potential,
+        transition_potentials=transition_potentials,
+        scan=(0, 0),
+        detectors=detector,
+        lazy=False,
+    )
+    array = np.asarray(result.array)
+    assert np.isfinite(array).all()
+    assert np.any(array != 0)
 
 


### PR DESCRIPTION
## Summary
- GPAW's new-style ASE calculator (default since GPAW 24, and the only path as of GPAW 26.x) exposes `calc.parameters` as a non-subscriptable `Parameters` dataclass rather than the old dict-like object, causing `GPAWPotential` to fail with `TypeError: 'Parameters' object is not subscriptable`.
- The new calculator's density object also renamed the compensation charge coefficients attribute from `Q_aL` to `ccc_aL`.
- Switched to attribute access (`gpaw.parameters.mode` / `.xc`) and added a fallback from `Q_aL` to `ccc_aL`, preserving compatibility with older/legacy GPAW calculators.
- Verified the core-loss EELS pipeline (`SubshellTransitions`, which uses a different GPAW entry point — the atomic all-electron solvers `gpaw.atom.all_electron`/`gpaw.atom.aeatom` — rather than the periodic-crystal calculator fixed above) also works correctly against GPAW 26+, and added a real-GPAW regression test (`test_subshell_transitions_real_gpaw_pipeline`) since the existing suite only exercised that code path with a synthetic, GPAW-free mock.
- That new test surfaced a related, separate bug: `core_loss.py`/`_poisson.py` only switch from the now-deprecated `scipy.special.sph_harm` to its replacement `sph_harm_y` once scipy's version is `>=1.17.0` (the release that removes `sph_harm` outright), even though `sph_harm_y` has been available since scipy 1.15. On any scipy in between (1.16.3, what's installed here, included), every call emits a `DeprecationWarning`, which abtem's own `filterwarnings = ["error", ...]` pytest config turns into a hard failure. Switched to importing `sph_harm_y` directly with an `ImportError` fallback instead of a hardcoded version-string gate, so the modern API is used as soon as it's available rather than only once the old one is gone. The actual argument-order translation from the original scipy-1.17 compatibility work (#242) is unchanged.

## Test plan
- [x] Reproduced the reported `TypeError` against a real GPAW 26.7.1b1 install and confirmed the fix resolves it.
- [x] Ran `GPAWPotential(calc, sampling=...).build().compute()` end-to-end successfully against GPAW 26.7.1b1.
- [x] Confirmed the API change against GPAW 26.7.0 source (`gpaw/new/ase_interface.py`, `gpaw/new/backwards_compatibility.py`).
- [x] Ran the full core-loss pipeline (`SubshellTransitions` → real GPAW radial wavefunctions → `TransitionPotential` → `Probe.transition_potential_scan`, single- and double-channel) against GPAW 26.7.1b1 and confirmed finite, non-zero results.
- [x] `test/test_ionization.py` (10 passed, 7 skipped), `test/test_gpaw.py`, `test/test_potentials.py` pass, aside from pre-existing environment-specific MPI grid-decomposition failures unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
