### PR TITLE
Magnetic potential/field improvements for collinear GPAW calculations

### DIFF
--- a/abtem/inelastic/core_loss.py
+++ b/abtem/inelastic/core_loss.py
@@ -206,7 +206,12 @@ def numerov(f, x0, dx, dh):
     """Given precomputed function f(x), solves for x(t), which satisfies:
     x''(t) = f(t) x(t)
     """
-    x = np.zeros(len(f))
+    # f.copy() rather than np.zeros(len(f)): some numba/numpy pairings
+    # (observed: numba 0.64.0 + numpy 2.4.3) fail to type numba's internal
+    # np.zeros -> np.empty lowering inside @njit, while ndarray.copy() is
+    # unaffected. Every element of x is overwritten below before being
+    # read, so the borrowed initial values from f are never used.
+    x = f.copy()
     x[0] = x0
     x[1] = x0 + dh * dx
     h2 = dh**2

--- a/abtem/magnetism/gpaw.py
+++ b/abtem/magnetism/gpaw.py
@@ -31,6 +31,17 @@ def calculate_constant_magnetic_field():
     pass
 
 
+def _apply_rotation_matrix(
+    vector_field: np.ndarray, rotation_matrix: np.ndarray
+) -> np.ndarray:
+    shape = vector_field.shape[1:]
+    vector_field_reshaped = vector_field.reshape(3, -1)
+
+    rotated_field_reshaped = rotation_matrix @ vector_field_reshaped
+
+    return rotated_field_reshaped.reshape((3,) + shape)
+
+
 def rotate_vector_field(
     vector_field: np.ndarray, euler_angles: tuple[float, float, float]
 ) -> np.ndarray:
@@ -49,17 +60,8 @@ def rotate_vector_field(
     rotated_field : np.ndarray
         Rotated 3D vector field.
     """
-    rotation = R.from_euler("xyz", euler_angles)
-    rotation_matrix = rotation.as_matrix()
-
-    shape = vector_field.shape[1:]
-    vector_field_reshaped = vector_field.reshape(3, -1)
-
-    rotated_field_reshaped = rotation_matrix @ vector_field_reshaped
-
-    rotated_field = rotated_field_reshaped.reshape((3,) + shape)
-
-    return rotated_field
+    rotation_matrix = R.from_euler("xyz", euler_angles).as_matrix()
+    return _apply_rotation_matrix(vector_field, rotation_matrix)
 
 
 def calculate_magnetic_vector_potential(spin_density, cell):
@@ -87,6 +89,58 @@ def get_magnetic_field_from_gpaw(calc, gridrefinement=2, assume_colinear=True):
     A = get_vector_potential_from_gpaw(calc, gridrefinement=gridrefinement)
     B = curl_fourier(A, calc.atoms.cell)
     return B
+
+
+#: Sentinel default for `rotate_field`: automatically rotate the
+#: largest-magnitude in-plane component into z (see
+#: `_auto_rotation_matrix_for_vector_field`). Pass an explicit Euler-angle
+#: tuple to pick a specific orientation, or `None` to disable rotation and
+#: see the raw (Az == 0) output.
+_AUTO_ROTATE_FIELD = "auto"
+
+#: Fallback rotation matrix used only when the raw field is exactly zero in
+#: the xy-plane too (e.g. no magnetic moment), where "largest component" is
+#: undefined. Equivalent to Euler angles (0, pi/2, 0).
+_DEFAULT_COLLINEAR_ROTATION_MATRIX = R.from_euler(
+    "xyz", (0.0, np.pi / 2, 0.0)
+).as_matrix()
+
+
+def _auto_rotation_matrix_for_vector_field(vector_field: np.ndarray) -> np.ndarray:
+    """
+    Rotation matrix that rotates the in-plane (x, y) component of
+    `vector_field` with the largest aggregate magnitude into z.
+
+    `calculate_magnetic_vector_potential` always builds the magnetization as
+    m = (0, 0, rho) -- collinear spin has no real-space direction, so GPAW's
+    internal spin axis is arbitrary. Because curl(m) and the subsequent
+    Poisson solve are applied component-wise, this makes the z-component of
+    `vector_field` (and hence the only component `adjust_coulomb_potential`
+    uses) identically zero for every collinear calculation, not just some.
+    Any in-plane axis is an equally valid choice to swap into z absent
+    additional information about the real magnetization direction, so this
+    picks the one that maximises the resulting z-component (in an
+    aggregate, least-squares sense) rather than an arbitrary fixed axis.
+    """
+    Ax = vector_field[0].astype(np.float64, copy=False)
+    Ay = vector_field[1].astype(np.float64, copy=False)
+
+    Sxx = float(np.sum(Ax * Ax))
+    Syy = float(np.sum(Ay * Ay))
+    Sxy = float(np.sum(Ax * Ay))
+
+    if Sxx == 0.0 and Syy == 0.0:
+        return _DEFAULT_COLLINEAR_ROTATION_MATRIX
+
+    # Angle maximising cos(t)^2 * Sxx + sin(t)^2 * Syy + sin(2t) * Sxy.
+    theta = 0.5 * np.arctan2(2 * Sxy, Sxx - Syy)
+
+    dominant = np.array([np.cos(theta), np.sin(theta), 0.0])
+    perpendicular = np.array([-np.sin(theta), np.cos(theta), 0.0])
+    original_z = np.array([0.0, 0.0, 1.0])
+
+    # Right-handed frame mapping the dominant in-plane direction to z.
+    return np.stack([perpendicular, original_z, dominant])
 
 
 def _check_unsupported_ensemble_params(frozen_phonons, repetitions):
@@ -126,7 +180,7 @@ class _GPAWMagnetics(_FieldBuilder):
         slice_thickness: float | tuple[float, ...] = 1.0,
         exit_planes: Optional[int | tuple[int, ...]] = None,
         plane: str = "xy",
-        rotate_field: Optional[tuple[float, float, float]] = None,
+        rotate_field: Optional[tuple[float, float, float]] | str = _AUTO_ROTATE_FIELD,
         origin: tuple[float, float, float] = (0.0, 0.0, 0.0),
         box: Optional[tuple[float, float, float]] = None,
         periodic: bool = True,
@@ -203,24 +257,31 @@ class _GPAWMagnetics(_FieldBuilder):
         if last_slice is None:
             last_slice = self.num_slices
 
+        vector_potential = get_vector_potential_from_gpaw(
+            self._calculators, gridrefinement=self.gridrefinement
+        )
+
         if self._quantity == "vector_potential":
-            array = get_vector_potential_from_gpaw(
-                self._calculators, gridrefinement=self.gridrefinement
-            )
+            array = vector_potential
         elif self._quantity == "magnetic_field":
-            array = get_magnetic_field_from_gpaw(
-                self._calculators, gridrefinement=self.gridrefinement
-            )
+            array = curl_fourier(vector_potential, self._calculators.atoms.cell)
         else:
             raise ValueError(f"Unknown quantity: {self._quantity}")
 
         if self.plane != "xy":
             axes = plane_to_axes(self.plane)
-            array = np.moveaxis(array, (axes[0] + 1, axes[1] + 1), (1, 2))
-            array = array[axes, ...]
+            moved_axes = (axes[0] + 1, axes[1] + 1)
+            array = np.moveaxis(array, moved_axes, (1, 2))[axes, ...]
+            vector_potential = np.moveaxis(vector_potential, moved_axes, (1, 2))[
+                axes, ...
+            ]
 
-        if self._rotate_field:
-            array = rotate_vector_field(array, self._rotate_field)
+        rotate_field = self._rotate_field
+        if isinstance(rotate_field, str) and rotate_field == _AUTO_ROTATE_FIELD:
+            rotation_matrix = _auto_rotation_matrix_for_vector_field(vector_potential)
+            array = _apply_rotation_matrix(array, rotation_matrix)
+        elif rotate_field:
+            array = rotate_vector_field(array, rotate_field)
 
         slice_thicknesses = np.array(self.slice_thickness)
         slice_shape = (3,) + self._valid_gpts
@@ -289,7 +350,7 @@ class GPAWMagneticField(_GPAWMagnetics, BaseMagneticField):
         slice_thickness: float | tuple[float, ...] = 1.0,
         exit_planes: Optional[int | tuple[int, ...]] = None,
         plane: str = "xy",
-        rotate_field: Optional[tuple[float, float, float]] = None,
+        rotate_field: Optional[tuple[float, float, float]] | str = _AUTO_ROTATE_FIELD,
         origin: tuple[float, float, float] = (0.0, 0.0, 0.0),
         box: Optional[tuple[float, float, float]] = None,
         periodic: bool = True,
@@ -329,7 +390,7 @@ class GPAWVectorPotential(_GPAWMagnetics, BaseVectorPotential):
         slice_thickness: float | tuple[float, ...] = 1.0,
         exit_planes: Optional[int | tuple[int, ...]] = None,
         plane: str = "xy",
-        rotate_field: Optional[tuple[float, float, float]] = None,
+        rotate_field: Optional[tuple[float, float, float]] | str = _AUTO_ROTATE_FIELD,
         origin: tuple[float, float, float] = (0.0, 0.0, 0.0),
         box: Optional[tuple[float, float, float]] = None,
         periodic: bool = True,

--- a/abtem/magnetism/gpaw.py
+++ b/abtem/magnetism/gpaw.py
@@ -519,29 +519,34 @@ class GPAWMagneticFields:
                 (self.magnetic_field.project()[2], "$B_z$", "T"),
             ]
 
-        fig = plt.figure(figsize=figsize)
-        grid = ImageGrid(
-            fig,
-            111,
-            nrows_ncols=(1, len(panels)),
-            cbar_mode="edge",
-            cbar_location="bottom",
-            cbar_pad=0.1,
-            cbar_size=0.1,
-            axes_pad=0.1,
-        )
+        # Create the figure with pyplot's interactive auto-display off, then
+        # return it: otherwise Jupyter's inline backend renders it once from
+        # the auto-display hook and a second time from the returned value,
+        # showing the same plot twice.
+        with plt.ioff():
+            fig = plt.figure(figsize=figsize)
+            grid = ImageGrid(
+                fig,
+                111,
+                nrows_ncols=(1, len(panels)),
+                cbar_mode="edge",
+                cbar_location="bottom",
+                cbar_pad=0.1,
+                cbar_size=0.1,
+                axes_pad=0.1,
+            )
 
-        for ax, (image, name, unit) in zip(grid, panels):
-            array = np.asarray(image.tile(tile).array)
-            if np.abs(array).max() < 1e-5:
-                vmin, vmax = -1e-5, 1e-5
-            else:
-                vmin, vmax = None, None
-            im = ax.imshow(array.T, vmin=vmin, vmax=vmax, origin="lower")
-            ax.set_title(name)
-            ax.cax.colorbar(im, label=unit)
-            ax.xaxis.set_visible(False)
-            ax.yaxis.set_visible(False)
+            for ax, (image, name, unit) in zip(grid, panels):
+                array = np.asarray(image.tile(tile).array)
+                if np.abs(array).max() < 1e-5:
+                    vmin, vmax = -1e-5, 1e-5
+                else:
+                    vmin, vmax = None, None
+                im = ax.imshow(array.T, vmin=vmin, vmax=vmax, origin="lower")
+                ax.set_title(name)
+                ax.cax.colorbar(im, label=unit)
+                ax.xaxis.set_visible(False)
+                ax.yaxis.set_visible(False)
 
         return fig
 

--- a/abtem/magnetism/gpaw.py
+++ b/abtem/magnetism/gpaw.py
@@ -480,6 +480,71 @@ class GPAWMagneticFields:
             potential = self.potential
         return self.vector_potential.adjust_coulomb_potential(potential, energy=energy)
 
+    def show(
+        self,
+        tile: tuple[int, int] = (1, 1),
+        figsize: tuple[int, int] = (8, 8),
+    ):
+        """
+        Show side-by-side projections of the electrostatic potential and
+        the x and z components of the vector potential -- and, if built,
+        the magnetic field. `Az`/`Bz` are the components that matter for
+        `combined_potential`; `Ax`/`Bx` are shown alongside for a sanity
+        check that the in-plane and z-swapped components look sensible
+        relative to each other.
+
+        Parameters
+        ----------
+        tile : two int, optional
+            Tile the projected images before plotting, e.g. to preview the
+            periodicity of a repeated unit cell.
+        figsize : two int, optional
+            Figure size passed to `matplotlib.pyplot.figure`.
+
+        Returns
+        -------
+        fig : matplotlib.figure.Figure
+        """
+        import matplotlib.pyplot as plt
+        from mpl_toolkits.axes_grid1 import ImageGrid
+
+        panels = [
+            (self.potential.project(), "$V$", "$Å^{-3}$"),
+            (self.vector_potential.project()[0], "$A_x$", "ÅT"),
+            (self.vector_potential.project()[2], "$A_z$", "ÅT"),
+        ]
+        if self.magnetic_field is not None:
+            panels += [
+                (self.magnetic_field.project()[0], "$B_x$", "T"),
+                (self.magnetic_field.project()[2], "$B_z$", "T"),
+            ]
+
+        fig = plt.figure(figsize=figsize)
+        grid = ImageGrid(
+            fig,
+            111,
+            nrows_ncols=(1, len(panels)),
+            cbar_mode="edge",
+            cbar_location="bottom",
+            cbar_pad=0.1,
+            cbar_size=0.1,
+            axes_pad=0.1,
+        )
+
+        for ax, (image, name, unit) in zip(grid, panels):
+            array = np.asarray(image.tile(tile).array)
+            if np.abs(array).max() < 1e-5:
+                vmin, vmax = -1e-5, 1e-5
+            else:
+                vmin, vmax = None, None
+            im = ax.imshow(array.T, vmin=vmin, vmax=vmax, origin="lower")
+            ax.set_title(name)
+            ax.cax.colorbar(im, label=unit)
+            ax.xaxis.set_visible(False)
+            ax.yaxis.set_visible(False)
+
+        return fig
+
 
 def gpaw_magnetic_fields(
     calculators: GPAW | list[GPAW] | list[str] | str,

--- a/abtem/magnetism/gpaw.py
+++ b/abtem/magnetism/gpaw.py
@@ -89,6 +89,21 @@ def get_magnetic_field_from_gpaw(calc, gridrefinement=2, assume_colinear=True):
     return B
 
 
+def _check_unsupported_ensemble_params(frozen_phonons, repetitions):
+    if frozen_phonons is not None:
+        raise NotImplementedError(
+            "frozen_phonons is not supported for magnetic fields/vector "
+            "potentials; build the field from a single calculator and combine "
+            "it with an electrostatic FrozenPhonons ensemble instead."
+        )
+    if tuple(repetitions) != (1, 1, 1):
+        raise NotImplementedError(
+            "repetitions is not supported for magnetic fields/vector "
+            "potentials; build the field for a single unit cell and call "
+            ".tile() on the resulting array instead."
+        )
+
+
 @runtime_checkable
 class GPAW(Protocol):
     @property
@@ -123,6 +138,8 @@ class _GPAWMagnetics(_FieldBuilder):
     ):
         if not assume_colinear:
             raise NotImplementedError("Non-collinear calculations not supported.")
+
+        _check_unsupported_ensemble_params(frozen_phonons, repetitions)
 
         self.gridrefinement = gridrefinement
 
@@ -282,6 +299,8 @@ class GPAWMagneticField(_GPAWMagnetics, BaseMagneticField):
         projection: str = "fft",
         device: Optional[str] = None,
     ):
+        _check_unsupported_ensemble_params(frozen_phonons, repetitions)
+
         super().__init__(
             calculators=calculators,
             array_object=MagneticFieldArray,
@@ -320,6 +339,8 @@ class GPAWVectorPotential(_GPAWMagnetics, BaseVectorPotential):
         projection: str = "fft",
         device: Optional[str] = None,
     ):
+        _check_unsupported_ensemble_params(frozen_phonons, repetitions)
+
         super().__init__(
             calculators=calculators,
             array_object=VectorPotentialArray,

--- a/abtem/magnetism/gpaw.py
+++ b/abtem/magnetism/gpaw.py
@@ -98,49 +98,39 @@ def get_magnetic_field_from_gpaw(calc, gridrefinement=2, assume_colinear=True):
 #: see the raw (Az == 0) output.
 _AUTO_ROTATE_FIELD = "auto"
 
-#: Fallback rotation matrix used only when the raw field is exactly zero in
-#: the xy-plane too (e.g. no magnetic moment), where "largest component" is
-#: undefined. Equivalent to Euler angles (0, pi/2, 0).
-_DEFAULT_COLLINEAR_ROTATION_MATRIX = R.from_euler(
-    "xyz", (0.0, np.pi / 2, 0.0)
-).as_matrix()
+#: Swaps x into z: (Ax, Ay, 0) -> (0, Ay, -Ax). Euler angles (0, pi/2, 0).
+_ROTATION_X_INTO_Z = R.from_euler("xyz", (0.0, np.pi / 2, 0.0)).as_matrix()
+
+#: Swaps y into z: (Ax, Ay, 0) -> (Ax, 0, Ay). Euler angles (pi/2, 0, 0).
+_ROTATION_Y_INTO_Z = R.from_euler("xyz", (np.pi / 2, 0.0, 0.0)).as_matrix()
 
 
 def _auto_rotation_matrix_for_vector_field(vector_field: np.ndarray) -> np.ndarray:
     """
-    Rotation matrix that rotates the in-plane (x, y) component of
-    `vector_field` with the largest aggregate magnitude into z.
+    Rotation matrix that swaps whichever of the in-plane (x, y) components
+    of `vector_field` has the larger aggregate magnitude into z.
 
     `calculate_magnetic_vector_potential` always builds the magnetization as
-    m = (0, 0, rho) -- collinear spin has no real-space direction, so GPAW's
+    m = (0, 0, rho): collinear spin has no real-space direction, so GPAW's
     internal spin axis is arbitrary. Because curl(m) and the subsequent
     Poisson solve are applied component-wise, this makes the z-component of
     `vector_field` (and hence the only component `adjust_coulomb_potential`
     uses) identically zero for every collinear calculation, not just some.
-    Any in-plane axis is an equally valid choice to swap into z absent
-    additional information about the real magnetization direction, so this
-    picks the one that maximises the resulting z-component (in an
-    aggregate, least-squares sense) rather than an arbitrary fixed axis.
+
+    Only the two 90-degree swaps (x into z, or y into z) are considered,
+    not an arbitrary in-plane rotation angle: x, y and z are the only
+    directions with a physical meaning here (the orthogonal axes of the
+    simulation cell), so a continuous "optimal" blend of Ax and Ay has no
+    real-space interpretation as a magnetization direction -- it would just
+    fit whatever numerical asymmetry happens to be in the grid.
     """
     Ax = vector_field[0].astype(np.float64, copy=False)
     Ay = vector_field[1].astype(np.float64, copy=False)
 
     Sxx = float(np.sum(Ax * Ax))
     Syy = float(np.sum(Ay * Ay))
-    Sxy = float(np.sum(Ax * Ay))
 
-    if Sxx == 0.0 and Syy == 0.0:
-        return _DEFAULT_COLLINEAR_ROTATION_MATRIX
-
-    # Angle maximising cos(t)^2 * Sxx + sin(t)^2 * Syy + sin(2t) * Sxy.
-    theta = 0.5 * np.arctan2(2 * Sxy, Sxx - Syy)
-
-    dominant = np.array([np.cos(theta), np.sin(theta), 0.0])
-    perpendicular = np.array([-np.sin(theta), np.cos(theta), 0.0])
-    original_z = np.array([0.0, 0.0, 1.0])
-
-    # Right-handed frame mapping the dominant in-plane direction to z.
-    return np.stack([perpendicular, original_z, dominant])
+    return _ROTATION_X_INTO_Z if Sxx >= Syy else _ROTATION_Y_INTO_Z
 
 
 def _check_unsupported_ensemble_params(frozen_phonons, repetitions):

--- a/abtem/magnetism/gpaw.py
+++ b/abtem/magnetism/gpaw.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, replace
 from typing import Optional, Protocol, runtime_checkable
 
 import numpy as np
@@ -18,7 +19,8 @@ from abtem.magnetism.iam import (
 )
 from abtem.magnetism.utils import bohr_magneton, vacuum_permeability
 from abtem.potentials.charge_density import curl_fourier, integrate_gradient_fourier
-from abtem.potentials.iam import _FieldBuilder
+from abtem.potentials.gpaw import GPAWPotential
+from abtem.potentials.iam import PotentialArray, _FieldBuilder
 
 
 def _calculate_non_periodic_magnetic_vector_potential():
@@ -409,6 +411,213 @@ class GPAWVectorPotential(_GPAWMagnetics, BaseVectorPotential):
             projection=projection,
             periodic=periodic,
         )
+
+
+@dataclass
+class GPAWMagneticFields:
+    """
+    Bundles the electrostatic potential, magnetic vector potential and
+    (optionally) magnetic field built from the same GPAW calculator(s) by
+    `gpaw_magnetic_fields`.
+
+    `potential` may carry a frozen-phonon ensemble axis (or, after tiling,
+    come from a `CrystalPotential` build); `vector_potential` and
+    `magnetic_field` are always for a single, rigid configuration -- see
+    `_check_unsupported_ensemble_params`. Use `.tile()` to bring the
+    magnetic components up to a repeated crystal's size, and
+    `.combined_potential()` to fold the vector potential into an
+    electrostatic potential via `adjust_coulomb_potential`.
+    """
+
+    potential: PotentialArray
+    vector_potential: VectorPotentialArray
+    magnetic_field: Optional[MagneticFieldArray] = None
+
+    def tile(
+        self, repetitions: tuple[int, int] | tuple[int, int, int]
+    ) -> "GPAWMagneticFields":
+        """
+        Tile `vector_potential` (and `magnetic_field`, if present) to match
+        a separately tiled/repeated electrostatic potential, e.g. built via
+        `abtem.CrystalPotential`.
+
+        `potential` is left untouched here -- tile or rebuild it separately
+        (e.g. `CrystalPotential(electrostatic_ensemble, repetitions=...)`)
+        before calling `combined_potential`.
+        """
+        return replace(
+            self,
+            vector_potential=self.vector_potential.tile(repetitions),
+            magnetic_field=(
+                self.magnetic_field.tile(repetitions)
+                if self.magnetic_field is not None
+                else None
+            ),
+        )
+
+    def combined_potential(
+        self, energy: float, potential: Optional[PotentialArray] = None
+    ) -> PotentialArray:
+        """
+        Combine an electrostatic potential with `vector_potential` via
+        `VectorPotentialArray.adjust_coulomb_potential`.
+
+        Parameters
+        ----------
+        energy : float
+            Electron energy [eV].
+        potential : PotentialArray, optional
+            The electrostatic potential to combine with `vector_potential`.
+            Defaults to `self.potential`; pass a separately
+            tiled/ensembled potential (e.g. a `CrystalPotential` build)
+            after calling `.tile()` for the frozen-phonon workflow.
+
+        Returns
+        -------
+        PotentialArray
+        """
+        if potential is None:
+            potential = self.potential
+        return self.vector_potential.adjust_coulomb_potential(potential, energy=energy)
+
+
+def gpaw_magnetic_fields(
+    calculators: GPAW | list[GPAW] | list[str] | str,
+    gpts: Optional[int | tuple[int, int]] = None,
+    sampling: Optional[float | tuple[float, float]] = None,
+    slice_thickness: float | tuple[float, ...] = 1.0,
+    exit_planes: Optional[int | tuple[int, ...]] = None,
+    plane: str = "xy",
+    origin: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    box: Optional[tuple[float, float, float]] = None,
+    periodic: bool = True,
+    frozen_phonons: Optional[BaseFrozenPhonons] = None,
+    rotate_field: Optional[tuple[float, float, float]] | str = _AUTO_ROTATE_FIELD,
+    include_magnetic_field: bool = False,
+    magnetic_calculator: Optional[GPAW] = None,
+    device: Optional[str] = None,
+    lazy: Optional[bool] = None,
+    potential_kwargs: Optional[dict] = None,
+    field_kwargs: Optional[dict] = None,
+) -> GPAWMagneticFields:
+    """
+    Build the electrostatic potential, magnetic vector potential and
+    (optionally) magnetic field from the same GPAW calculator(s) in one
+    call.
+
+    `frozen_phonons` (an ensemble of atomic-displacement configurations) is
+    only supported for the electrostatic `potential` -- the magnetic
+    components come from a single, rigid ab initio calculation and cannot
+    vary per configuration. Tile the returned object with `.tile()` to
+    match a separately built, possibly-ensembled electrostatic potential
+    (e.g. from `abtem.CrystalPotential`), then combine with
+    `.combined_potential()`.
+
+    Parameters
+    ----------
+    calculators : (list of) gpaw.calculator.GPAW or (list of) str
+        One or more converged GPAW calculators (or paths to `.gpw` files).
+        Forwarded to `GPAWPotential`. If a list (a frozen-phonon ensemble),
+        `magnetic_calculator` must be given explicitly, since
+        `GPAWVectorPotential`/`GPAWMagneticField` only support a single
+        calculator.
+    gpts, sampling, slice_thickness, exit_planes, plane, origin, box,
+    periodic, device : see `GPAWPotential`, `GPAWVectorPotential`
+        Forwarded to all built components.
+    frozen_phonons : BaseFrozenPhonons, optional
+        Forwarded to `GPAWPotential` only.
+    rotate_field : tuple of three float, "auto", or None
+        Forwarded to `GPAWVectorPotential`/`GPAWMagneticField`. Defaults to
+        `"auto"`: automatically swap the larger-magnitude in-plane
+        component into z (see `_auto_rotation_matrix_for_vector_field`).
+    include_magnetic_field : bool
+        If True, also build the magnetic field `B` (not used by
+        `combined_potential`, only for inspection/visualization). Roughly
+        doubles the GPAW-side cost of the magnetic part, so it is off by
+        default.
+    magnetic_calculator : gpaw.calculator.GPAW, optional
+        The single calculator representing the (rigid) magnetic
+        contribution. Defaults to `calculators` when that is a single
+        calculator; required when `calculators` is a list.
+    lazy : bool, optional
+        Passed to the electrostatic potential's `.build()`. The magnetic
+        components are always built eagerly, since
+        `GPAWVectorPotential`/`GPAWMagneticField` do not support lazy
+        building.
+    potential_kwargs, field_kwargs : dict, optional
+        Extra keyword arguments forwarded only to `GPAWPotential`, or only
+        to `GPAWVectorPotential`/`GPAWMagneticField`, respectively (e.g.
+        their differing `gridrefinement` defaults).
+
+    Returns
+    -------
+    GPAWMagneticFields
+    """
+    if isinstance(calculators, (list, tuple)):
+        if magnetic_calculator is None:
+            raise ValueError(
+                "calculators is a list (a frozen-phonon ensemble); "
+                "GPAWVectorPotential/GPAWMagneticField only support a "
+                "single calculator. Pass magnetic_calculator explicitly to "
+                "pick which one represents the (rigid) magnetic "
+                "contribution."
+            )
+    elif magnetic_calculator is None:
+        magnetic_calculator = calculators
+
+    potential_kwargs = dict(potential_kwargs or {})
+    field_kwargs = dict(field_kwargs or {})
+
+    shared = dict(
+        gpts=gpts,
+        sampling=sampling,
+        slice_thickness=slice_thickness,
+        exit_planes=exit_planes,
+        plane=plane,
+        origin=origin,
+        box=box,
+        periodic=periodic,
+        device=device,
+    )
+
+    potential = GPAWPotential(
+        calculators,
+        frozen_phonons=frozen_phonons,
+        **shared,
+        **potential_kwargs,
+    ).build(lazy=lazy)
+    if not lazy:
+        potential = potential.compute()
+
+    vector_potential = (
+        GPAWVectorPotential(
+            magnetic_calculator,
+            rotate_field=rotate_field,
+            **shared,
+            **field_kwargs,
+        )
+        .build()
+        .compute()
+    )
+
+    magnetic_field = None
+    if include_magnetic_field:
+        magnetic_field = (
+            GPAWMagneticField(
+                magnetic_calculator,
+                rotate_field=rotate_field,
+                **shared,
+                **field_kwargs,
+            )
+            .build()
+            .compute()
+        )
+
+    return GPAWMagneticFields(
+        potential=potential,
+        vector_potential=vector_potential,
+        magnetic_field=magnetic_field,
+    )
 
 
 class SpinDensityMagneticField:

--- a/abtem/potentials/gpaw.py
+++ b/abtem/potentials/gpaw.py
@@ -86,7 +86,22 @@ class _DummyGPAW:
         # compensation charge coefficients from Q_aL to ccc_aL.
         Q_aL = getattr(gpaw.density, "Q_aL", None)
         if Q_aL is None:
-            Q_aL = gpaw.density.ccc_aL
+            Q_aL = getattr(gpaw.density, "ccc_aL", None)
+        if Q_aL is None:
+            # Neither attribute is populated: on old-style GPAW (Density.Q_aL
+            # starts as None) this happens for a calculator restarted from a
+            # .gpw file without rerunning the SCF loop, since Q_aL is filled
+            # in as a side effect of calculate() rather than eagerly on load.
+            # Compute it explicitly instead of assuming it is already cached.
+            if hasattr(gpaw.density, "calculate_multipole_moments"):
+                _, Q_aL = gpaw.density.calculate_multipole_moments()
+            elif hasattr(gpaw.density, "calculate_compensation_charge_coefficients"):
+                Q_aL = gpaw.density.calculate_compensation_charge_coefficients()
+            else:
+                raise AttributeError(
+                    "could not find or compute GPAW's compensation charge "
+                    "coefficients (Q_aL/ccc_aL) on this density object"
+                )
 
         kwargs = {
             "setup_mode": gpaw.parameters.mode,

--- a/abtem/potentials/gpaw.py
+++ b/abtem/potentials/gpaw.py
@@ -82,15 +82,21 @@ class _DummyGPAW:
         atoms = gpaw.atoms.copy()
         atoms.calc = None
 
+        # GPAW's new-style calculator (default since GPAW 26) renames the
+        # compensation charge coefficients from Q_aL to ccc_aL.
+        Q_aL = getattr(gpaw.density, "Q_aL", None)
+        if Q_aL is None:
+            Q_aL = gpaw.density.ccc_aL
+
         kwargs = {
-            "setup_mode": gpaw.parameters["mode"],
-            "setup_xc": gpaw.parameters["xc"],
+            "setup_mode": gpaw.parameters.mode,
+            "setup_xc": gpaw.parameters.xc,
             "nt_sG": gpaw.density.nt_sG.copy(),
             "gd": gpaw.density.gd.new_descriptor(comm=SerialCommunicator()),
             "D_asp": dict(gpaw.density.D_asp),
             "atoms": atoms,
             "valence_potential": gpaw.get_electrostatic_potential(),
-            "Q_aL": dict(gpaw.density.Q_aL),
+            "Q_aL": dict(Q_aL),
         }
 
         return cls(**kwargs)

--- a/abtem/potentials/iam.py
+++ b/abtem/potentials/iam.py
@@ -1228,9 +1228,12 @@ class FieldArray(BaseField, ArrayObject):
 
         assert len(repetitions) == 3
 
-        new_array = np.tile(
-            self.array, (repetitions[2], repetitions[0], repetitions[1])
-        )
+        tile_reps = [1] * len(self.array.shape)
+        tile_reps[-self._base_dims] = repetitions[2]
+        tile_reps[-2] = repetitions[0]
+        tile_reps[-1] = repetitions[1]
+
+        new_array = np.tile(self.array, tuple(tile_reps))
 
         if self.extent is not None:
             new_extent = (


### PR DESCRIPTION
## Summary
- Fixed `FieldArray.tile()` for vector-valued fields (`VectorPotentialArray`, `MagneticFieldArray`): it hard-coded the last 3 array axes as `(z, x, y)`, which only holds for scalar potentials, so tiling a vector/magnetic field silently tiled the wrong axis and raised a slice-thickness mismatch error.
- `GPAWMagneticField`/`GPAWVectorPotential` now raise `NotImplementedError` for `frozen_phonons`/`repetitions` instead of silently ignoring them (they were accepted but never implemented).
- `rotate_field` now defaults to `"auto"`: since collinear spin has no real-space direction, GPAW's internal magnetization axis always produces `Az == 0`. `"auto"` automatically swaps whichever in-plane component (`Ax` or `Ay`) has the larger magnitude into `z`, restricted to the two physically meaningful 90-degree swaps (not an arbitrary blended angle). Explicit `rotate_field` tuples and `rotate_field=None` (raw output) still work as before.
- Added `gpaw_magnetic_fields(...)`, which builds the electrostatic potential, vector potential, and (optionally) magnetic field from the same GPAW calculator(s) in one call, returning a `GPAWMagneticFields` bundle with `.tile()` and `.combined_potential()` to support combining a rigid ab initio magnetic contribution with a separately tiled/frozen-phonon-ensembled electrostatic potential.
- Added `GPAWMagneticFields.show()` for a side-by-side `V`/`Ax`/`Az`/`Bx`/`Bz` comparison plot.

## Usage

```python
import numpy as np
import gpaw

import abtem
from abtem.inelastic.phonons import FrozenPhonons
from abtem.magnetism.gpaw import gpaw_magnetic_fields

# ------------------------------------------------------------------
# 1. Load the converged, spin-polarized (collinear) DFT calculation.
# ------------------------------------------------------------------
atoms, calc = gpaw.restart("saved_calculation.gpw")

sampling = 0.05
energy = 300e3          # electron energy [eV]
reps = (5, 5, 4)         # tile the DFT unit cell into a crystal

# ------------------------------------------------------------------
# 2. Build the electrostatic potential, vector potential, and (if
#    needed) magnetic field from the same calculator in one call.
#
#    rotate_field defaults to "auto": it picks whichever in-plane
#    component (Ax or Ay) is larger and swaps it into Az, so Az is
#    guaranteed nonzero without any manual Euler-angle bookkeeping.
#    Pass rotate_field=(0.0, np.pi / 2, 0.0) (or any other tuple) to
#    force a specific orientation instead, or rotate_field=None to see
#    the raw (Az == 0) output.
# ------------------------------------------------------------------
fields = gpaw_magnetic_fields(
    calc,
    sampling=sampling,
    plane="xy",
    include_magnetic_field=True,   # set False (default) to skip B; only
                                    # needed here for visualization below
)

fields.potential          # PotentialArray  (electrostatic, exact DFT config)
fields.vector_potential   # VectorPotentialArray, shape (num_slices, 3, *gpts)
fields.magnetic_field     # MagneticFieldArray, or None if not requested

fields.show()                    # V, Ax, Az, Bx, Bz side by side
fields.show(tile=(2, 2))         # preview a tiled/repeated view

# ------------------------------------------------------------------
# 3a. Simple case: no frozen phonons, single deterministic potential.
#     Combine at the unit-cell level, then tile the combined result.
# ------------------------------------------------------------------
magnetic_potential_unit = fields.combined_potential(energy=energy)

magnetic_crystal_potential = (
    abtem.CrystalPotential(magnetic_potential_unit, repetitions=reps)
    .build()
    .compute()
)

# ------------------------------------------------------------------
# 3b. Frozen-phonon case: use rattled IAM configurations for the
#     electrostatic part (thermal diffuse scattering), while keeping
#     the ab initio magnetic vector potential rigid across all of
#     them. Combination now has to happen *after* tiling, since the
#     electrostatic ensemble and the magnetic part are tiled
#     independently and only line up once both are the crystal size.
# ------------------------------------------------------------------
frozen_phonons = FrozenPhonons(atoms, num_configs=8, sigmas=0.1)
electrostatic_unit = abtem.Potential(
    frozen_phonons, sampling=sampling, slice_thickness=1.0
)

# num_frozen_phonons independent tiled realizations; each tile of each
# realization draws from the 8-configuration displacement pool.
crystal_potential = (
    abtem.CrystalPotential(
        electrostatic_unit,
        repetitions=reps,
        num_frozen_phonons=6,
        ensemble_mean=False,
    )
    .build()
    .compute()
)

# Tile the (rigid, non-ensemble) magnetic components to the same size.
tiled_fields = fields.tile(reps)

# Now combine: adjust_coulomb_potential broadcasts the single tiled
# vector potential against every frozen-phonon realization.
magnetic_crystal_potential = tiled_fields.combined_potential(
    energy=energy, potential=crystal_potential
)
# -> PotentialArray with ensemble_shape == (6,), ready for multislice.

# ------------------------------------------------------------------
# 4. Use exactly like any other potential downstream -- no special
#    casing needed since combined_potential() already returns a
#    normal PotentialArray.
# ------------------------------------------------------------------
# waves = abtem.PlaneWave(energy=energy, sampling=sampling)
# exit_waves = waves.multislice(magnetic_crystal_potential).compute()
```

## Test plan
- [x] Verified against real spin-polarized GPAW calculations (GPAW 26.7.1b1) that `tile()`, the auto rotation, `gpaw_magnetic_fields()`, and `combined_potential()` are numerically correct/bit-identical to the equivalent manual API calls.
- [x] Ran the exact usage example above (both the simple and frozen-phonon paths) end to end against a real GPAW 26.7.1b1 calculation.
- [x] Verified `GPAWMagneticFields.show()` renders correctly (including the fix for it doubly-rendering in Jupyter).
- [x] `test/test_magnetics.py`, `test/test_potentials.py` pass (42 passed, 18 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
