### PR TITLE
Fix GPAWPotential single-calculator frozen_phonons ensemble building

### DIFF
--- a/abtem/potentials/gpaw.py
+++ b/abtem/potentials/gpaw.py
@@ -564,6 +564,7 @@ class GPAWPotential(_PotentialBuilder):
 
         if args["frozen_phonons"] is not None:
             frozen_phonons = frozen_phonons_partial(args["frozen_phonons"])
+            frozen_phonons = frozen_phonons.item()
         else:
             frozen_phonons = None
 
@@ -600,9 +601,16 @@ class GPAWPotential(_PotentialBuilder):
 
         if isinstance(self.frozen_phonons, FrozenPhonons):
             array = np.zeros(len(self.frozen_phonons), dtype=object)
-            for i, fp in enumerate(
-                self.frozen_phonons._partition_args(chunks, lazy=lazy)[0]
-            ):
+            partitioned = self.frozen_phonons._partition_args(chunks, lazy=lazy)[0]
+
+            # Iterating a dask array yields per-element dask array slices;
+            # passing those into dask.delayed() and wrapping the result with
+            # another from_delayed()/concatenate() confuses dask's shape
+            # inference (IndexError deep in dask.array.core during compute).
+            # Delayed objects from to_delayed() compose correctly instead.
+            fp_chunks = partitioned.to_delayed().ravel() if lazy else partitioned
+
+            for i, fp in enumerate(fp_chunks):
                 if lazy:
                     block = dask.delayed(frozen_phonons)(calculators, fp)
 

--- a/test/test_gpaw.py
+++ b/test/test_gpaw.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 from ase import Atoms, units
 
+from abtem.inelastic.phonons import FrozenPhonons
 from abtem.potentials.iam import Potential
 
 try:
@@ -66,19 +67,19 @@ def test_compare_ps2ae_to_abtem_bonding(gpaw_calculator_bonding):
     assert_psae_matches_abtem(gpaw_calculator_bonding)
 
 
-# @pytest.mark.skipif("gpaw" not in sys.modules, reason="requires gpaw")
-# def test_gpaw_potential_with_frozen_phonons(gpaw_calculator_bonding):
-#     frozen_phonons = FrozenPhonons(
-#         gpaw_calculator_bonding.atoms, num_configs=2, sigmas=0.1
-#     )
-#     gpaw_potential = GPAWPotential(
-#         gpaw_calculator_bonding, sampling=0.05, frozen_phonons=frozen_phonons
-#     )
-#     assert gpaw_potential.ensemble_shape == (2,)
-#     assert gpaw_potential.build().ensemble_shape == (2,)
-#     gpaw_potential = gpaw_potential.build().compute()
-#     assert gpaw_potential.ensemble_shape == (2,)
-#     assert not np.allclose(gpaw_potential.array[0], gpaw_potential.array[1])
+@pytest.mark.skipif("gpaw" not in sys.modules, reason="requires gpaw")
+def test_gpaw_potential_with_frozen_phonons(gpaw_calculator_bonding):
+    frozen_phonons = FrozenPhonons(
+        gpaw_calculator_bonding.atoms, num_configs=2, sigmas=0.1
+    )
+    gpaw_potential = GPAWPotential(
+        gpaw_calculator_bonding, sampling=0.05, frozen_phonons=frozen_phonons
+    )
+    assert gpaw_potential.ensemble_shape == (2,)
+    assert gpaw_potential.build().ensemble_shape == (2,)
+    gpaw_potential = gpaw_potential.build().compute()
+    assert gpaw_potential.ensemble_shape == (2,)
+    assert not np.allclose(gpaw_potential.array[0], gpaw_potential.array[1])
 
 
 @pytest.mark.skipif("gpaw" not in sys.modules, reason="requires gpaw")


### PR DESCRIPTION
## Summary
`GPAWPotential(calc, frozen_phonons=FrozenPhonons(...))` approximates frozen phonons for a **single** GPAW calculation: the valence density/potential is computed once and kept fixed, while the (purely radial) PAW core-correction interpolators are evaluated at rattled nuclear positions per configuration. This path existed in the code and its docstring, but was broken and its regression test disabled.

Two bugs, both in the ensemble machinery that reconstructs a per-configuration `GPAWPotential` from partitioned args:

- `_gpaw_potential` never unwrapped the `_wrap_with_array(...)`-wrapped result from `frozen_phonons_partial(...)`, so it tried to construct `GPAWPotential(..., frozen_phonons=<numpy array>)` and failed with `AttributeError: 'numpy.ndarray' object has no attribute 'atoms'`. The working IAM `Potential._from_partitioned_args_func` already does this same `frozen_phonons.item()` unwrap — `GPAWPotential` was just missing it.
- The lazy build path iterated the partitioned dask array directly, which yields per-element dask array *slices*; passing those into `dask.delayed()` and re-wrapping the result via another `from_delayed()`/`concatenate()` confuses dask's internal shape inference (`IndexError` deep in `dask.array.core` during `.compute()`, on dask 2026.6.0). I reproduced this in a minimal, abtem-independent script to confirm it isn't an abtem logic bug. Using `partitioned.to_delayed()` to get proper `Delayed` chunk handles instead of raw array slices avoids it — `Delayed` objects compose with `dask.delayed()` correctly, unlike raw `da.Array` slices.

Re-enabled `test_gpaw_potential_with_frozen_phonons`, which had been commented out.

**Depends on [#325](https://github.com/abTEM/abTEM/pull/325) (`newgpawfix`)**: this branch is based on `dev`, which doesn't yet include the GPAW 26+ `.parameters`/`Q_aL` compatibility fix. Any test here that builds a real GPAW calculator against GPAW 26+ will fail with the unrelated `TypeError: 'Parameters' object is not subscriptable` until #325 merges. I verified the frozen-phonons fix itself against a real GPAW 26.7.1b1 calculation with that other fix applied locally (not included in this diff, to keep this PR scoped to just the frozen-phonons bug).

## Test plan
- [x] Reproduced both bugs and confirmed the fixes against a real GPAW 26.7.1b1 calculation (with #325's fix applied locally for testing).
- [x] Eager (`lazy=False`) and lazy (`lazy=True`) builds now agree exactly.
- [x] The two frozen-phonon configurations produce genuinely different potentials (rattling takes effect: `not np.allclose(array[0], array[1])`).
- [x] Composes correctly with `repetitions` (tiling) — verified the periodic valence potential comes out tiled correctly via the existing FFT-based slice interpolation, with no additional code needed.
- [x] Reproduced the dask `IndexError` in a minimal, abtem-independent script to confirm root cause before fixing.
- [x] `test/test_gpaw.py::test_gpaw_potential_with_frozen_phonons` re-enabled and passes (pending #325's merge in this environment — currently blocked here only by the pre-existing `.parameters` issue, and separately by an environment-specific MPI grid-decomposition limit affecting several other tests in this file on this many-core workstation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
