### PR TITLE
Opt-in multi-GPU support via dask-cuda

### DIFF
--- a/abtem/array.py
+++ b/abtem/array.py
@@ -45,7 +45,9 @@ from abtem.core.backend import (
     copy_to_device,
     cp,
     device_name_from_array_module,
+    ensure_cuda_cluster,
     get_array_module,
+    is_gpu_dask_client,
 )
 from abtem.core.chunks import Chunks, iterate_chunk_ranges, validate_chunks
 from abtem.core.ensemble import Ensemble, _wrap_with_array, unpack_blockwise_args
@@ -506,14 +508,29 @@ def _compute(
     if is_gpu:
         check_cupy_is_installed()
 
-        if "scheduler" not in kwargs:
+        from distributed import get_client
+
+        try:
+            client = get_client()
+        except ValueError:
+            client = None
+
+        # Start a dask-cuda cluster spanning all visible GPUs when multi-GPU is
+        # enabled, no client is already handling the computation, and the user has
+        # not explicitly requested a scheduler.
+        if (
+            client is None
+            and "scheduler" not in kwargs
+            and config.get("dask.multi-gpu", False)
+            and cp.cuda.runtime.getDeviceCount() > 1
+        ):
+            client = ensure_cuda_cluster()
+
+        # The threaded scheduler and multi-threaded workers cannot be used with CuPy;
+        # fall back to synchronous execution unless a suitable (dask-cuda) client is
+        # handling the computation.
+        if not is_gpu_dask_client(client) and "scheduler" not in kwargs:
             kwargs["scheduler"] = "synchronous"
-
-        if "num_workers" not in kwargs:
-            kwargs["num_workers"] = cp.cuda.runtime.getDeviceCount()
-
-        if "threads_per_worker" not in kwargs:
-            kwargs["threads_per_worker"] = cp.cuda.runtime.getDeviceCount()
 
     with _compute_context(
         progress_bar, profiler=profiler, resource_profiler=resource_profiler

--- a/abtem/core/abtem.yaml
+++ b/abtem/core/abtem.yaml
@@ -18,6 +18,9 @@ dask:
   chunk-size: 128 MB
   # The target chunk size to use for dask arrays on the gpu
   chunk-size-gpu: 512 MB
+  # Automatically distribute gpu computations over all visible gpus by starting a
+  # dask-cuda cluster. Requires the optional dask-cuda package.
+  multi-gpu: false
 cupy:
   # The size of the fft cache in MB used by cupy
   # https://docs.cupy.dev/en/stable/user_guide/fft.html#fft-plan-cache

--- a/abtem/core/backend.py
+++ b/abtem/core/backend.py
@@ -52,6 +52,80 @@ def check_cupy_is_installed():
         raise RuntimeError("CuPy is not installed, GPU calculations disabled")
 
 
+_cuda_cluster_client = None
+
+
+def ensure_cuda_cluster():
+    """
+    Start a dask-cuda cluster spanning all visible GPUs and return its client.
+
+    The cluster assigns one worker process to each GPU, allowing dask to distribute
+    computations across all of them. It is created once per process and reused on
+    subsequent calls. Requires the optional dask-cuda package.
+
+    Returns
+    -------
+    distributed.Client
+        The client connected to the dask-cuda cluster.
+    """
+    global _cuda_cluster_client
+
+    if _cuda_cluster_client is not None:
+        if getattr(_cuda_cluster_client, "status", None) == "running":
+            return _cuda_cluster_client
+        # The previous cluster was shut down; discard it and start a new one.
+        _cuda_cluster_client = None
+
+    try:
+        from dask_cuda import LocalCUDACluster  # type: ignore
+    except ImportError:
+        raise RuntimeError(
+            "The dask-cuda package is required to distribute computations across "
+            "multiple GPUs. Please install it (see "
+            "https://docs.rapids.ai/api/dask-cuda/stable/install/), or set the "
+            "configuration option 'dask.multi-gpu' to false."
+        )
+
+    from distributed import Client
+
+    _cuda_cluster_client = Client(LocalCUDACluster())
+
+    return _cuda_cluster_client
+
+
+def is_gpu_dask_client(client) -> bool:
+    """
+    Check whether a distributed client can safely execute CuPy computations.
+
+    Only a client whose workers are each single-threaded — as produced by
+    ``dask_cuda.LocalCUDACluster``, which additionally pins one GPU per worker — is
+    considered suitable. The threaded scheduler and multi-threaded workers share a
+    single CUDA context per process, which cannot be used with CuPy.
+
+    Parameters
+    ----------
+    client : distributed.Client or None
+        The client to check.
+
+    Returns
+    -------
+    bool
+        True if the client is running and all of its workers are single-threaded.
+    """
+    if client is None:
+        return False
+
+    if getattr(client, "status", None) != "running":
+        return False
+
+    try:
+        nthreads = client.nthreads()
+    except Exception:
+        return False
+
+    return len(nthreads) > 0 and all(n == 1 for n in nthreads.values())
+
+
 def validate_device(device: str | None = None) -> str:
     """
     Validate the device string.

--- a/abtem/core/backend.py
+++ b/abtem/core/backend.py
@@ -88,7 +88,21 @@ def ensure_cuda_cluster():
 
     from distributed import Client
 
-    _cuda_cluster_client = Client(LocalCUDACluster())
+    # Cap each worker's memory to a share of the cgroup/job limit so a
+    # memory-constrained allocation (e.g. a Slurm cgroup) spills instead of being
+    # OOM-killed. dask-cuda otherwise sizes workers from the node total, which
+    # over-commits when the cgroup grants less than the node has.
+    cluster_kwargs: dict = {}
+    try:
+        from distributed.system import MEMORY_LIMIT
+
+        n_gpus = cp.cuda.runtime.getDeviceCount() if cp is not None else 0
+        if n_gpus > 0:
+            cluster_kwargs["memory_limit"] = int(0.85 * MEMORY_LIMIT / n_gpus)
+    except Exception:  # noqa: BLE001 -- fall back to dask-cuda's default sizing
+        pass
+
+    _cuda_cluster_client = Client(LocalCUDACluster(**cluster_kwargs))
 
     return _cuda_cluster_client
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,13 @@ gpaw = [
     "hankel",
     "sympy",
 ]
+# Install every optional runtime extra at once. GPU packages (cupy, dask-cuda)
+# are intentionally excluded: their wheels are CUDA/RAPIDS-version specific and
+# must be installed to match the local toolkit (see the multi-GPU docs).
+all = [
+    "abtem[extra]",
+    "abtem[gpaw]",
+]
 
 [dependency-groups]
 dev = [

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -23,6 +23,10 @@ def pytest_configure(config):
         "ignore",
         category=UserWarning,
     )
+    config.addinivalue_line(
+        "markers",
+        "multigpu: requires >=2 GPUs and dask-cuda; skipped otherwise",
+    )
 
 
 # def pytest_addoption(parser):

--- a/test/test_multigpu.py
+++ b/test/test_multigpu.py
@@ -1,0 +1,143 @@
+"""Multi-GPU integration tests for abTEM's dask-cuda support.
+
+Skipped unless the machine has >=2 GPUs *and* dask-cuda installed. Each test
+runs a real ``dask_cuda.LocalCUDACluster`` (one worker per GPU) via abTEM's own
+``ensure_cuda_cluster`` and checks that GPU computations actually distribute and
+that the result does not depend on how many GPUs were used.
+"""
+
+import numpy as np
+import pytest
+from utils import requires_multigpu
+
+import abtem
+from abtem.core.backend import asnumpy, is_gpu_dask_client
+
+# All tests here need multiple GPUs; ignore the noisy dask/cupy runtime warnings
+# (the suite otherwise runs with filterwarnings=error).
+pytestmark = [pytest.mark.multigpu, requires_multigpu, pytest.mark.filterwarnings("ignore")]
+
+
+# --------------------------------------------------------------------------
+# deterministic workloads (fixed seed -> identical frozen-phonon configs)
+# --------------------------------------------------------------------------
+
+
+def _atoms():
+    from ase.build import bulk
+
+    return bulk("Si", "diamond", a=5.43, cubic=True) * (2, 2, 3)
+
+
+def _exit_waves(n_configs):
+    """Exit waves keep the frozen-phonon axis: n_configs independent dask blocks."""
+    frozen_phonons = abtem.FrozenPhonons(_atoms(), num_configs=n_configs, sigmas=0.1, seed=1)
+    potential = abtem.Potential(frozen_phonons, sampling=0.1)
+    return abtem.PlaneWave(energy=100e3).multislice(potential)
+
+
+def _haadf(n_configs=4):
+    frozen_phonons = abtem.FrozenPhonons(_atoms(), num_configs=n_configs, sigmas=0.1, seed=1)
+    potential = abtem.Potential(frozen_phonons, sampling=0.1)
+    probe = abtem.Probe(energy=100e3, semiangle_cutoff=20)
+    scan = abtem.GridScan(start=(0, 0), end=(2.715, 2.715), sampling=0.3)
+    return probe.scan(potential, scan=scan, detectors=abtem.AnnularDetector(inner=40, outer=100))
+
+
+def _worker_gpu_pci():
+    """PCI address of a worker's pinned GPU (unique per physical device)."""
+    import cupy
+
+    p = cupy.cuda.runtime.getDeviceProperties(cupy.cuda.runtime.getDevice())
+    return (p["pciDomainID"], p["pciBusID"], p["pciDeviceID"])
+
+
+@pytest.fixture(scope="module")
+def cuda_client():
+    """One dask-cuda cluster spanning all GPUs, built via abTEM's ensure_cuda_cluster."""
+    from abtem.core import backend
+
+    backend._cuda_cluster_client = None
+    client = backend.ensure_cuda_cluster()
+    yield client
+    cluster = getattr(client, "cluster", None)
+    client.close()
+    if cluster is not None:
+        cluster.close()
+    backend._cuda_cluster_client = None
+
+
+# --------------------------------------------------------------------------
+# cluster properties
+# --------------------------------------------------------------------------
+
+
+def test_cluster_is_gpu_appropriate(cuda_client):
+    assert is_gpu_dask_client(cuda_client)
+    nthreads = cuda_client.nthreads()
+    assert len(nthreads) >= 2
+    assert all(t == 1 for t in nthreads.values())
+
+
+def test_workers_pinned_to_distinct_gpus(cuda_client):
+    pcis = cuda_client.run(_worker_gpu_pci)
+    assert len(set(pcis.values())) == len(cuda_client.nthreads())
+
+
+def test_ensure_cuda_cluster_is_memoized(cuda_client):
+    from abtem.core import backend
+
+    assert backend.ensure_cuda_cluster() is cuda_client
+    assert backend._cuda_cluster_client is cuda_client
+
+
+# --------------------------------------------------------------------------
+# distribution + correctness
+# --------------------------------------------------------------------------
+
+
+def test_gpu_compute_distributes_over_all_workers(cuda_client):
+    from distributed import get_task_stream
+
+    n = len(cuda_client.nthreads())
+    with abtem.config.set({"device": "gpu"}):
+        waves = _exit_waves(n_configs=2 * n)
+        with get_task_stream(cuda_client) as ts:
+            result = waves.compute(progress_bar=False)
+
+    arr = asnumpy(result.array)
+    assert arr.shape[0] == 2 * n
+    assert np.all(np.isfinite(arr.real)) and np.all(np.isfinite(arr.imag))
+
+    workers = {r.get("worker") for r in ts.data if isinstance(r, dict) and r.get("worker")}
+    assert len(workers) == n, f"work ran on {len(workers)}/{n} GPU workers"
+
+
+def test_haadf_image_independent_of_gpu_distribution(cuda_client):
+    """The HAADF image must be the same computed on one device or across all GPUs."""
+    with abtem.config.set({"device": "gpu"}):
+        # single device (synchronous scheduler bypasses the cluster)
+        reference = _haadf(n_configs=4).compute(progress_bar=False, scheduler="synchronous")
+        # distributed across every GPU via the active cluster
+        distributed_result = _haadf(n_configs=4).compute(progress_bar=False)
+
+    np.testing.assert_allclose(
+        asnumpy(distributed_result.array),
+        asnumpy(reference.array),
+        rtol=1e-4,
+        atol=1e-8,
+    )
+
+
+def test_automatic_multigpu_config_distributes(cuda_client):
+    """config['dask.multi-gpu'] with the active cluster still distributes correctly."""
+    from distributed import get_task_stream
+
+    n = len(cuda_client.nthreads())
+    with abtem.config.set({"device": "gpu", "dask.multi-gpu": True}):
+        waves = _exit_waves(n_configs=2 * n)
+        with get_task_stream(cuda_client) as ts:
+            waves.compute(progress_bar=False)
+
+    workers = {r.get("worker") for r in ts.data if isinstance(r, dict) and r.get("worker")}
+    assert len(workers) == n

--- a/test/test_multigpu_logic.py
+++ b/test/test_multigpu_logic.py
@@ -1,0 +1,208 @@
+"""Logic tests for abTEM's multi-GPU support that need no real multi-GPU hardware.
+
+Covers the client-suitability check, the memoized cluster lifecycle, and the
+scheduler-selection branches of ``_compute`` -- via mocks / a threaded CPU
+cluster -- so the behaviour is exercised on ordinary (single-GPU or CPU) CI.
+"""
+
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+import abtem
+import abtem.array
+from abtem.core import backend
+from abtem.core.backend import cp, is_gpu_dask_client
+
+
+# --------------------------------------------------------------------------
+# is_gpu_dask_client  (needs only distributed; no cupy / GPU)
+# --------------------------------------------------------------------------
+
+
+def test_is_gpu_dask_client_none():
+    assert is_gpu_dask_client(None) is False
+
+
+def test_is_gpu_dask_client_closed():
+    assert is_gpu_dask_client(mock.Mock(status="closed")) is False
+
+
+def test_is_gpu_dask_client_single_threaded_running():
+    client = mock.Mock(status="running")
+    client.nthreads.return_value = {"w1": 1, "w2": 1}
+    assert is_gpu_dask_client(client) is True
+
+
+def test_is_gpu_dask_client_rejects_multithreaded():
+    client = mock.Mock(status="running")
+    client.nthreads.return_value = {"w1": 2}
+    assert is_gpu_dask_client(client) is False
+
+
+def test_is_gpu_dask_client_rejects_empty():
+    client = mock.Mock(status="running")
+    client.nthreads.return_value = {}
+    assert is_gpu_dask_client(client) is False
+
+
+@pytest.mark.filterwarnings("ignore")
+def test_is_gpu_dask_client_rejects_real_cpu_cluster():
+    """A plain threaded LocalCluster (opened for the dashboard) is unsafe for CuPy."""
+    from distributed import Client, LocalCluster
+
+    with LocalCluster(
+        processes=False, n_workers=1, threads_per_worker=2, dashboard_address=":0"
+    ) as cluster:
+        with Client(cluster) as client:
+            assert is_gpu_dask_client(client) is False
+
+
+# --------------------------------------------------------------------------
+# ensure_cuda_cluster  (mocked dask_cuda; no GPU)
+# --------------------------------------------------------------------------
+
+
+def _fake_dask_cuda_module():
+    m = types.ModuleType("dask_cuda")
+    m.LocalCUDACluster = type("LocalCUDACluster", (), {})
+    return m
+
+
+def test_ensure_cuda_cluster_memoizes(monkeypatch):
+    monkeypatch.setattr(backend, "_cuda_cluster_client", None)
+    monkeypatch.setitem(sys.modules, "dask_cuda", _fake_dask_cuda_module())
+    created = []
+
+    def fake_client(cluster):
+        created.append(1)
+        return mock.Mock(status="running")
+
+    monkeypatch.setattr("distributed.Client", fake_client)
+
+    c1 = backend.ensure_cuda_cluster()
+    c2 = backend.ensure_cuda_cluster()
+    assert c1 is c2
+    assert len(created) == 1  # created once, then reused
+
+
+def test_ensure_cuda_cluster_recreates_when_dead(monkeypatch):
+    monkeypatch.setattr(backend, "_cuda_cluster_client", mock.Mock(status="closed"))
+    monkeypatch.setitem(sys.modules, "dask_cuda", _fake_dask_cuda_module())
+    created = []
+
+    def fake_client(cluster):
+        created.append(1)
+        return mock.Mock(status="running")
+
+    monkeypatch.setattr("distributed.Client", fake_client)
+
+    client = backend.ensure_cuda_cluster()
+    assert client.status == "running"
+    assert len(created) == 1  # stale/closed client discarded and rebuilt
+
+
+def test_ensure_cuda_cluster_requires_dask_cuda(monkeypatch):
+    monkeypatch.setattr(backend, "_cuda_cluster_client", None)
+    monkeypatch.setitem(sys.modules, "dask_cuda", None)  # force ImportError on import
+    with pytest.raises(RuntimeError, match="dask-cuda"):
+        backend.ensure_cuda_cluster()
+
+
+# --------------------------------------------------------------------------
+# _compute scheduler selection on the GPU path  (needs cupy to build gpu meta)
+# --------------------------------------------------------------------------
+
+
+def _no_client(*args, **kwargs):
+    raise ValueError("no global client")
+
+
+def _build_lazy_gpu():
+    return abtem.Probe(energy=100e3, semiangle_cutoff=20, gpts=32, extent=5).build(lazy=True)
+
+
+@pytest.mark.skipif(cp is None, reason="no gpu")
+@pytest.mark.filterwarnings("ignore")
+def test_gpu_no_client_forces_synchronous(monkeypatch):
+    import distributed
+
+    monkeypatch.setattr(distributed, "get_client", _no_client)
+    captured = {}
+
+    def fake_compute(*args, **kwargs):
+        captured.update(kwargs)
+        return ([None],)
+
+    monkeypatch.setattr(abtem.array.dask, "compute", fake_compute)
+    with abtem.config.set({"device": "gpu", "dask.multi-gpu": False}):
+        _build_lazy_gpu().compute(progress_bar=False)
+    assert captured.get("scheduler") == "synchronous"
+    # the removed dead kwargs must not reappear
+    assert "num_workers" not in captured and "threads_per_worker" not in captured
+
+
+@pytest.mark.skipif(cp is None, reason="no gpu")
+@pytest.mark.filterwarnings("ignore")
+def test_multigpu_config_starts_cluster(monkeypatch):
+    import distributed
+
+    monkeypatch.setattr(distributed, "get_client", _no_client)
+    started = []
+    monkeypatch.setattr(
+        abtem.array, "ensure_cuda_cluster",
+        lambda: (started.append(1), mock.Mock(status="running"))[1],
+    )
+    monkeypatch.setattr(abtem.array, "is_gpu_dask_client", lambda c: c is not None)
+    monkeypatch.setattr(abtem.array.cp.cuda.runtime, "getDeviceCount", lambda: 2)
+    monkeypatch.setattr(abtem.array.dask, "compute", lambda *a, **k: ([None],))
+
+    with abtem.config.set({"device": "gpu", "dask.multi-gpu": True}):
+        _build_lazy_gpu().compute(progress_bar=False)
+    assert started == [1]
+
+
+@pytest.mark.skipif(cp is None, reason="no gpu")
+@pytest.mark.filterwarnings("ignore")
+def test_single_gpu_multigpu_config_no_cluster(monkeypatch):
+    import distributed
+
+    monkeypatch.setattr(distributed, "get_client", _no_client)
+    started = []
+    monkeypatch.setattr(abtem.array, "ensure_cuda_cluster", lambda: started.append(1))
+    monkeypatch.setattr(abtem.array.cp.cuda.runtime, "getDeviceCount", lambda: 1)
+    captured = {}
+
+    def fake_compute(*args, **kwargs):
+        captured.update(kwargs)
+        return ([None],)
+
+    monkeypatch.setattr(abtem.array.dask, "compute", fake_compute)
+    with abtem.config.set({"device": "gpu", "dask.multi-gpu": True}):
+        _build_lazy_gpu().compute(progress_bar=False)
+    assert started == []  # only one GPU -> no cluster
+    assert captured.get("scheduler") == "synchronous"
+
+
+@pytest.mark.skipif(cp is None, reason="no gpu")
+@pytest.mark.filterwarnings("ignore")
+def test_explicit_scheduler_skips_cluster(monkeypatch):
+    import distributed
+
+    monkeypatch.setattr(distributed, "get_client", _no_client)
+    started = []
+    monkeypatch.setattr(abtem.array, "ensure_cuda_cluster", lambda: started.append(1))
+    monkeypatch.setattr(abtem.array.cp.cuda.runtime, "getDeviceCount", lambda: 2)
+    captured = {}
+
+    def fake_compute(*args, **kwargs):
+        captured.update(kwargs)
+        return ([None],)
+
+    monkeypatch.setattr(abtem.array.dask, "compute", fake_compute)
+    with abtem.config.set({"device": "gpu", "dask.multi-gpu": True}):
+        _build_lazy_gpu().compute(progress_bar=False, scheduler="synchronous")
+    assert started == []  # user asked for a scheduler -> no cluster spun up
+    assert captured.get("scheduler") == "synchronous"

--- a/test/test_multigpu_logic.py
+++ b/test/test_multigpu_logic.py
@@ -67,7 +67,8 @@ def test_is_gpu_dask_client_rejects_real_cpu_cluster():
 
 def _fake_dask_cuda_module():
     m = types.ModuleType("dask_cuda")
-    m.LocalCUDACluster = type("LocalCUDACluster", (), {})
+    # ensure_cuda_cluster may pass memory_limit=..., so accept **kwargs
+    m.LocalCUDACluster = type("LocalCUDACluster", (), {"__init__": lambda self, **kw: None})
     return m
 
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -119,3 +119,29 @@ def assert_scanned_measurement_as_expected(
 
 
 gpu = pytest.param("gpu", marks=pytest.mark.skipif(cp is None, reason="no gpu"))
+
+
+def _gpu_count() -> int:
+    if cp is None:
+        return 0
+    try:
+        return cp.cuda.runtime.getDeviceCount()
+    except Exception:  # pragma: no cover -- driver/runtime hiccup
+        return 0
+
+
+try:
+    import dask_cuda as _dask_cuda  # noqa: F401
+
+    _HAS_DASK_CUDA = True
+except ImportError:
+    _HAS_DASK_CUDA = False
+
+
+# Skip marker for tests that genuinely need to distribute across GPUs: they
+# require both >=2 GPUs and dask-cuda (one worker process per GPU). Use together
+# with `pytest.mark.multigpu` so the suite can be selected with `-m multigpu`.
+requires_multigpu = pytest.mark.skipif(
+    _gpu_count() < 2 or not _HAS_DASK_CUDA,
+    reason="requires >=2 GPUs and dask-cuda",
+)


### PR DESCRIPTION
Hi!


This PR introduces fixes to the multi-GPU support in abTEM. Claude has implemented all of the changes and I have kept a watchful eye. Specifically this PR adds opt-in support for distributing a GPU calculation across **all GPUs on a
node**, using [dask-cuda](https://docs.rapids.ai/api/dask-cuda/stable/) (one worker process per GPU). Single-GPU behavior is unchanged; multi-GPU is entirely opt-in.

## Usage

Automatic — abTEM starts a dask-cuda cluster spanning every visible GPU:
```python
abtem.config.set({"device": "gpu", "dask.multi-gpu": True})

#continue with your abTEM script
```

Bring your own cluster (for RMM pools, UCX, a subset of GPUs) — abTEM detects and uses an active dask-cuda client:
```python
from dask_cuda import LocalCUDACluster
from distributed import Client
client = Client(LocalCUDACluster())
abtem.config.set({"device": "gpu"})

#continue with your abTEM script
```

## What's in it
1. New config flag `dask.multi-gpu` (default false) in `abtem/core/abtem.yaml`. 
2. _compute (array.py) now, on the GPU path, respects an active distributed client instead of always forcing the synchronous scheduler, and auto-starts a dask-cuda cluster when dask.multi-gpu is enabled (and there is >1 GPU, no active client, and no explicit scheduler=). Removes the dead num_workers/threads_per_worker kwargs.
3. backend.ensure_cuda_cluster() — memoizes a LocalCUDACluster client and rebuilds it if a previous one was shut down; clear error if dask-cuda is missing.
4. backend.is_gpu_dask_client() — only single-threaded, GPU-pinned clients (as produced by LocalCUDACluster) are used for CuPy; a plain multi-threaded LocalCluster (e.g. one opened for the dashboard) is not used and abTEM safely falls back to synchronous execution.
5. abtem[all] extra aggregating the optional runtime extras. (GPU packages are intentionally excluded — cupy/dask-cuda wheels are CUDA/RAPIDS-version specific and must match the local toolkit.)

## Testing
1. `test/test_multigpu_logic.py` — mock/CPU-cluster logic tests that run on ordinary CI: client-suitability, ensure_cuda_cluster memoization/liveness/ missing-dependency, and every scheduler-selection branch of _compute.
2. test/test_multigpu.py — real dask-cuda integration tests, marked multigpu and skipped unless there are ≥2 GPUs and dask-cuda (requires_multigpu): cluster is GPU-appropriate, workers pin to distinct GPUs, a compute distributes over all workers (explicit-client and dask.multi-gpu paths), and the HAADF image is invariant to the number of GPUs.
3. Validated on a 4×A40 node (SrTiO₃, 3600 atoms, frozen-phonon HAADF): near-linear scaling — 1/2/4 GPUs = 754.7 / 378.5 / 189.8 s (1.99× / 3.98×, 99% efficiency) — and the resulting image is bitwise identical regardless of GPU count (max relative deviation 0.0).

## Dependencies / caveats
dask-cuda is optional and user-installed (like cupy), matched to the local CUDA/RAPIDS version. Note the current dask-cuda pins a specific dask; on newer dask it may need a --no-deps install until a matching dask-cuda releases.
Speed-up requires the computation to split into ≥ N independent chunks (frozen phonons, scan positions, tilt series, PRISM); a single plane-wave multislice won't benefit.
Docs: abTEM/doc#19

🤖 Generated with [Claude Code](https://claude.com/claude-code)