### PR TITLE
Fix numba TypingError in quasi-dipole interpolation on some numba/numpy pairings

### DIFF
--- a/abtem/magnetism/iam.py
+++ b/abtem/magnetism/iam.py
@@ -265,8 +265,12 @@ def interpolate_quasi_dipole_field_projections(
     integral_limits,
     integral_sampling,
     tables,
+    B,
 ):
-    B = np.zeros((3, tables.shape[2], tables.shape[3]))
+    # B is a caller-allocated (3, tables.shape[2], tables.shape[3]) scratch
+    # buffer, fully overwritten every iteration below: some numba/numpy
+    # pairings fail to type numba's internal np.zeros -> np.empty lowering
+    # inside @njit, so it can't be allocated in here.
     for position, magnetic_moment in zip(positions, magnetic_moments):
         shifted_limits = slice_limits - position[2]
         i = np.argmin(np.abs(integral_limits - shifted_limits[0]))
@@ -314,8 +318,12 @@ def interpolate_quasi_dipole_vector_field_projections(
     integral_limits,
     integral_sampling,
     tables,
+    A,
 ):
-    A = np.zeros((3, tables.shape[2], tables.shape[3]))
+    # A is a caller-allocated (3, tables.shape[2], tables.shape[3]) scratch
+    # buffer, fully overwritten every iteration below: some numba/numpy
+    # pairings fail to type numba's internal np.zeros -> np.empty lowering
+    # inside @njit, so it can't be allocated in here.
     for position, magnetic_moment in zip(positions, magnetic_moments):
         shifted_limits = slice_limits - position[2]
         i = np.argmin(np.abs(integral_limits - shifted_limits[0]))
@@ -432,6 +440,7 @@ class QuasiDipoleProjections:
 
             integral_limits = self._slice_limits(symbol)
             tables = self.get_integral_table(symbol)
+            scratch = np.zeros((3, tables.shape[2], tables.shape[3]), dtype=tables.dtype)
 
             self._interpolation_func(
                 array,
@@ -442,6 +451,7 @@ class QuasiDipoleProjections:
                 integral_limits,
                 integral_sampling,
                 tables,
+                scratch,
             )
 
         return array


### PR DESCRIPTION
## Summary

`interpolate_quasi_dipole_field_projections` and `interpolate_quasi_dipole_vector_field_projections` (`abtem/magnetism/iam.py`) each allocate a local `(3, nx, ny)` scratch buffer with `np.zeros(...)` inside an `@jit(nopython=True)` function. On some numba/numpy pairings (confirmed: numba 0.64.0 + numpy 2.4.3) numba's internal `np.zeros -> np.empty` lowering fails to type-check inside nopython mode, even though the resulting shape is a clean `UniTuple`:

```
TypingError: No implementation of function Function(<built-in function zeros>) ...
Use of unsupported NumPy function 'numpy.empty' or unsupported use of the function.
```

The same numba version compiles `ndarray.copy()`-based allocation just fine elsewhere in the codebase (`finite_difference.py`'s Laplace stencil) — confirmed directly: in a failing traceback, the Laplace stencil (using `.copy()`) executed successfully immediately before the `np.zeros`-based code failed on the very next call.

## Fix

Sidesteps `np.zeros` entirely instead of chasing the exact numba/numpy version boundary where it breaks: `QuasiDipoleProjections.integrate_on_grid` now allocates the scratch buffer in plain Python (unaffected — the bug is specific to numba's *compiled* array-constructor lowering) before calling into the njit function, which now takes it as a parameter and only ever overwrites it in place. No array constructor is called inside compiled code at all.

## How this was found

Surfaced by #330 (`noncollinear-pauli`)'s new `test_iam_noncollinear_smoke`, the first test to exercise `interpolate_quasi_dipole_vector_field_projections` on a GPU workstation running numba 0.64.0 + numpy 2.4.3. The sibling scalar-field function (`interpolate_quasi_dipole_field_projections`, used by `MagneticField`) has the identical pattern and is fixed the same way, even though no currently-failing test happened to reach it first.

This file is unmodified by `noncollinear-pauli` relative to `dev` — the bug is pre-existing on `dev`, just not previously exercised by any test on that environment.

## Test plan

- [x] `pytest test/test_pauli_multislice.py::test_iam_noncollinear_smoke` passes on `noncollinear-pauli` with this same patch applied there
- [x] No behavior change: the scratch buffer is fully overwritten every atom-loop iteration either way, so allocation location doesn't affect output
- [x] Confirmed pre-existing/unrelated `test_gpaw.py` failures on this machine are unchanged with vs. without this patch (`git stash` before/after comparison)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
