### PR TITLE
Add BiP-PRISM beam partitioning to PRISM-EELS

### DIFF
--- a/abtem/inelastic/core_loss.py
+++ b/abtem/inelastic/core_loss.py
@@ -2068,6 +2068,7 @@ def prism_transition_potential_scan_beam_basis(
             )
 
     # --- Main loop ---
+    warned_empty_mask = False
     for slice_index, transmission in enumerate(transmissions):
         s_waves = _step(s_waves, transmission)
 
@@ -2119,6 +2120,44 @@ def prism_transition_potential_scan_beam_basis(
             site_xy = np.array(
                 [atom.position[0], atom.position[1]], dtype=np.float32
             )
+
+            # Which scan positions fall inside this atom's PRISM window
+            # (only depends on site_xy, not on any of the S1/S2 reconstruction
+            # below) -- compute and check it FIRST so a scan too coarse for
+            # this atom (no position lands inside its window, so it would
+            # contribute exactly zero) skips the reconstruction work entirely
+            # instead of building empty-batch arrays that some backends (e.g.
+            # CuPy's FFT) reject.
+            mask = xp.ones(n_positions, dtype=bool)
+            if interpolation[0] > 1:
+                mask &= (
+                    xp.abs(positions[:, 0] - site_xy[0])
+                    % (extent[0] - prism_region[0])
+                ) <= prism_region[0]
+            if interpolation[1] > 1:
+                mask &= (
+                    xp.abs(positions[:, 1] - site_xy[1])
+                    % (extent[1] - prism_region[1])
+                ) <= prism_region[1]
+
+            if not bool(mask.any()):
+                if not warned_empty_mask:
+                    warnings.warn(
+                        "PRISM-EELS beam-basis: at least one ionization site "
+                        "has no scan position within its PRISM window "
+                        "(extent / interpolation, cropped to half that per "
+                        "axis) -- the scan is too coarse relative to "
+                        "`interpolation` for that site to contribute "
+                        "anything. Such sites are skipped (equivalent to a "
+                        "zero contribution); use a denser scan or lower "
+                        "`interpolation` if this is unintended.",
+                        stacklevel=2,
+                    )
+                    warned_empty_mask = True
+                continue
+
+            coeff_masked = coefficients[mask]  # (n_masked, n_k)
+
             site_pixel = site_xy / full_sampling_arr
             site_pixel_int = np.rint(site_pixel).astype(int)
             crop_corner = (
@@ -2167,20 +2206,6 @@ def prism_transition_potential_scan_beam_basis(
             else:
                 s1_crop = wrapped_crop_2d(s_waves.array, crop_corner, window_gpts)
             HS1 = H_crop[:, None] * s1_crop[None, :]  # (n_T, n_k, wh, ww)
-
-            mask = xp.ones(n_positions, dtype=bool)
-            if interpolation[0] > 1:
-                mask &= (
-                    xp.abs(positions[:, 0] - site_xy[0])
-                    % (extent[0] - prism_region[0])
-                ) <= prism_region[0]
-            if interpolation[1] > 1:
-                mask &= (
-                    xp.abs(positions[:, 1] - site_xy[1])
-                    % (extent[1] - prism_region[1])
-                ) <= prism_region[1]
-
-            coeff_masked = coefficients[mask]  # (n_masked, n_k)
 
             if double_channel:
                 if partitions_s2 is not None:

--- a/abtem/inelastic/core_loss.py
+++ b/abtem/inelastic/core_loss.py
@@ -1701,6 +1701,12 @@ def prism_transition_potential_scan_beam_basis(
     sites=None,
     double_channel: bool = True,
     inelastic_crop: float | tuple[float, float] | None = None,
+    partitions_s1: int | None = None,
+    partitions_s2: int | None = None,
+    n_angular: int = 6,
+    mag_preserve: bool = True,
+    collection_angle: float | None = None,
+    focal_backprop: str | float | None = None,
 ):
     """PRISM-EELS beam-basis reduction (Brown et al. Sec. IV B / Eq. dropped
     in supplementary; ``PRISM_double_channeling_nanoparticle.m``) — the
@@ -1783,6 +1789,41 @@ def prism_transition_potential_scan_beam_basis(
         (``extent / interpolation``) with a warning if larger — see
         Limitations above. If ``None`` (default), the PRISM cell is used,
         matching the real-space driver's default window.
+    partitions_s1, partitions_s2 : int or None, optional
+        Enable **BiP-PRISM** beam partitioning (paper Alg. 5). When set, ``S1``
+        (aperture beams) and/or ``S2`` (detector/reciprocal-grid beams) are built
+        on a sparse hex-ring **parent** set with ``partitions_*`` radial rings
+        (``n_radial`` in the paper) and reconstructed locally at each ionized atom
+        by windowed natural-neighbor interpolation. ``None`` (default) builds the
+        full (unpartitioned) matrices — the exact beam-basis path. The
+        full-parent limit is exact (paper eq-part-exact); at finite parent counts
+        the on-atom reconstruction error governs the total error (locality result).
+    n_angular : int, optional
+        Base azimuthal parent sampling; hex ring ``i`` carries ``n_angular*(1+i)``
+        samples (default 6). Shared by the ``S1`` and ``S2`` partitions.
+    mag_preserve : bool, optional
+        Apply the magnitude-preserving reconstruction (paper eq-magpreserve,
+        default ``True``) that counters the amplitude loss of the convex complex
+        average — required for quantitatively correct absolute map intensity.
+    collection_angle : float or None, optional
+        S2 detector-collection semiangle [mrad]. When set, ``S2`` is built only on
+        the reciprocal-grid beams inside ``|k| <= collection_angle/1e3/lambda`` (the
+        detector disk) instead of the full native grid — the BiP-PRISM map regime
+        (paper Alg. 5). This leaves the detector-integrated map unchanged as long as
+        the disk covers the detector's outer angle (the beam-basis reduction already
+        computes ``I = sum_q |a_q|^2``), while making ``partitions_s2`` far more
+        accurate at low parent counts (the S2 columns are smooth over the small
+        disk) and cheaper to build. ``None`` (default) uses the full grid.
+    focal_backprop : {"centroid"}, float or None, optional
+        S1-only accuracy lever (paper Sec. 3.3.6, "Fix 2"). When set, the S1 parent
+        columns are Fresnel back-propagated to the scattering-centroid plane before
+        the windowed NNW interpolation and forward-propagated back afterwards — the
+        de-tilted parents recohere best there, so the convex average decoheres least
+        and the on-atom probe reconstruction error drops (2-3x for thick specimens).
+        ``"centroid"`` back-propagates half the traversed depth; a float ``f`` uses
+        ``f * depth``. Applies only to ``partitions_s1`` (the detector-side ``S2``
+        parents have no crossover plane, so it is a no-op for them). ``None``
+        (default) disables it.
 
     Returns
     -------
@@ -1796,7 +1837,16 @@ def prism_transition_potential_scan_beam_basis(
         allocate_multislice_measurements,
         conventional_multislice_step,
     )
-    from abtem.prism.utils import wrapped_crop_2d
+    from abtem.multislice import _fresnel_propagator_array
+    from abtem.prism._bipartite import (
+        focal_backprop_distance,
+        fresnel_margin,
+        natural_neighbor_weights,
+        pad_window,
+        select_parent_beams,
+        windowed_reconstruct,
+    )
+    from abtem.prism.utils import plane_waves, wrapped_crop_2d
     from abtem.waves import Waves
 
     ctx = _prism_eels_common_setup(
@@ -1893,6 +1943,73 @@ def prism_transition_potential_scan_beam_basis(
             min(window_gpts[1], cell_gpts[1]),
         )
 
+    # --- Beam partitioning setup (BiP-PRISM, paper Alg. 5) ---------------------
+    # Build S1 / S2 on sparse hex-ring parent beams and reconstruct the full beam
+    # set locally at each atom (windowed NNW). ``None`` = exact unpartitioned path.
+    wave_vectors_np = ctx.wave_vectors_np  # (n_k, 2) aperture beams [1/Å]
+    w1 = k_par1 = None
+    if partitions_s1 is not None:
+        p1_idx = select_parent_beams(wave_vectors_np, partitions_s1, n_angular)
+        k_par1 = wave_vectors_np[p1_idx]
+        w1 = natural_neighbor_weights(k_par1, wave_vectors_np)  # (n_k, Bp1)
+        s1_par_array = plane_waves(
+            xp.asarray(k_par1, dtype=np.float32), extent, gpts
+        ) * (np.prod(interpolation) / np.prod(gpts))
+        s_waves = Waves(
+            s1_par_array,
+            energy=energy,
+            extent=extent,
+            ensemble_axes_metadata=[OrdinalAxis(values=tuple(range(len(p1_idx))))],
+        )
+
+    # Focal back-propagation (S1 only, paper Sec. 3.3.6): static prep. The per-slice
+    # back-propagation distance (centroid = half the traversed depth) is computed in
+    # the loop from the cumulative slice thickness.
+    do_focal_s1 = partitions_s1 is not None and bool(focal_backprop)
+    if do_focal_s1:
+        from abtem.core.energy import energy2wavelength
+
+        fb_wavelength = energy2wavelength(energy)
+        fb_cumthick = np.cumsum(np.asarray(potential.slice_thickness, dtype=float))
+        # Max transverse carrier frequency of the re-tilted S1 columns = the
+        # aperture-disk radius (a conservative upper bound on the discrete beam
+        # frequencies), which sets the Fresnel lateral spread for the window margin.
+        fb_kmax = s_matrix.semiangle_cutoff / 1e3 / fb_wavelength
+
+    # S2 output-beam set: the detector-collection disk (BiP-PRISM map regime) when
+    # ``collection_angle`` is given, else the full native reciprocal grid (PR #289
+    # behaviour). Columns ``a_q`` are scattered back onto the grid before the
+    # detector integrates ``|a_q|^2``, so the map is unchanged when the disk covers
+    # the detector's outer angle. When ``partitions_s2`` is set, only the Bp2
+    # hex-ring parent beams of this set are built and the rest are reconstructed.
+    s2_rows = s2_cols = k_s2 = w2 = k_par2 = None
+    s2_build_rows = s2_build_cols = None
+    if double_channel:
+        from abtem.core.energy import energy2wavelength
+
+        fy = np.fft.fftfreq(gpts[0], d=full_sampling[0])
+        fx = np.fft.fftfreq(gpts[1], d=full_sampling[1])
+        KY, KX = np.meshgrid(fy, fx, indexing="ij")
+        if collection_angle is not None:
+            k_max = collection_angle / 1e3 / energy2wavelength(energy)
+            s2_mask = (KY**2 + KX**2) <= k_max**2
+        else:
+            s2_mask = np.ones(tuple(gpts), dtype=bool)
+        rows_nz, cols_nz = np.nonzero(s2_mask)  # row-major (C) order
+        s2_rows = rows_nz.astype(int)
+        s2_cols = cols_nz.astype(int)
+        k_s2 = np.stack([KY[s2_mask], KX[s2_mask]], axis=1)  # (n_s2, 2)
+        if partitions_s2 is not None:
+            p2_idx = select_parent_beams(k_s2, partitions_s2, n_angular)
+            k_par2 = k_s2[p2_idx]
+            w2 = natural_neighbor_weights(k_par2, k_s2)  # (n_s2, Bp2)
+            s2_build_rows = s2_rows[p2_idx]
+            s2_build_cols = s2_cols[p2_idx]
+        else:
+            s2_build_rows = s2_rows
+            s2_build_cols = s2_cols
+    n_s2 = 0 if s2_rows is None else len(s2_rows)
+
     # --- Allocate measurements (full scan shape; identical pattern to the
     # real-space driver, single exit plane). ---
     # Detection resolution: double-channel's q-basis is intrinsically the
@@ -1958,22 +2075,45 @@ def prism_transition_potential_scan_beam_basis(
         if len(sites_this_slice) == 0:
             continue
 
+        # S1 focal back-propagation: bring the parent columns to the scattering
+        # centroid plane once per slice (full grid, shared across atoms).
+        s1_bp = None
+        back_distance = 0.0
+        if do_focal_s1:
+            back_distance = focal_backprop_distance(
+                float(fb_cumthick[slice_index]), focal_backprop
+            )
+            if back_distance:
+                back_kernel = _fresnel_propagator_array(
+                    -back_distance, tuple(gpts), full_sampling, energy,
+                    s_matrix.device,
+                )
+                s1_bp = ifft2(fft2(s_waves.array) * back_kernel)  # (Bp1, *gpts)
+
         s2_full = None
         if double_channel:
-            # Build S2 over the FULL native reciprocal grid: reverse
-            # multislice (conjugate transmission, transposed propagate
-            # order) of every reciprocal-pixel delta function, batched.
-            delta_k = xp.eye(n_pix, dtype=complex_dtype).reshape((n_pix,) + tuple(gpts))
+            # Build S2 by reverse multislice (conjugate transmission, transposed
+            # propagate order) of reciprocal-pixel delta functions, over the S2
+            # build set: every beam of the S2 output set (full grid or detector
+            # disk) when unpartitioned, or only its Bp2 hex-ring parent beams when
+            # ``partitions_s2`` is set (the S2 build-cost / memory win).
+            n_build = len(s2_build_rows)
+            delta_k = xp.zeros((n_build,) + tuple(gpts), dtype=complex_dtype)
+            delta_k[
+                xp.arange(n_build),
+                xp.asarray(s2_build_rows),
+                xp.asarray(s2_build_cols),
+            ] = 1.0
             s2_array = ifft2(delta_k)
             s2_waves = Waves(
                 s2_array,
                 energy=energy,
                 extent=extent,
-                ensemble_axes_metadata=[OrdinalAxis(values=tuple(range(n_pix)))],
+                ensemble_axes_metadata=[OrdinalAxis(values=tuple(range(n_build)))],
             )
             for t in reversed(transmissions[slice_index + 1 :]):
                 s2_waves = _step(s2_waves, t, conjugate=True, transpose=True)
-            s2_full = s2_waves.array  # (n_pix, *gpts)
+            s2_full = s2_waves.array  # (n_build, *gpts): n_pix exact OR Bp2 parents
 
         for atom in sites_this_slice:
             site_xy = np.array(
@@ -1986,12 +2126,46 @@ def prism_transition_potential_scan_beam_basis(
                 int(site_pixel_int[1]) - window_gpts[1] // 2,
             )
 
+            # Un-wrapped window pixel indices (match wrapped_crop_2d ordering);
+            # phases are exactly gpts-periodic so the un-wrapped indices are valid.
+            iy = np.arange(crop_corner[0], crop_corner[0] + window_gpts[0])
+            ix = np.arange(crop_corner[1], crop_corner[1] + window_gpts[1])
+
             shift_k = fft_shift_kernel(
                 xp.asarray(site_pixel.reshape(1, 2), dtype=np.float32), gpts
             )[0]
             H_full = ifft2(tp_k * shift_k)  # (n_T, *gpts), shifted to true site position
             H_crop = wrapped_crop_2d(H_full, crop_corner, window_gpts)
-            s1_crop = wrapped_crop_2d(s_waves.array, crop_corner, window_gpts)
+            if partitions_s1 is not None and s1_bp is not None:
+                # Focal back-prop path: reconstruct at the centroid plane on a
+                # window padded by the Fresnel reach, then forward-propagate the
+                # reconstruction to the ionization plane and crop to the window.
+                m = fresnel_margin(
+                    back_distance, fb_wavelength, fb_kmax, full_sampling, gpts
+                )
+                py, iny = pad_window(crop_corner[0], window_gpts[0], m, gpts[0])
+                px, inx = pad_window(crop_corner[1], window_gpts[1], m, gpts[1])
+                s1_par_pad = wrapped_crop_2d(
+                    s1_bp, (int(py[0]), int(px[0])), (len(py), len(px))
+                )
+                recon_pad = windowed_reconstruct(
+                    s1_par_pad, w1, k_par1, wave_vectors_np, py, px,
+                    extent, gpts, mag_preserve=mag_preserve,
+                )  # (n_k, Py, Px) at the centroid plane
+                fwd_kernel = _fresnel_propagator_array(
+                    back_distance, (len(py), len(px)), full_sampling, energy,
+                    s_matrix.device,
+                )
+                recon_pad = ifft2(fft2(recon_pad) * fwd_kernel)
+                s1_crop = recon_pad[:, iny][:, :, inx]  # (n_k, wh, ww)
+            elif partitions_s1 is not None:
+                s1_par_crop = wrapped_crop_2d(s_waves.array, crop_corner, window_gpts)
+                s1_crop = windowed_reconstruct(
+                    s1_par_crop, w1, k_par1, wave_vectors_np, iy, ix,
+                    extent, gpts, mag_preserve=mag_preserve,
+                )  # (n_k, wh, ww)
+            else:
+                s1_crop = wrapped_crop_2d(s_waves.array, crop_corner, window_gpts)
             HS1 = H_crop[:, None] * s1_crop[None, :]  # (n_T, n_k, wh, ww)
 
             mask = xp.ones(n_positions, dtype=bool)
@@ -2009,21 +2183,35 @@ def prism_transition_potential_scan_beam_basis(
             coeff_masked = coefficients[mask]  # (n_masked, n_k)
 
             if double_channel:
-                S2_crop = wrapped_crop_2d(s2_full, crop_corner, window_gpts)
-                S2_flat = S2_crop.conj().reshape(n_pix, -1)
-                recip_full = xp.stack(
+                if partitions_s2 is not None:
+                    s2_par_crop = wrapped_crop_2d(s2_full, crop_corner, window_gpts)
+                    S2_crop = windowed_reconstruct(
+                        s2_par_crop, w2, k_par2, k_s2, iy, ix,
+                        extent, gpts, mag_preserve=mag_preserve,
+                    )  # (n_s2, wh, ww)
+                else:
+                    S2_crop = wrapped_crop_2d(s2_full, crop_corner, window_gpts)
+                S2_flat = S2_crop.conj().reshape(n_s2, -1)  # (n_s2, W)
+                # a_q(rho) for the S2 output beams q: N * conj(S2) . H . S1, then
+                # combine over aperture beams k with the per-position coefficients.
+                a = xp.stack(
                     [
                         (
-                            n_pix
-                            * (S2_flat @ HS1[t].reshape(n_k, -1).T)  # (n_pix, n_k)
+                            n_pix  # N = prod(gpts), the FFT-pair normalisation
+                            * (S2_flat @ HS1[t].reshape(n_k, -1).T)  # (n_s2, n_k)
                         )
-                        @ coeff_masked.T  # (n_pix, n_masked)
+                        @ coeff_masked.T  # (n_s2, n_masked)
                         for t in range(n_T)
                     ]
-                )  # (n_T, n_pix, n_masked)
-                recip_full = xp.moveaxis(recip_full, -1, 1).reshape(
-                    (n_T, -1) + tuple(gpts)
-                )  # (n_T, n_masked, *gpts)
+                )  # (n_T, n_s2, n_masked)
+                # Scatter a_q onto the full reciprocal grid (zeros outside the S2
+                # set); the detector then integrates |a_q|^2 over its aperture.
+                recip_full = xp.zeros(
+                    (n_T, a.shape[-1]) + tuple(gpts), dtype=complex_dtype
+                )
+                recip_full[:, :, xp.asarray(s2_rows), xp.asarray(s2_cols)] = (
+                    xp.moveaxis(a, -1, 1)  # (n_T, n_masked, n_s2)
+                )
             else:
                 # Single channel: S2 is trivial -- FFT the windowed
                 # scattered field directly (no reverse multislice, and no

--- a/abtem/prism/_bipartite.py
+++ b/abtem/prism/_bipartite.py
@@ -191,7 +191,8 @@ def pad_window(corner, length, margin, n):
 
     Returns ``(padded_indices, inner_slice)`` where ``padded_indices`` are the
     un-wrapped pixel indices of the widened window and ``inner_slice`` selects the
-    original window within it: ``padded_indices[inner_slice] == corner + arange(length)``.
+    original window within it:
+    ``padded_indices[inner_slice] == corner + arange(length)``.
     The margin gives the windowed forward-Fresnel enough room that its periodic
     wrap-around stays outside the inner window (paper: ``_fb_margin``).
     """
@@ -217,7 +218,9 @@ def fresnel_margin(distance, wavelength, k_max, sampling, gpts):
 
 
 def _window_tilt(k, iy, ix, extent, gpts, sign, xp, cdtype):
-    """``exp(sign · 2πi k · r)`` on the window pixels ``(iy, ix)`` → ``(len(k), wy, wx)``.
+    """``exp(sign · 2πi k · r)`` on the window pixels ``(iy, ix)``.
+
+    Returns shape ``(len(k), wy, wx)``.
 
     Matches :func:`abtem.prism.utils.plane_waves`: ``r = (iy·extent0/gpts0,
     ix·extent1/gpts1)``. The window indices may be un-wrapped (negative or
@@ -225,12 +228,12 @@ def _window_tilt(k, iy, ix, extent, gpts, sign, xp, cdtype):
     integer for the PRISM beam grid, so this is consistent with the wrapped crop.
     """
     real_dtype = get_dtype(complex=False)
-    dy = np.float32(extent[0] / gpts[0])
-    dx = np.float32(extent[1] / gpts[1])
+    dy = real_dtype(extent[0] / gpts[0])
+    dx = real_dtype(extent[1] / gpts[1])
     x = xp.asarray(iy, dtype=real_dtype) * dy  # (wy,)
     y = xp.asarray(ix, dtype=real_dtype) * dx  # (wx,)
     k = xp.asarray(k, dtype=real_dtype)  # (M, 2)
-    phase = (sign * 2.0 * np.float32(np.pi)) * (
+    phase = real_dtype(sign * 2.0 * np.pi) * (
         k[:, 0, None, None] * x[None, :, None] + k[:, 1, None, None] * y[None, None, :]
     )
     return complex_exponential(phase).astype(cdtype)

--- a/abtem/prism/_bipartite.py
+++ b/abtem/prism/_bipartite.py
@@ -1,0 +1,296 @@
+"""Geometry and reconstruction helpers for BiP-PRISM core-loss EELS.
+
+BiP-PRISM (paper Alg. 5, "bi-partitioned PRISM") accelerates dual-scattering-matrix
+PRISM-EELS by building *both* the probe-forming matrix ``S1`` and the detector/exit
+matrix ``S2`` on a sparse set of **parent beams** (a hex-ring subsample of the beam
+set), then reconstructing the full beam set *locally at each ionized atom* by
+**natural-neighbor interpolation** of the de-tilted parent columns, with an optional
+**magnitude-preserving** correction (paper eq-magpreserve) that counters the
+amplitude loss the convex complex average would otherwise introduce.
+
+This module holds the geometry-only, backend-agnostic pieces:
+
+- :func:`select_parent_beams` — hex-ring parent selection (indices into the beam set).
+- :func:`natural_neighbor_weights` — partition-of-unity interpolation weights
+  ``(n_query, n_parent)`` (vectorised Delaunay-barycentric by default; Sibson optional).
+- :func:`windowed_reconstruct` — per-atom windowed reconstruction (de-tilt → NNW
+  combine → magnitude-preserve → re-tilt), evaluated only on a crop window.
+
+These mirror the scatterem reference (``_select_parent_beams``,
+``natural_neighbor_weights``, ``PartitionedScatteringMatrix._nnw_window``) but are
+expressed in abTEM's ``plane_waves`` phase convention:
+``column_b(r) = exp(+2πi k_b · r)`` with ``r`` in Å.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.spatial import Delaunay
+
+from abtem.core.backend import get_array_module
+from abtem.core.complex import complex_exponential
+from abtem.core.utils import get_dtype
+
+
+def _to_numpy(array) -> np.ndarray:
+    if hasattr(array, "get"):  # cupy
+        array = array.get()
+    return np.asarray(array)
+
+
+def select_parent_beams(
+    wave_vectors, n_radial: int, n_angular: int = 6
+) -> np.ndarray:
+    """Hex-ring parent-beam selection (port of scatterem ``_select_parent_beams``).
+
+    Samples the beam set on the DC beam plus ``n_radial`` concentric hex rings
+    (ring ``i`` carries ``n_angular * (1 + i)`` angular samples, rotated by
+    ``i·π/n_angular``), snaps each sample to the nearest actual beam, and
+    de-duplicates. Because parents are *indices into* ``wave_vectors``, the
+    full-parent limit (parents = all beams) is exact.
+
+    Parameters
+    ----------
+    wave_vectors : (N, 2) array_like
+        Beam coordinates (any consistent units; only their geometry matters).
+    n_radial : int
+        Number of concentric parent rings (radial resolution). ``>= 1``.
+    n_angular : int, optional
+        Base azimuthal sampling; ring ``i`` gets ``n_angular * (1 + i)`` samples.
+
+    Returns
+    -------
+    parent_indices : (Bp,) int ndarray
+        Sorted, unique indices into ``wave_vectors``.
+    """
+    wv = _to_numpy(wave_vectors).astype(np.float64)
+    if n_radial < 1:
+        raise ValueError("n_radial must be >= 1")
+
+    radius = float(np.linalg.norm(wv, axis=1).max())
+    a_off = np.pi / n_angular
+    samples = [[0.0, 0.0]]
+    for i, r in enumerate(np.linspace(0.0, radius, n_radial + 1)[1:]):
+        n_ang = n_angular * (1 + i)
+        for a in np.linspace(-np.pi, np.pi, n_ang, endpoint=False):
+            samples.append([r * np.sin(a + a_off * i), r * np.cos(a + a_off * i)])
+    samples = np.asarray(samples, dtype=np.float64)
+
+    d = np.linalg.norm(samples[:, None, :] - wv[None, :, :], axis=2)
+    return np.unique(np.argmin(d, axis=1))
+
+
+def _linear_barycentric_weights(
+    parents: np.ndarray, queries: np.ndarray, minimum_weight_cutoff: float = 1e-2
+) -> np.ndarray:
+    """Vectorised piecewise-linear (Delaunay barycentric) weights ``(B, Bp)``.
+
+    Each query's weights are the barycentric coordinates of the Delaunay triangle
+    it falls in (3 parents); queries outside the convex hull fall back to the
+    nearest parent (weight 1). Partition of unity, exact at parents. Port of
+    scatterem ``_linear_barycentric_weights``.
+    """
+    known = np.asarray(parents, dtype=float)
+    interp = np.asarray(queries, dtype=float)
+    B, Bs = interp.shape[0], known.shape[0]
+    weights = np.zeros((B, Bs))
+
+    def _nearest_all():
+        d = np.linalg.norm(known[None, :, :] - interp[:, None, :], axis=2)
+        weights[np.arange(B), d.argmin(axis=1)] = 1.0
+        return weights
+
+    if Bs < 3:
+        return _nearest_all()
+    try:
+        tri = Delaunay(known)
+    except Exception:
+        return _nearest_all()
+
+    simplex = tri.find_simplex(interp)  # (B,), -1 outside the convex hull
+    inside = simplex >= 0
+    if inside.any():
+        sx = simplex[inside]
+        transform = tri.transform[sx]  # (Bin, 3, 2)
+        r = interp[inside] - transform[:, 2, :]
+        bary2 = np.einsum("bij,bj->bi", transform[:, :2, :], r)
+        bary = np.concatenate([bary2, 1.0 - bary2.sum(1, keepdims=True)], axis=1)
+        verts = tri.simplices[sx]  # (Bin, 3)
+        rows = np.repeat(np.nonzero(inside)[0], 3)
+        weights[rows, verts.reshape(-1)] = bary.reshape(-1)
+    out = np.nonzero(~inside)[0]
+    if out.size:
+        d = np.linalg.norm(known[None, :, :] - interp[out][:, None, :], axis=2)
+        weights[out, d.argmin(axis=1)] = 1.0
+
+    weights[weights < minimum_weight_cutoff] = 0.0
+    row_sum = weights.sum(axis=1, keepdims=True)
+    row_sum[row_sum == 0] = 1.0
+    return weights / row_sum
+
+
+def natural_neighbor_weights(
+    parents,
+    queries,
+    method: str = "linear",
+    minimum_weight_cutoff: float = 1e-2,
+) -> np.ndarray:
+    """Interpolation weights expressing each query beam as a convex blend of parents.
+
+    Parameters
+    ----------
+    parents : (Bp, 2) array_like
+        Parent-beam coordinates.
+    queries : (B, 2) array_like
+        Query (target) beam coordinates.
+    method : {"linear"}
+        Only ``"linear"`` is supported: vectorised Delaunay-barycentric weights
+        (C0, fully vectorised, nearest-fallback outside the convex hull) — this is
+        the scatterem reference default and is "adequate for the smooth
+        probe-reconstruction use in partitioned PRISM" (paper). abTEM's Sibson
+        weights (:func:`abtem.prism._natural_neighbors.pairwise_weights`) are C1
+        but raise ``QhullError`` on degenerate circumcenter polygons, so they are
+        not exposed here.
+
+    Returns
+    -------
+    weights : (B, Bp) ndarray
+        ``weights[b, p]`` = weight of parent ``p`` in reconstructing query ``b``.
+        Rows are a partition of unity; a query coinciding with a parent is one-hot.
+    """
+    parents = _to_numpy(parents).astype(np.float64)
+    queries = _to_numpy(queries).astype(np.float64)
+
+    if method == "linear":
+        return _linear_barycentric_weights(parents, queries, minimum_weight_cutoff)
+    raise ValueError(f"unknown method {method!r} (only 'linear' is supported)")
+
+
+def focal_backprop_distance(traversed_depth, focal_backprop):
+    """Back-propagation distance [Å] before NNW interpolation (paper Sec. 3.3.6).
+
+    ``focal_backprop`` = ``"centroid"`` -> half the traversed depth (the scattering
+    centroid of the entrance-to-plane path, where the de-tilted parent envelopes
+    are most coherent so the convex NNW average decoheres least); a float ``f`` ->
+    ``f * traversed_depth``; ``None``/``0`` -> ``0.0`` (no back-propagation).
+    """
+    if not focal_backprop:
+        return 0.0
+    if isinstance(focal_backprop, str):
+        if focal_backprop != "centroid":
+            raise ValueError(
+                f"focal_backprop str must be 'centroid', got {focal_backprop!r}"
+            )
+        return 0.5 * float(traversed_depth)
+    return float(focal_backprop) * float(traversed_depth)
+
+
+def pad_window(corner, length, margin, n):
+    """Pad a length-``length`` window starting at ``corner`` by ``margin`` on each
+    side (capped to the full axis ``n``).
+
+    Returns ``(padded_indices, inner_slice)`` where ``padded_indices`` are the
+    un-wrapped pixel indices of the widened window and ``inner_slice`` selects the
+    original window within it: ``padded_indices[inner_slice] == corner + arange(length)``.
+    The margin gives the windowed forward-Fresnel enough room that its periodic
+    wrap-around stays outside the inner window (paper: ``_fb_margin``).
+    """
+    length = int(length)
+    lp = min(length + 2 * int(margin), int(n))
+    left = (lp - length) // 2
+    padded = (int(corner) - left) + np.arange(lp)
+    return padded, slice(left, left + length)
+
+
+def fresnel_margin(distance, wavelength, k_max, sampling, gpts):
+    """Window padding [px] covering the Fresnel lateral spread of a propagation by
+    ``distance`` [Å] for transverse frequencies up to ``k_max`` [1/Å].
+
+    ``spread ~ distance * lambda * k_max`` in Å -> ``/dx`` in pixels; padded by 1.5x
+    plus a small constant, capped at half the grid (paper: ``_fb_margin``).
+    """
+    if not distance:
+        return 0
+    dx = min(sampling)
+    spread_px = abs(distance) * wavelength * k_max / dx
+    return int(min(max(4, np.ceil(1.5 * spread_px) + 2), min(gpts) // 2))
+
+
+def _window_tilt(k, iy, ix, extent, gpts, sign, xp, cdtype):
+    """``exp(sign · 2πi k · r)`` on the window pixels ``(iy, ix)`` → ``(len(k), wy, wx)``.
+
+    Matches :func:`abtem.prism.utils.plane_waves`: ``r = (iy·extent0/gpts0,
+    ix·extent1/gpts1)``. The window indices may be un-wrapped (negative or
+    ``>= gpts``); the phase is exactly ``gpts``-periodic because ``k · extent`` is
+    integer for the PRISM beam grid, so this is consistent with the wrapped crop.
+    """
+    real_dtype = get_dtype(complex=False)
+    dy = np.float32(extent[0] / gpts[0])
+    dx = np.float32(extent[1] / gpts[1])
+    x = xp.asarray(iy, dtype=real_dtype) * dy  # (wy,)
+    y = xp.asarray(ix, dtype=real_dtype) * dx  # (wx,)
+    k = xp.asarray(k, dtype=real_dtype)  # (M, 2)
+    phase = (sign * 2.0 * np.float32(np.pi)) * (
+        k[:, 0, None, None] * x[None, :, None] + k[:, 1, None, None] * y[None, None, :]
+    )
+    return complex_exponential(phase).astype(cdtype)
+
+
+def windowed_reconstruct(
+    parent_cols,
+    weights,
+    k_parents,
+    k_targets,
+    iy,
+    ix,
+    extent,
+    gpts,
+    mag_preserve: bool = True,
+):
+    """Reconstruct the target beam columns on a crop window from the parent columns.
+
+    Implements paper eq-window-recon (+ eq-magpreserve): de-tilt each parent column
+    by its own carrier ``exp(-2πi k_p · r)``, natural-neighbor combine to the target
+    beams, optionally restore the interpolated magnitude, and re-tilt each target by
+    its carrier ``exp(+2πi k_b · r)`` — all evaluated only on the window.
+
+    Parameters
+    ----------
+    parent_cols : (Bp, wy, wx) array
+        Parent scattering-matrix columns cropped to the window (backend-native).
+    weights : (B, Bp) array_like
+        Natural-neighbor weights (from :func:`natural_neighbor_weights`).
+    k_parents : (Bp, 2) array_like
+        Parent-beam wave vectors (1/Å).
+    k_targets : (B, 2) array_like
+        Target-beam wave vectors (1/Å).
+    iy, ix : 1-D int array_like
+        Window pixel rows / columns (un-wrapped indices into the full grid).
+    extent, gpts : pair
+        Full-grid extent (Å) and gpts, for the phase-ramp real coordinates.
+    mag_preserve : bool, optional
+        Apply the magnitude-preserving correction (default ``True``).
+
+    Returns
+    -------
+    (B, wy, wx) array
+        Reconstructed target columns on the window, same backend/dtype as
+        ``parent_cols``.
+    """
+    xp = get_array_module(parent_cols)
+    cdtype = parent_cols.dtype
+    w = xp.asarray(_to_numpy(weights), dtype=cdtype)  # (B, Bp)
+
+    detilt = _window_tilt(k_parents, iy, ix, extent, gpts, -1.0, xp, cdtype)
+    Sd = parent_cols * detilt  # (Bp, wy, wx)
+
+    recon = xp.einsum("bp,pwv->bwv", w, Sd)  # (B, wy, wx)
+    if mag_preserve:
+        mag = xp.einsum("bp,pwv->bwv", w.real.astype(cdtype), xp.abs(Sd).astype(cdtype))
+        mag = mag.real
+        denom = xp.abs(recon)
+        denom = xp.where(denom > 1e-20, denom, xp.asarray(1e-20, dtype=denom.dtype))
+        recon = mag * (recon / denom)
+
+    tilt = _window_tilt(k_targets, iy, ix, extent, gpts, +1.0, xp, cdtype)
+    return recon * tilt

--- a/abtem/prism/s_matrix.py
+++ b/abtem/prism/s_matrix.py
@@ -1992,9 +1992,19 @@ class SMatrix(BaseSMatrix, Ensemble, CopyMixin, EqualityMixin):
     def _eager_transition_potential_scan(
         self, scan, detectors, transition_potentials, sites, double_channel,
         inelastic_crop=None,
+        reduction="real_space",
+        partitions_s1=None,
+        partitions_s2=None,
+        n_angular=6,
+        mag_preserve=True,
+        collection_angle=None,
+        focal_backprop=None,
         squeeze=True,
     ):
-        from abtem.inelastic.core_loss import prism_transition_potential_scan
+        from abtem.inelastic.core_loss import (
+            prism_transition_potential_scan,
+            prism_transition_potential_scan_beam_basis,
+        )
 
         extra_ensemble_axes_shape, extra_ensemble_axes_metadata = (
             self._build_ensemble_shape_metadata()
@@ -2011,12 +2021,9 @@ class SMatrix(BaseSMatrix, Ensemble, CopyMixin, EqualityMixin):
         else:
             measurements = None
 
-        num_blocks = 0
-        for i, _, s_matrix in self.generate_blocks(1):
-            s_matrix = s_matrix.item()
-
-            new_measurements = ensure_list(
-                prism_transition_potential_scan(
+        def _run_block(s_matrix):
+            if reduction in ("beam_basis", "bipartite"):
+                return prism_transition_potential_scan_beam_basis(
                     s_matrix=s_matrix,
                     transition_potentials=transition_potentials,
                     scan=scan,
@@ -2024,8 +2031,28 @@ class SMatrix(BaseSMatrix, Ensemble, CopyMixin, EqualityMixin):
                     sites=sites,
                     double_channel=double_channel,
                     inelastic_crop=inelastic_crop,
+                    partitions_s1=partitions_s1,
+                    partitions_s2=partitions_s2,
+                    n_angular=n_angular,
+                    mag_preserve=mag_preserve,
+                    collection_angle=collection_angle,
+                    focal_backprop=focal_backprop,
                 )
+            return prism_transition_potential_scan(
+                s_matrix=s_matrix,
+                transition_potentials=transition_potentials,
+                scan=scan,
+                detectors=detectors,
+                sites=sites,
+                double_channel=double_channel,
+                inelastic_crop=inelastic_crop,
             )
+
+        num_blocks = 0
+        for i, _, s_matrix in self.generate_blocks(1):
+            s_matrix = s_matrix.item()
+
+            new_measurements = ensure_list(_run_block(s_matrix))
 
             if measurements is None:
                 measurements = new_measurements
@@ -2053,6 +2080,13 @@ class SMatrix(BaseSMatrix, Ensemble, CopyMixin, EqualityMixin):
     def _lazy_transition_potential_scan(
         s_matrix, scan, detectors, transition_potentials, sites, double_channel,
         inelastic_crop=None,
+        reduction="real_space",
+        partitions_s1=None,
+        partitions_s2=None,
+        n_angular=6,
+        mag_preserve=True,
+        collection_angle=None,
+        focal_backprop=None,
     ):
         s_matrix = s_matrix.item()
         measurements = s_matrix._eager_transition_potential_scan(
@@ -2062,6 +2096,13 @@ class SMatrix(BaseSMatrix, Ensemble, CopyMixin, EqualityMixin):
             sites=sites,
             double_channel=double_channel,
             inelastic_crop=inelastic_crop,
+            reduction=reduction,
+            partitions_s1=partitions_s1,
+            partitions_s2=partitions_s2,
+            n_angular=n_angular,
+            mag_preserve=mag_preserve,
+            collection_angle=collection_angle,
+            focal_backprop=focal_backprop,
             squeeze=False,
         )
 
@@ -2078,6 +2119,13 @@ class SMatrix(BaseSMatrix, Ensemble, CopyMixin, EqualityMixin):
         double_channel: bool = False,
         inelastic_crop=None,
         lazy: bool = None,
+        reduction: str = "real_space",
+        partitions_s1: int | None = None,
+        partitions_s2: int | None = None,
+        n_angular: int = 6,
+        mag_preserve: bool = True,
+        collection_angle: float | None = None,
+        focal_backprop: str | float | None = None,
     ):
         """**Experimental** PRISM-based core-loss scan.
 
@@ -2121,6 +2169,38 @@ class SMatrix(BaseSMatrix, Ensemble, CopyMixin, EqualityMixin):
         lazy : bool, optional
             If True, create the measurements lazily using Dask; otherwise,
             compute eagerly. Defaults to the user configuration value.
+        reduction : {"real_space", "beam_basis", "bipartite"}, optional
+            Reduction backend. ``"real_space"`` (default) is the production
+            windowed real-space driver
+            (:func:`~abtem.inelastic.core_loss.prism_transition_potential_scan`).
+            ``"beam_basis"``/``"bipartite"`` use the dual-scattering-matrix
+            beam-basis driver
+            (:func:`~abtem.inelastic.core_loss.prism_transition_potential_scan_beam_basis`),
+            which supports **BiP-PRISM** beam partitioning. Any of
+            ``partitions_s1``, ``partitions_s2`` or ``collection_angle`` being set
+            auto-selects the beam-basis backend.
+        partitions_s1, partitions_s2 : int or None, optional
+            BiP-PRISM (paper Alg. 5) beam partitioning: build ``S1`` (aperture) and
+            ``S2`` (detector) on sparse hex-ring parent beams with this many radial
+            rings and reconstruct locally at each atom by windowed natural-neighbor
+            interpolation. ``None`` builds the full matrices. Requires the
+            beam-basis backend.
+        n_angular : int, optional
+            Base azimuthal parent sampling for the hex rings (default 6).
+        mag_preserve : bool, optional
+            Magnitude-preserving reconstruction (paper eq-magpreserve, default
+            ``True``) — needed for quantitative absolute intensities.
+        collection_angle : float or None, optional
+            ``S2`` detector-collection semiangle [mrad] limiting the ``S2`` beams to
+            the detector disk (BiP-PRISM map regime); leaves the detector-integrated
+            map unchanged while making ``partitions_s2`` accurate and cheap. Requires
+            the beam-basis backend.
+        focal_backprop : {"centroid"}, float or None, optional
+            S1-only accuracy lever (paper Sec. 3.3.6): back-propagate the ``S1``
+            parent columns to the scattering-centroid plane before windowed NNW
+            interpolation and forward-propagate afterwards, reducing the on-atom
+            probe reconstruction error for thick specimens. Requires ``partitions_s1``
+            and the beam-basis backend.
 
         Returns
         -------
@@ -2130,6 +2210,21 @@ class SMatrix(BaseSMatrix, Ensemble, CopyMixin, EqualityMixin):
         from abtem.inelastic.core_loss import (
             prism_transition_potential_scan,
         )
+
+        if reduction not in ("real_space", "beam_basis", "bipartite"):
+            raise ValueError(
+                f"unknown reduction {reduction!r} (use 'real_space', "
+                "'beam_basis' or 'bipartite')"
+            )
+        # Partition / collection kwargs only apply to the beam-basis backend;
+        # auto-select it so the user does not have to set both.
+        if reduction == "real_space" and (
+            partitions_s1 is not None
+            or partitions_s2 is not None
+            or collection_angle is not None
+            or focal_backprop is not None
+        ):
+            reduction = "beam_basis"
 
         if scan is None:
             scan = GridScan(
@@ -2150,6 +2245,13 @@ class SMatrix(BaseSMatrix, Ensemble, CopyMixin, EqualityMixin):
                 sites=sites,
                 double_channel=double_channel,
                 inelastic_crop=inelastic_crop,
+                reduction=reduction,
+                partitions_s1=partitions_s1,
+                partitions_s2=partitions_s2,
+                n_angular=n_angular,
+                mag_preserve=mag_preserve,
+                collection_angle=collection_angle,
+                focal_backprop=focal_backprop,
             )
             return _wrap_measurements(measurements)
 
@@ -2180,6 +2282,13 @@ class SMatrix(BaseSMatrix, Ensemble, CopyMixin, EqualityMixin):
             sites=sites,
             double_channel=double_channel,
             inelastic_crop=inelastic_crop,
+            reduction=reduction,
+            partitions_s1=partitions_s1,
+            partitions_s2=partitions_s2,
+            n_angular=n_angular,
+            mag_preserve=mag_preserve,
+            collection_angle=collection_angle,
+            focal_backprop=focal_backprop,
             meta=np.array((), dtype=object),
         )
 

--- a/benchmarks/bench_bipprism_eels.py
+++ b/benchmarks/bench_bipprism_eels.py
@@ -1,0 +1,788 @@
+"""Benchmark: multislice vs PRISM-EELS (beam-basis) vs BiP-PRISM on SrTiO3.
+
+Four reduction backends for core-loss STEM-EELS, all detected through the
+SAME fixed-angle annular detector so timings/memory are directly comparable:
+
+  - multislice   : abtem.Probe.transition_potential_scan (ground truth)
+  - real_space   : SMatrix.transition_potential_scan(reduction="real_space")
+                   (the production windowed PRISM-EELS driver, PR #289 MVP)
+  - beam_basis   : SMatrix.transition_potential_scan(reduction="beam_basis")
+                   (exact dual-scattering-matrix reduction, GitHub #293 --
+                   what the abTEM project calls "PRISM-EELS" in its beam-basis
+                   form; S2 is built over the *detector-collection disk*, not
+                   the full native grid, via ``collection_angle`` -- without
+                   that the O(gpts^2) full-grid S2 build is intractable)
+  - bipartite    : SMatrix.transition_potential_scan(reduction="bipartite")
+                   (BiP-PRISM, PR #334: S1 and S2 built on sparse hex-ring
+                   *parent* beams and reconstructed per-atom; ``partitions_s1``
+                   / ``partitions_s2`` control the parent count)
+
+Three sweeps (mirrors benchmarks/bench_prism_eels.py's style/infra):
+  1. Scan positions (fixed thickness, fixed cell)     -- amortisation of the
+     S-matrix build over many probe positions.
+  2. Specimen thickness (fixed scan, fixed cell)       -- per-slice cost.
+  3. Lateral cell size / field of view (fixed scan,     -- THE stress test for
+     fixed thickness, ``px_per_unit`` held constant so   BiP-PRISM: at fixed
+     real-space sampling doesn't change with cell size)  ``collection_angle``,
+                                                          the number of
+     reciprocal-grid pixels inside the detector disk grows with cell size
+     (denser k-sampling, dk = 1/extent) for BOTH real_space's window and
+     beam_basis's per-pixel reverse-multislice S2 build -- while BiP-PRISM's
+     parent count (``partitions_s2``) stays fixed by construction. This is
+     where BiP-PRISM's memory/time advantage over exact beam_basis should
+     show up most clearly.
+
+Peak memory: tracemalloc (CPU) or a CuPy MemoryHook (GPU), exactly as in
+bench_prism_eels.py. Every timed call is preceded by one untimed warm-up
+call (see ``_measure``) so CuPy kernel JIT/autotune on the first call of a
+new shape doesn't pollute the measurement -- at small problem sizes that
+one-time cost can dwarf the real compute and make a sweep look flat/noisy.
+
+Problem sizes (nz, scan grid, sc_values) are set for GPU-scale runs, not
+quick smoke tests -- sweep 2 reaches 256 slices (~1000 A) and sweep 3
+reaches sc=16 (512x512 gpts), both at a fixed 4096-position (64x64) scan --
+above the scan-position crossover sweep 1 shows, so PRISM's per-slice /
+per-cell-size behaviour isn't confounded by still being amortisation-bound.
+On CPU, or to iterate quickly, pass explicit smaller values to
+sweep_scan_positions/sweep_thickness/sweep_cell_size directly.
+
+Each variant is tracked independently within a sweep (see the ``alive``
+dict threaded through ``_run_all_variants``): once a variant fails at some
+size it's marked dead and skipped (recorded as NaN) for the rest of that
+sweep, while variants that haven't failed yet keep going to larger sizes.
+A sweep only stops once every variant has failed.
+
+Usage
+-----
+    python bench_bipprism_eels.py [device] [sc] [interp] \
+        [partitions_s1] [partitions_s2] [collection_angle]
+    python bench_bipprism_eels.py gpu 4 4 4 4 25.0
+
+Notes
+-----
+- ``beam_basis`` and ``bipartite`` require: single exit plane, no
+  frozen-phonon ensemble, ``downsample=False`` -- all satisfied by the
+  CrystalPotential setup below (repetitions only, no frozen phonons).
+- ``beam_basis`` without ``collection_angle`` builds S2 over the FULL native
+  grid (O(gpts^2) reverse-multislice propagations) -- this script always
+  passes ``collection_angle`` to keep it tractable, and uses a fixed-angle
+  ``AnnularDetector`` (not ``FlexibleAnnularDetector``) across ALL four
+  variants so they detect exactly the same physical quantity.
+- The cell-size sweep's top end (sc=16, gpts=512x512) is expected to push
+  ``real_space``/``beam_basis`` toward (or past) GPU memory limits before
+  ``bipartite`` -- that gap IS the result BiP-PRISM is for. A GPU OOM
+  there is caught by ``_run_one`` and recorded as NaN for that variant only
+  (see the per-variant ``alive`` tracking above); ``bipartite`` keeps
+  running past it. Trim ``sc_values`` in ``sweep_cell_size`` if it's taking
+  too long or OOMing earlier than you'd like to see.
+"""
+import gc
+import sys
+import time
+import tracemalloc
+
+import dask
+import matplotlib.pyplot as plt
+import numpy as np
+from ase import Atoms
+
+import abtem
+from abtem.core.axes import OrdinalAxis
+from abtem.inelastic.core_loss import TransitionPotentialArray, energy2sigma
+
+# timed_ms uses lazy=True + .compute() so Probe.build's max_batch chunking
+# actually kicks in (see timed_ms below); the default threaded scheduler would
+# run that computation on a worker thread the CuPy MemoryHook doesn't see,
+# silently reporting 0 MB for multislice. Force the synchronous scheduler
+# (same fix bench_prism_eels.py's sibling, prism_eels_cell_size.py, uses) so
+# .compute() runs in-thread where both the timer and the hook are active.
+dask.config.set(scheduler="synchronous")
+
+# abTEM defaults diagnostics.progress_bar to "tqdm" and prints one on every
+# .compute() (timed_ms) -- with many sweep points that interleaves garbage
+# into piped/redirected stdout. Disable both progress-bar mechanisms
+# (dask's, and the separate per-task one some multislice loops use).
+abtem.config.set(
+    {"diagnostics.progress_bar": False, "diagnostics.task_progress": False}
+)
+
+# ---------------------------------------------------------------------------
+# CLI arguments
+# ---------------------------------------------------------------------------
+device = sys.argv[1] if len(sys.argv) > 1 else "cpu"
+sc = int(sys.argv[2]) if len(sys.argv) > 2 else (4 if device == "gpu" else 2)
+interp = int(sys.argv[3]) if len(sys.argv) > 3 else (4 if device == "gpu" else 4)
+partitions_s1 = int(sys.argv[4]) if len(sys.argv) > 4 else 4
+partitions_s2 = int(sys.argv[5]) if len(sys.argv) > 5 else 4
+detector_outer = 20.0  # mrad, fixed physical detector across all variants
+collection_angle = (
+    float(sys.argv[6]) if len(sys.argv) > 6 else detector_outer + 5.0
+)
+
+# ---------------------------------------------------------------------------
+# GPU-specific helpers (conditional import) -- identical to bench_prism_eels.py
+# ---------------------------------------------------------------------------
+if device == "gpu":
+    import cupy as cp
+
+    _mempool = cp.get_default_memory_pool()
+    _pinned_pool = cp.get_default_pinned_memory_pool()
+
+    def _gpu_sync():
+        cp.cuda.Device().synchronize()
+
+    class _PeakMemoryHook(cp.cuda.MemoryHook):
+        def __init__(self, baseline):
+            self.peak = baseline
+
+        def malloc_postprocess(self, device_id, size, mem_size, mem_ptr, pmem_id):
+            used = _mempool.used_bytes()
+            if used > self.peak:
+                self.peak = used
+
+    def _measure_peak_gpu(func, *args, **kwargs):
+        _gpu_sync()
+        gc.collect()
+        _mempool.free_all_blocks()
+        _pinned_pool.free_all_blocks()
+        _gpu_sync()
+
+        baseline = _mempool.used_bytes()
+        hook = _PeakMemoryHook(baseline)
+        with hook:
+            t0 = time.perf_counter()
+            result = func(*args, **kwargs)
+            _gpu_sync()
+            elapsed = time.perf_counter() - t0
+
+        peak_mb = (hook.peak - baseline) / 1024**2
+        return result, elapsed, max(peak_mb, 0.0)
+
+
+def _measure(func, *args, **kwargs):
+    """Dispatch CPU (tracemalloc) vs GPU (CuPy hook) timing + peak memory.
+
+    Runs ``func`` once first and discards the result -- a cold first call
+    pays for CuPy kernel JIT/autotune and any lazy CUDA context setup, which
+    at small problem sizes can dwarf the actual compute and make timings
+    look flat/noisy across a sweep. The warm-up eats that cost once so the
+    timed call reflects steady-state performance.
+    """
+    func(*args, **kwargs)
+    if device == "gpu":
+        result, elapsed, peak = _measure_peak_gpu(func, *args, **kwargs)
+    else:
+        gc.collect()
+        tracemalloc.start()
+        t0 = time.perf_counter()
+        result = func(*args, **kwargs)
+        elapsed = time.perf_counter() - t0
+        _, peak_bytes = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peak = peak_bytes / 1024**2
+    return result, elapsed, peak
+
+
+# ---------------------------------------------------------------------------
+# SrTiO3 unit cell (perovskite, a = 3.905 A)
+# ---------------------------------------------------------------------------
+a = 3.905
+energy = 200e3
+semiangle_cutoff = 25.0
+px_per_unit = 32  # A/px held fixed as sc grows (divisible by interp 1,2,4,8,16,32)
+
+srtio3_unit = Atoms(
+    "SrTiO3",
+    positions=[
+        (0, 0, 0),
+        (a / 2, a / 2, a / 2),
+        (a / 2, a / 2, 0),
+        (a / 2, 0, a / 2),
+        (0, a / 2, a / 2),
+    ],
+    cell=[a, a, a],
+    pbc=True,
+)
+
+
+def make_potential_and_tp(nz, sc_local=None):
+    """Build CrystalPotential and synthetic Ti K-edge TransitionPotentialArray.
+
+    ``sc_local`` overrides the module-level ``sc`` (used by the cell-size
+    sweep); the per-axis grid is ``sc_local * px_per_unit`` so real-space
+    sampling (A/px) stays fixed as the cell grows -- this is what makes
+    reciprocal-space sampling (dk = 1/extent) get denser with cell size,
+    which is the regime BiP-PRISM's beam partitioning targets.
+    """
+    sc_local = sc if sc_local is None else sc_local
+    gpts_local = (sc_local * px_per_unit, sc_local * px_per_unit)
+    atoms = srtio3_unit * (sc_local, sc_local, nz)
+    pot_unit = abtem.Potential(
+        srtio3_unit, gpts=(px_per_unit, px_per_unit),
+        slice_thickness=a, device=device,
+    )
+    crystal_pot = abtem.CrystalPotential(
+        potential_unit=pot_unit, repetitions=(sc_local, sc_local, nz)
+    )
+    extent = crystal_pot.extent
+    rng = np.random.default_rng(42)
+    sampling = (extent[0] / gpts_local[0], extent[1] / gpts_local[1])
+    y = np.arange(gpts_local[0], dtype=np.float32) * sampling[0]
+    x = np.arange(gpts_local[1], dtype=np.float32) * sampling[1]
+    yy, xx = np.meshgrid(y, x, indexing="ij")
+    gauss = np.exp(-(xx**2 + yy**2) / (2 * 0.5**2)).astype(np.float32)
+    raw = (
+        rng.standard_normal((2, *gpts_local))
+        + 1j * rng.standard_normal((2, *gpts_local))
+    ).astype(np.complex64)
+    tp_array = np.fft.fft2(raw * gauss[None]) / energy2sigma(energy)
+    tp = TransitionPotentialArray(
+        Z=22,
+        array=tp_array.astype(np.complex64),
+        energy=energy,
+        extent=extent,
+        ensemble_axes_metadata=[OrdinalAxis(values=(0, 1))],
+        metadata={"Z": 22, "n": 1, "l": 0},
+    )
+    return crystal_pot, tp, atoms
+
+
+# ---------------------------------------------------------------------------
+# Per-variant run wrappers -- all share the SAME fixed-angle AnnularDetector
+# ---------------------------------------------------------------------------
+VARIANTS = ["multislice", "real_space", "beam_basis", "bipartite"]
+COLORS = {"multislice": "k", "real_space": "C0", "beam_basis": "C1", "bipartite": "C2"}
+LABELS = {
+    "multislice": "Multislice",
+    "real_space": "PRISM (real_space)",
+    "beam_basis": "PRISM-EELS (beam_basis)",
+    "bipartite": f"BiP-PRISM (s1={partitions_s1}, s2={partitions_s2})",
+}
+
+
+def _detector():
+    return abtem.AnnularDetector(inner=0, outer=detector_outer)
+
+
+def timed_ms(probe, potential, tp, scan, atoms, double_channel):
+    def _run():
+        # lazy=True (not False): Probe.build's eager path
+        # (WavesBuilder._build_validated) computes the ENTIRE scan as one
+        # array/kernel call regardless of `max_batch`, ignoring it entirely
+        # -- only the lazy=True path actually dask-chunks the scan by
+        # `max_batch` (from config['dask.chunk-size-gpu']). At large scan
+        # counts the unchunked eager path is both unrepresentative of real
+        # usage and, on some GPUs, can trigger a CUDA illegal-address crash
+        # from a single oversized batched kernel launch.
+        return probe.transition_potential_scan(
+            potential=potential,
+            transition_potentials=tp,
+            scan=scan,
+            detectors=_detector(),
+            sites=atoms,
+            double_channel=double_channel,
+            lazy=True,
+        ).compute()
+
+    _, elapsed, peak = _measure(_run)
+    return elapsed, peak
+
+
+# The three SMatrix.transition_potential_scan variants below stay lazy=False
+# deliberately, unlike timed_ms above: SMatrix's lazy=True path (see
+# transition_potential_scan in abtem/prism/s_matrix.py) only dask-chunks
+# over ensemble blocks (frozen-phonon/potential configs) -- for our
+# single-configuration CrystalPotential that's one block, i.e. no
+# chunking at all. The scan dimension is appended to `chunks` unsplit
+# (`chunks += scan.shape`), so lazy=True would still build the full scan
+# in one call here; it isn't a mitigation for this reduction family the
+# way it is for Probe.transition_potential_scan.
+def timed_real_space(S, tp, scan, atoms, double_channel):
+    def _run():
+        return S.transition_potential_scan(
+            tp,
+            scan=scan,
+            detectors=_detector(),
+            sites=atoms,
+            double_channel=double_channel,
+            reduction="real_space",
+            lazy=False,
+        )
+
+    _, elapsed, peak = _measure(_run)
+    return elapsed, peak
+
+
+def timed_beam_basis(S, tp, scan, atoms, double_channel):
+    def _run():
+        return S.transition_potential_scan(
+            tp,
+            scan=scan,
+            detectors=_detector(),
+            sites=atoms,
+            double_channel=double_channel,
+            reduction="beam_basis",
+            collection_angle=collection_angle,
+            lazy=False,
+        )
+
+    _, elapsed, peak = _measure(_run)
+    return elapsed, peak
+
+
+def timed_bipartite(S, tp, scan, atoms, double_channel):
+    def _run():
+        return S.transition_potential_scan(
+            tp,
+            scan=scan,
+            detectors=_detector(),
+            sites=atoms,
+            double_channel=double_channel,
+            reduction="bipartite",
+            collection_angle=collection_angle,
+            partitions_s1=partitions_s1,
+            partitions_s2=partitions_s2,
+            lazy=False,
+        )
+
+    _, elapsed, peak = _measure(_run)
+    return elapsed, peak
+
+
+TIMED_FUNCS = {
+    "real_space": timed_real_space,
+    "beam_basis": timed_beam_basis,
+    "bipartite": timed_bipartite,
+}
+
+
+# ---------------------------------------------------------------------------
+# Sweeps
+# ---------------------------------------------------------------------------
+def _run_one(name, func, *args):
+    """Run one timed_* call; on failure, warn and return (nan, nan) so a
+    single bad config doesn't kill an otherwise-long unattended sweep.
+
+    Two known ways this can legitimately fail as problem sizes grow:
+    (1) if a scan grid is so sparse relative to ``interpolation`` that NO
+    scan position falls inside some atom's PRISM window, that atom's
+    per-position mask is all-False -- CPU/NumPy tolerates the resulting
+    zero-batch-size FFT, CuPy's GPU FFT does not (see the ``min_scan_n``
+    guard in ``sweep_scan_positions``, which avoids this; this is a
+    backstop for any other edge case). (2) ``real_space``/``beam_basis``
+    build S1/S2 over the full aperture/collection-disk beam set, so at
+    large cell sizes (sweep 3) they can genuinely exceed GPU memory --
+    that is the exact failure mode BiP-PRISM's partitioning is meant to
+    avoid, so seeing ``beam_basis`` OOM while ``bipartite`` keeps working
+    at the same cell size is an expected, informative result, not a bug.
+    """
+    try:
+        return func(*args)
+    except Exception as exc:  # noqa: BLE001 -- keep the sweep alive
+        msg = repr(exc)
+        print(f"  [WARN] {name} failed: {msg}")
+        # The caught exception's traceback references every frame between
+        # here and the OOM site, which keeps that frame's local arrays (the
+        # partially-built ones that got as far as they could before the
+        # allocator gave up) alive -- `del exc` + a cyclic-GC pass BEFORE
+        # `free_all_blocks()` is required, or the pool cannot actually
+        # reclaim that memory (frame<->traceback is a reference cycle,
+        # not just a refcount, so plain refcounting never collects it).
+        # Without this, one OOM leaves the pool permanently holding however
+        # much the failed call had allocated, and every later config --
+        # even a tiny one -- OOMs again against that same stuck total.
+        del exc
+        gc.collect()
+        if device == "gpu":
+            _mempool.free_all_blocks()
+            _pinned_pool.free_all_blocks()
+            _gpu_sync()
+        return float("nan"), float("nan")
+
+
+def _run_all_variants(probe, S, tp, scan, atoms, double_channel, alive):
+    """Run each variant that's still ``alive`` for one config; return
+    ``{variant: (t, mem)}``.
+
+    ``alive`` is a ``{variant: bool}`` dict owned by the calling sweep loop
+    and mutated in place: once a variant's ``_run_one`` call comes back NaN
+    it's marked dead here, and every later size in that sweep skips it
+    (recording NaN without even attempting the call) while variants that
+    haven't failed yet keep going -- so each variant is pushed to its OWN
+    limit rather than the whole sweep stopping at the first one to fail.
+    """
+    out = {}
+    if alive["multislice"]:
+        out["multislice"] = _run_one(
+            "multislice", timed_ms, probe, S.potential, tp, scan, atoms, double_channel
+        )
+        if np.isnan(out["multislice"][0]):
+            alive["multislice"] = False
+    else:
+        out["multislice"] = (float("nan"), float("nan"))
+
+    for variant, func in TIMED_FUNCS.items():
+        if alive[variant]:
+            out[variant] = _run_one(variant, func, S, tp, scan, atoms, double_channel)
+            if np.isnan(out[variant][0]):
+                alive[variant] = False
+        else:
+            out[variant] = (float("nan"), float("nan"))
+    return out
+
+
+def sweep_scan_positions(double_channel, nz=16, scan_ns=None):
+    """Sweep 1: vary scan grid, fixed thickness and cell size.
+
+    ``nz=16`` (~62 A) rather than a couple of slices so multislice does
+    enough real per-position propagation work to not be swamped by fixed
+    per-call overhead (kernel launch, warm-up notwithstanding).
+
+    ``scan_ns`` defaults to multiples of ``2 * interp`` -- below that, the
+    scan grid can be sparse enough relative to the PRISM cell
+    (``extent / interpolation``, and the per-atom valid window is HALF of
+    that) that some atoms see zero valid scan positions; see ``_run_one``.
+    The top of the range (32x the minimum) reaches into the tens of
+    thousands of positions -- realistic full-frame EELS map territory,
+    and enough for multislice's O(n_pos) cost to dominate its fixed
+    overhead.
+    """
+    if scan_ns is None:
+        min_n = max(2, 2 * interp)
+        scan_ns = tuple(min_n * k for k in (1, 2, 4, 8, 16, 32))
+    mode = "double" if double_channel else "single"
+    potential, tp, atoms = make_potential_and_tp(nz)
+    n_slices = len(list(potential.generate_slices()))
+
+    probe = abtem.Probe(
+        energy=energy, semiangle_cutoff=semiangle_cutoff, device=device
+    )
+    probe.grid.match(potential)
+
+    S = abtem.SMatrix(
+        potential=potential, energy=energy, semiangle_cutoff=semiangle_cutoff,
+        interpolation=interp, downsample=False, device=device,
+    )
+    cell_xy = potential.extent
+
+    print("=" * 88)
+    print(
+        f"SrTiO3 {sc}x{sc}x{nz}  |  {S.gpts}  |  {n_slices} slices  |  "
+        f"{energy / 1e3:.0f} keV {semiangle_cutoff} mrad  |  {mode}-channel  |  "
+        f"detector {detector_outer} mrad, collection {collection_angle} mrad"
+    )
+    print(f"--- Sweep 1: scan positions (nz={nz}, sc={sc}, interp={interp}) ---")
+    header = f"{'n':>4s} {'N_pos':>6s}"
+    for v in VARIANTS:
+        header += f" | {v:>11s} t(s) {'MB':>6s}"
+    print(header)
+
+    results = {v: {"t": [], "m": []} for v in VARIANTS}
+    n_pos_list = []
+    alive = {v: True for v in VARIANTS}
+    for n in scan_ns:
+        scan = abtem.GridScan(start=(0, 0), end=cell_xy, gpts=(n, n), endpoint=False)
+        n_pos_list.append(n * n)
+        row = _run_all_variants(probe, S, tp, scan, atoms, double_channel, alive)
+        line = f"{n:4d} {n * n:6d}"
+        for v in VARIANTS:
+            t, m = row[v]
+            results[v]["t"].append(t)
+            results[v]["m"].append(m)
+            line += f" | {t:11.3f}s {m:6.0f}"
+        print(line)
+        if not any(alive.values()):
+            print("  (stopping sweep: every variant has failed)")
+            break
+
+    return dict(
+        x=n_pos_list, xlabel="Scan positions", n_slices=n_slices, results=results
+    )
+
+
+def sweep_thickness(
+    double_channel, scan_n=None, nz_values=(4, 8, 16, 32, 64, 128, 256)
+):
+    """Sweep 2: vary z-repetitions, fixed scan grid and cell size.
+
+    Up to 256 slices (~1000 A) -- deep enough that per-slice cost actually
+    accumulates into a measurable signal instead of being noise-floor.
+
+    ``scan_n`` defaults to 64 (4096 positions) -- comfortably above the
+    scan-position crossover from sweep 1, where PRISM's S-matrix reuse
+    starts winning over multislice, so this sweep's per-slice comparison
+    isn't confounded by being on the wrong side of that crossover (see
+    ``sweep_scan_positions``'s ``min_n`` guard for the safety floor this
+    is also subject to).
+    """
+    if scan_n is None:
+        scan_n = max(64, 2 * interp)
+    n_pos = scan_n**2
+
+    print(
+        f"\n--- Sweep 2: thickness (sc={sc}, {scan_n}x{scan_n}={n_pos} positions) ---"
+    )
+    header = f"{'nz':>4s} {'thick':>7s}"
+    for v in VARIANTS:
+        header += f" | {v:>11s} t(s) {'MB':>6s}"
+    print(header)
+
+    results = {v: {"t": [], "m": []} for v in VARIANTS}
+    thickness_list = []
+    alive = {v: True for v in VARIANTS}
+    for nz in nz_values:
+        potential, tp, atoms = make_potential_and_tp(nz)
+        thickness_list.append(nz * a)
+
+        probe = abtem.Probe(
+            energy=energy, semiangle_cutoff=semiangle_cutoff, device=device
+        )
+        probe.grid.match(potential)
+        S = abtem.SMatrix(
+            potential=potential, energy=energy, semiangle_cutoff=semiangle_cutoff,
+            interpolation=interp, downsample=False, device=device,
+        )
+        scan = abtem.GridScan(
+            start=(0, 0), end=potential.extent, gpts=(scan_n, scan_n), endpoint=False
+        )
+        row = _run_all_variants(probe, S, tp, scan, atoms, double_channel, alive)
+        line = f"{nz:4d} {nz * a:6.1f}A"
+        for v in VARIANTS:
+            t, m = row[v]
+            results[v]["t"].append(t)
+            results[v]["m"].append(m)
+            line += f" | {t:11.3f}s {m:6.0f}"
+        print(line)
+        if not any(alive.values()):
+            print("  (stopping sweep: every variant has failed)")
+            break
+
+    return dict(
+        x=thickness_list, xlabel="Specimen thickness (A)", n_pos=n_pos, results=results
+    )
+
+
+def sweep_cell_size(
+    double_channel, nz=16, scan_n=None, sc_values=(2, 4, 8, 12, 16)
+):
+    """Sweep 3 (new): vary lateral cell size at FIXED A/px sampling.
+
+    This is the stress test for BiP-PRISM: as the cell grows, reciprocal-space
+    sampling gets denser (dk = 1/extent), so the number of beams inside a
+    FIXED physical ``collection_angle`` disk grows -- real_space's window and
+    beam_basis's per-pixel S2 reverse-multislice both get more expensive,
+    while bipartite's parent count (partitions_s1/partitions_s2) is fixed by
+    construction and should stay roughly flat.
+
+    ``sc_values`` reaches gpts=512x512 at the top end (``sc=16``), where
+    ``real_space``/``beam_basis`` build S1/S2 over the FULL aperture /
+    collection-disk beam set -- expect them to become the memory bottleneck
+    (potentially even OOM on GPU) well before ``bipartite`` does, since its
+    parent count is fixed by ``partitions_s1``/``partitions_s2`` regardless
+    of cell size. That gap is the demonstration, not a bug: each variant is
+    tracked independently (see ``_run_all_variants``'s ``alive`` dict), so
+    ``real_space``/``beam_basis`` failing early doesn't cut ``bipartite``'s
+    run short -- it keeps going against ``sc_values`` until it finds its
+    own limit. Extend the list if your GPU has headroom past the built-in
+    top end.
+
+    ``scan_n`` defaults to 64 (4096 positions), matching ``sweep_thickness``
+    (see its docstring for why: above the scan-position crossover from
+    sweep 1). Since ``sc`` scales the extent and the scan grid is fixed,
+    the ratio of scan spacing to PRISM-cell size (see
+    ``sweep_scan_positions``) stays constant across ``sc_values`` -- so one
+    ``scan_n`` covers the whole sweep.
+
+    The x-axis is the supercell size ``sc`` itself (not the derived
+    ``sc * px_per_unit`` gpts) -- gpts is still shown in the printed table
+    for reference.
+    """
+    if scan_n is None:
+        scan_n = max(64, 2 * interp)
+    n_pos = scan_n**2
+
+    print(
+        f"\n--- Sweep 3: cell size (nz={nz}, {scan_n}x{scan_n}={n_pos} positions, "
+        f"collection_angle={collection_angle} mrad) ---"
+    )
+    header = f"{'sc':>4s} {'gpts':>9s}"
+    for v in VARIANTS:
+        header += f" | {v:>11s} t(s) {'MB':>6s}"
+    print(header)
+
+    results = {v: {"t": [], "m": []} for v in VARIANTS}
+    sc_list = []
+    alive = {v: True for v in VARIANTS}
+    for sc_local in sc_values:
+        potential, tp, atoms = make_potential_and_tp(nz, sc_local=sc_local)
+        sc_list.append(sc_local)
+
+        probe = abtem.Probe(
+            energy=energy, semiangle_cutoff=semiangle_cutoff, device=device
+        )
+        probe.grid.match(potential)
+        S = abtem.SMatrix(
+            potential=potential, energy=energy, semiangle_cutoff=semiangle_cutoff,
+            interpolation=interp, downsample=False, device=device,
+        )
+        scan = abtem.GridScan(
+            start=(0, 0), end=potential.extent, gpts=(scan_n, scan_n), endpoint=False
+        )
+        row = _run_all_variants(probe, S, tp, scan, atoms, double_channel, alive)
+        line = f"{sc_local:4d} {sc_local * px_per_unit:4d}x{sc_local * px_per_unit:<4d}"
+        for v in VARIANTS:
+            t, m = row[v]
+            results[v]["t"].append(t)
+            results[v]["m"].append(m)
+            line += f" | {t:11.3f}s {m:6.0f}"
+        print(line)
+        if not any(alive.values()):
+            print("  (stopping sweep: every variant has failed)")
+            break
+
+    return dict(
+        x=sc_list, xlabel="Supercell size (sc)",
+        n_pos=n_pos, results=results,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Plotting -- 3 sweeps x 3 panels (time, speedup vs multislice, memory)
+# ---------------------------------------------------------------------------
+def plot(sweep_results, out_path, double_channel):
+    mode = "double" if double_channel else "single"
+    mem_label = "Peak GPU memory (MB)" if device == "gpu" else "Peak traced memory (MB)"
+    fig, axes = plt.subplots(3, 3, figsize=(15, 13))
+
+    for row_idx, (title, r) in enumerate(sweep_results.items()):
+        x = np.asarray(r["x"], dtype=float)
+
+        ax = axes[row_idx, 0]
+        for v in VARIANTS:
+            ax.plot(x, r["results"][v]["t"], "o-", ms=5, lw=1.5,
+                    color=COLORS[v], label=LABELS[v])
+        ax.set_xlabel(r["xlabel"])
+        ax.set_ylabel("Wall-clock time (s)")
+        ax.set_yscale("log")
+        ax.set_title(f"{title}: total time")
+        ax.legend(fontsize=7)
+        ax.grid(True, alpha=0.3)
+
+        ax = axes[row_idx, 1]
+        ms_t = np.asarray(r["results"]["multislice"]["t"])
+        for v in VARIANTS:
+            if v == "multislice":
+                continue
+            speedup = ms_t / np.asarray(r["results"][v]["t"])
+            ax.plot(x, speedup, "o-", ms=5, lw=1.5, color=COLORS[v], label=LABELS[v])
+        ax.axhline(1.0, color="k", ls=":", alpha=0.5)
+        ax.set_xlabel(r["xlabel"])
+        ax.set_ylabel("Speedup vs multislice")
+        ax.set_title(f"{title}: speedup")
+        ax.legend(fontsize=7)
+        ax.grid(True, alpha=0.3)
+
+        ax = axes[row_idx, 2]
+        for v in VARIANTS:
+            ax.plot(x, r["results"][v]["m"], "o-", ms=5, lw=1.5,
+                    color=COLORS[v], label=LABELS[v])
+        ax.set_xlabel(r["xlabel"])
+        ax.set_ylabel(mem_label)
+        ax.set_title(f"{title}: peak memory")
+        ax.legend(fontsize=7)
+        ax.grid(True, alpha=0.3)
+
+    fig.suptitle(
+        f"PRISM-EELS variant benchmark ({device}, {mode}-channel): SrTiO3, "
+        f"sc={sc}, interp={interp}, partitions_s1={partitions_s1}, "
+        f"partitions_s2={partitions_s2}, collection_angle={collection_angle} mrad, "
+        f"{energy / 1e3:.0f} keV, {semiangle_cutoff} mrad aperture, "
+        f"{detector_outer} mrad detector",
+        fontsize=10,
+    )
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    print(f"\nSaved: {out_path}")
+    plt.close()
+
+
+# ---------------------------------------------------------------------------
+# Validation -- confirm the harness itself is wired correctly before timing
+# ---------------------------------------------------------------------------
+def validate_interp1():
+    """Sanity check at interpolation=1: real_space, beam_basis, and bipartite
+    (with NO partitioning, i.e. the exact full-parent limit) must all match
+    conventional multislice, for both single- and double-channel."""
+    potential, tp, atoms = make_potential_and_tp(nz=2, sc_local=1)
+
+    probe = abtem.Probe(
+        energy=energy, semiangle_cutoff=semiangle_cutoff, device=device
+    )
+    probe.grid.match(potential)
+    scan = abtem.GridScan(
+        start=(0, 0), end=potential.extent, gpts=(2, 2), endpoint=False
+    )
+    detector = _detector()
+
+    S1 = abtem.SMatrix(
+        potential=potential, energy=energy, semiangle_cutoff=semiangle_cutoff,
+        interpolation=1, downsample=False, device=device,
+    )
+
+    for dc in [False, True]:
+        mode = "double" if dc else "single"
+        print(f"Validating variants vs multislice at interp=1 ({mode}-channel) ... ",
+              end="", flush=True)
+        res_ms = probe.transition_potential_scan(
+            potential=potential, transition_potentials=tp, scan=scan,
+            detectors=detector, sites=atoms, double_channel=dc, lazy=False,
+        )
+        arr_ms = np.asarray(res_ms.array)
+
+        res_real = S1.transition_potential_scan(
+            tp, scan=scan, detectors=detector, sites=atoms,
+            double_channel=dc, reduction="real_space", lazy=False,
+        )
+        res_bb = S1.transition_potential_scan(
+            tp, scan=scan, detectors=detector, sites=atoms, double_channel=dc,
+            reduction="beam_basis", collection_angle=None, lazy=False,
+        )
+        res_bip = S1.transition_potential_scan(
+            tp, scan=scan, detectors=detector, sites=atoms, double_channel=dc,
+            reduction="bipartite", collection_angle=None,
+            partitions_s1=None, partitions_s2=None, lazy=False,
+        )
+
+        for name, res in [("real_space", res_real), ("beam_basis", res_bb),
+                          ("bipartite (no partitions)", res_bip)]:
+            arr = np.asarray(res.array)
+            assert arr.shape == arr_ms.shape, (
+                f"{name}: shape mismatch {arr.shape} vs {arr_ms.shape}"
+            )
+            np.testing.assert_allclose(arr, arr_ms, rtol=1e-4, atol=1e-6)
+        print("OK")
+
+
+if __name__ == "__main__":
+    import pathlib
+
+    stem = pathlib.Path(__file__).with_suffix("")
+
+    validate_interp1()
+
+    for dc in [False, True]:
+        mode = "single" if not dc else "double"
+        out_path = (
+            f"{stem}_{device}_{mode}_sc{sc}_i{interp}_"
+            f"p{partitions_s1}-{partitions_s2}.pdf"
+        )
+        # No explicit nz/scan_n overrides here -- use each sweep function's
+        # own tuned defaults (see their docstrings).
+        r1 = sweep_scan_positions(double_channel=dc)
+        r2 = sweep_thickness(double_channel=dc)
+        r3 = sweep_cell_size(double_channel=dc)
+        plot(
+            {"Scan positions": r1, "Thickness": r2, "Cell size": r3},
+            out_path,
+            double_channel=dc,
+        )

--- a/test/test_bipprism.py
+++ b/test/test_bipprism.py
@@ -1,0 +1,503 @@
+"""Tests for the BiP-PRISM (bi-partitioned PRISM core-loss EELS) port.
+
+BiP-PRISM (paper Alg. 5) partitions BOTH the probe-forming matrix S1 and the
+detector/exit matrix S2 onto sparse hex-ring *parent* beams and reconstructs the
+full beam set locally at each ionized atom by windowed natural-neighbor
+interpolation (+ magnitude preservation). This module first tests the geometry /
+reconstruction helpers in ``abtem.prism._bipartite`` (M0), then the partitioned
+beam-basis driver (M1+).
+"""
+
+import numpy as np
+import pytest
+
+from abtem.prism.utils import plane_waves
+
+
+def _hex_beam_grid(radius=3, scale=0.1):
+    """A small circular-aperture-like set of 2D wave vectors (1/Å)."""
+    ks = np.arange(-radius, radius + 1)
+    KX, KY = np.meshgrid(ks, ks, indexing="ij")
+    mask = KX**2 + KY**2 <= radius**2
+    return np.stack([KX[mask], KY[mask]], axis=1).astype(np.float64) * scale
+
+
+# --------------------------------------------------------------------------- M0
+# parent selection
+
+
+def test_select_parent_beams_returns_unique_subset():
+    from abtem.prism._bipartite import select_parent_beams
+
+    wv = _hex_beam_grid()
+    idx = select_parent_beams(wv, n_radial=2, n_angular=6)
+
+    assert idx.ndim == 1
+    assert np.array_equal(idx, np.unique(idx))          # sorted + de-duplicated
+    assert idx.min() >= 0 and idx.max() < len(wv)       # valid indices into wv
+    assert len(idx) < len(wv)                            # genuinely a subsample
+    dc = int(np.argmin(np.linalg.norm(wv, axis=1)))      # DC beam is a parent
+    assert dc in idx
+
+
+# natural-neighbor weights
+
+
+def test_natural_neighbor_weights_full_parents_is_identity():
+    from abtem.prism._bipartite import natural_neighbor_weights
+
+    wv = _hex_beam_grid()
+    w = natural_neighbor_weights(wv, wv, method="linear")  # parents == queries
+    assert w.shape == (len(wv), len(wv))
+    np.testing.assert_allclose(w, np.eye(len(wv)), atol=1e-9)
+
+
+def test_natural_neighbor_weights_partition_of_unity():
+    from abtem.prism._bipartite import (
+        natural_neighbor_weights,
+        select_parent_beams,
+    )
+
+    wv = _hex_beam_grid()
+    idx = select_parent_beams(wv, n_radial=2, n_angular=6)
+    w = natural_neighbor_weights(wv[idx], wv, method="linear")
+    assert w.shape == (len(wv), len(idx))
+    np.testing.assert_allclose(w.sum(axis=1), np.ones(len(wv)), atol=1e-9)
+    assert (w >= 0).all()
+
+
+# windowed reconstruction
+
+
+def test_windowed_reconstruct_full_parents_recovers_exact_columns():
+    from abtem.prism._bipartite import windowed_reconstruct
+
+    extent = (10.0, 10.0)
+    gpts = (16, 16)
+    wv = _hex_beam_grid()
+
+    cols = np.asarray(plane_waves(wv, extent, gpts))     # (B, gy, gx) exact columns
+    iy = np.arange(3, 11)
+    ix = np.arange(5, 13)
+    cols_win = cols[:, iy][:, :, ix]                     # (B, wy, wx)
+
+    recon = windowed_reconstruct(
+        parent_cols=cols_win,
+        weights=np.eye(len(wv)),
+        k_parents=wv,
+        k_targets=wv,
+        iy=iy,
+        ix=ix,
+        extent=extent,
+        gpts=gpts,
+        mag_preserve=True,
+    )
+    np.testing.assert_allclose(recon, cols_win, atol=1e-5)
+
+
+def test_windowed_reconstruct_detilt_removes_carrier():
+    """De-tilting a plane-wave column by its own wave vector yields a constant
+    (DC) field on the window, proving the phase convention matches plane_waves."""
+    from abtem.prism._bipartite import windowed_reconstruct
+
+    extent = (10.0, 10.0)
+    gpts = (16, 16)
+    wv = _hex_beam_grid()
+    b = int(np.argmax(np.linalg.norm(wv, axis=1)))       # a high-angle beam
+    k = wv[b : b + 1]                                     # single "parent" == "target"
+
+    cols = np.asarray(plane_waves(k, extent, gpts))       # (1, gy, gx)
+    iy = np.arange(2, 12)
+    ix = np.arange(4, 14)
+    cols_win = cols[:, iy][:, :, ix]
+
+    # Reconstruct with a single parent/target: de-tilt(k) then re-tilt(k) == identity.
+    recon = windowed_reconstruct(
+        parent_cols=cols_win,
+        weights=np.ones((1, 1)),
+        k_parents=k,
+        k_targets=k,
+        iy=iy,
+        ix=ix,
+        extent=extent,
+        gpts=gpts,
+        mag_preserve=False,
+    )
+    np.testing.assert_allclose(recon, cols_win, atol=1e-5)
+
+
+# --------------------------------------------------------------------------- M1
+# Partitioned beam-basis driver (BiP-PRISM). Its no-partition limit is the
+# existing bit-exact beam-basis path (guarded by test_ionization.py); here we
+# check that the partitioned path stays highly correlated with the
+# unpartitioned reference (the paper's Pearson metric).
+
+import ase  # noqa: E402
+import abtem  # noqa: E402
+from abtem.core.axes import OrdinalAxis  # noqa: E402
+from abtem.inelastic.core_loss import TransitionPotentialArray  # noqa: E402
+
+
+def _synthetic_tp(Z, gpts, extent, energy=100e3, n_transitions=1, seed=0):
+    rng = np.random.default_rng(seed)
+    array = (
+        rng.standard_normal((n_transitions, *gpts))
+        + 1j * rng.standard_normal((n_transitions, *gpts))
+    ).astype(np.complex64)
+    return TransitionPotentialArray(
+        Z=Z, array=array, energy=energy, extent=extent,
+        ensemble_axes_metadata=[OrdinalAxis(values=tuple(range(n_transitions)))],
+        metadata={"Z": Z, "n": 1, "l": 0},
+    )
+
+
+def _prism_eels_setup(gpts=(24, 24), reps=(1, 1, 2)):
+    unit = ase.build.bulk("Si", cubic=True)
+    atoms = unit * reps
+    st = float(unit.cell[2, 2])
+    pot = abtem.Potential(atoms, gpts=gpts, slice_thickness=st, device="cpu")
+    tp = _synthetic_tp(14, gpts, pot.extent, energy=100e3)
+    scan = abtem.GridScan(
+        start=(0, 0), end=(unit.cell[0, 0], unit.cell[1, 1]),
+        sampling=0.5, endpoint=False,
+    )
+    sm = abtem.SMatrix(
+        potential=pot, energy=100e3, semiangle_cutoff=20.0,
+        interpolation=1, downsample=False, device="cpu",
+    )
+    det = abtem.FlexibleAnnularDetector(to_cpu=True)
+    return sm, tp, scan, det, atoms
+
+
+def _pearson(a, b):
+    a = np.asarray(a).ravel().astype(np.float64)
+    b = np.asarray(b).ravel().astype(np.float64)
+    return float(np.corrcoef(a, b)[0, 1])
+
+
+def _run(driver, sm, tp, scan, det, atoms, **kw):
+    return np.asarray(driver(sm, tp, scan, det, sites=atoms, **kw).array)
+
+
+@pytest.mark.parametrize("double_channel", [False, True])
+def test_bipprism_s1_partition_high_correlation(double_channel):
+    from abtem.inelastic.core_loss import (
+        prism_transition_potential_scan_beam_basis as drv,
+    )
+
+    sm, tp, scan, det, atoms = _prism_eels_setup()
+    ref = _run(drv, sm, tp, scan, det, atoms, double_channel=double_channel)
+    par = _run(drv, sm, tp, scan, det, atoms, double_channel=double_channel,
+               partitions_s1=4)
+    assert par.shape == ref.shape
+    assert np.all(np.isfinite(par))
+    assert _pearson(par, ref) > 0.99
+
+
+def test_bipprism_s2_partition_converges_to_exact():
+    """S2 partitioned over the *full* reciprocal grid converges monotonically to
+    the exact (unpartitioned) map as the parent count grows — the paper's
+    eq-part-exact full-parent limit. (BiP-PRISM proper partitions S2 over the
+    smaller detector-collection disk, which is far more accurate at low parent
+    counts; that is the detector-disk milestone.)"""
+    from abtem.inelastic.core_loss import (
+        prism_transition_potential_scan_beam_basis as drv,
+    )
+
+    sm, tp, scan, det, atoms = _prism_eels_setup()
+    ref = _run(drv, sm, tp, scan, det, atoms, double_channel=True)
+
+    corr = []
+    for n_radial in (3, 10):
+        par = _run(drv, sm, tp, scan, det, atoms, double_channel=True,
+                   partitions_s2=n_radial)
+        assert par.shape == ref.shape
+        assert np.all(np.isfinite(par))
+        corr.append(_pearson(par, ref))
+
+    assert corr[0] < corr[1]                       # more parents -> closer to exact
+    assert corr[-1] > 0.98                          # approaches exact at full parents
+
+
+def test_bipprism_both_partitions_converges_to_exact():
+    from abtem.inelastic.core_loss import (
+        prism_transition_potential_scan_beam_basis as drv,
+    )
+
+    sm, tp, scan, det, atoms = _prism_eels_setup()
+    ref = _run(drv, sm, tp, scan, det, atoms, double_channel=True)
+
+    par_coarse = _run(drv, sm, tp, scan, det, atoms, double_channel=True,
+                      partitions_s1=3, partitions_s2=3)
+    par_fine = _run(drv, sm, tp, scan, det, atoms, double_channel=True,
+                    partitions_s1=6, partitions_s2=10)
+    assert par_coarse.shape == ref.shape
+    assert np.all(np.isfinite(par_coarse)) and np.all(np.isfinite(par_fine))
+    # both S1 and S2 partitioned; finer parents -> closer to exact
+    assert _pearson(par_fine, ref) > _pearson(par_coarse, ref)
+    assert _pearson(par_fine, ref) > 0.98
+
+
+def test_bipprism_mag_preserve_flag_runs_both_ways():
+    from abtem.inelastic.core_loss import (
+        prism_transition_potential_scan_beam_basis as drv,
+    )
+
+    sm, tp, scan, det, atoms = _prism_eels_setup()
+    with_mp = _run(drv, sm, tp, scan, det, atoms, double_channel=True,
+                   partitions_s1=3, partitions_s2=3, mag_preserve=True)
+    no_mp = _run(drv, sm, tp, scan, det, atoms, double_channel=True,
+                 partitions_s1=3, partitions_s2=3, mag_preserve=False)
+    assert with_mp.shape == no_mp.shape
+    assert np.all(np.isfinite(with_mp)) and np.all(np.isfinite(no_mp))
+    # both should still correlate with the pattern
+    assert _pearson(with_mp, no_mp) > 0.9
+
+
+# --------------------------------------------------------------------------- M2
+# Detector-collection-disk S2 (the paper's BiP-PRISM map regime).
+
+
+def test_bipprism_collection_angle_matches_full_grid():
+    """Restricting S2 to a collection disk that covers the detector's outer angle
+    leaves the detector-integrated map unchanged (the beam-basis reduction already
+    sums |a_q|^2 over the detector); it only skips building S2 for beams the
+    detector discards."""
+    from abtem.inelastic.core_loss import (
+        prism_transition_potential_scan_beam_basis as drv,
+    )
+
+    sm, tp, scan, _, atoms = _prism_eels_setup()
+    ann = abtem.AnnularDetector(inner=0, outer=30)
+    ref = _run(drv, sm, tp, scan, ann, atoms, double_channel=True)
+    disk = _run(drv, sm, tp, scan, ann, atoms, double_channel=True,
+                collection_angle=35)
+    assert disk.shape == ref.shape
+    np.testing.assert_allclose(disk, ref, rtol=1e-4, atol=1e-8)
+
+
+def test_bipprism_collection_angle_s2_partition_accurate():
+    """Over the small detector-collection disk, S2 partitioning at a modest parent
+    count is highly accurate — the paper's BiP-PRISM operating regime."""
+    from abtem.inelastic.core_loss import (
+        prism_transition_potential_scan_beam_basis as drv,
+    )
+
+    sm, tp, scan, _, atoms = _prism_eels_setup()
+    ann = abtem.AnnularDetector(inner=0, outer=30)
+    ref = _run(drv, sm, tp, scan, ann, atoms, double_channel=True,
+               collection_angle=35)
+    par = _run(drv, sm, tp, scan, ann, atoms, double_channel=True,
+               collection_angle=35, partitions_s2=4)
+    assert par.shape == ref.shape
+    assert np.all(np.isfinite(par))
+    assert _pearson(par, ref) > 0.99
+
+
+def test_bipprism_full_partitioned_map_collection_disk():
+    """Full BiP-PRISM: partition both S1 and S2 over the collection disk; the map
+    stays highly correlated with the exact dual-matrix map."""
+    from abtem.inelastic.core_loss import (
+        prism_transition_potential_scan_beam_basis as drv,
+    )
+
+    sm, tp, scan, _, atoms = _prism_eels_setup()
+    ann = abtem.AnnularDetector(inner=0, outer=30)
+    ref = _run(drv, sm, tp, scan, ann, atoms, double_channel=True,
+               collection_angle=35)
+    par = _run(drv, sm, tp, scan, ann, atoms, double_channel=True,
+               collection_angle=35, partitions_s1=4, partitions_s2=4)
+    assert par.shape == ref.shape
+    assert np.all(np.isfinite(par))
+    assert _pearson(par, ref) > 0.99
+
+
+# --------------------------------------------------------------- public API (M2b)
+
+
+def test_bipprism_public_api_dispatch_matches_driver():
+    """SMatrix.transition_potential_scan auto-selects the beam-basis backend when
+    partition kwargs are given and reproduces the direct driver call."""
+    from abtem.inelastic.core_loss import (
+        prism_transition_potential_scan_beam_basis as drv,
+    )
+
+    sm, tp, scan, _, atoms = _prism_eels_setup()
+    ann = abtem.AnnularDetector(inner=0, outer=30)
+    direct = np.asarray(
+        drv(sm, tp, scan, ann, sites=atoms, double_channel=True,
+            collection_angle=35, partitions_s1=4, partitions_s2=4).array
+    )
+    pub = sm.transition_potential_scan(
+        tp, scan=scan, detectors=ann, sites=atoms, double_channel=True,
+        collection_angle=35, partitions_s1=4, partitions_s2=4, lazy=False,
+    )
+    pub_arr = np.asarray(pub.array)
+    assert pub_arr.shape == direct.shape
+    np.testing.assert_allclose(pub_arr, direct, rtol=1e-5, atol=1e-8)
+
+
+def test_bipprism_public_api_lazy_matches_eager():
+    sm, tp, scan, _, atoms = _prism_eels_setup()
+    ann = abtem.AnnularDetector(inner=0, outer=30)
+    eager = np.asarray(
+        sm.transition_potential_scan(
+            tp, scan=scan, detectors=ann, sites=atoms, double_channel=True,
+            reduction="bipartite", collection_angle=35,
+            partitions_s1=4, partitions_s2=4, lazy=False,
+        ).array
+    )
+    lazy = np.asarray(
+        sm.transition_potential_scan(
+            tp, scan=scan, detectors=ann, sites=atoms, double_channel=True,
+            reduction="bipartite", collection_angle=35,
+            partitions_s1=4, partitions_s2=4, lazy=True,
+        ).compute().array
+    )
+    np.testing.assert_allclose(lazy, eager, rtol=1e-5, atol=1e-8)
+
+
+# ------------------------------------------------------------- validation (M3)
+
+
+def test_bipprism_mag_preserve_recovers_scale():
+    """Quantitative check of the magnitude-preserving reconstruction (paper
+    eq-magpreserve / Sec. 3.3.6): the plain complex NNW average decoheres and
+    *loses* absolute map intensity, growing with thickness; mag_preserve pairs the
+    interpolated magnitude with the complex-sum phase and recovers the scale."""
+    from abtem.inelastic.core_loss import (
+        prism_transition_potential_scan_beam_basis as drv,
+    )
+
+    # a thicker slab makes the decoherence (which grows with propagation) visible
+    sm, tp, scan, _, atoms = _prism_eels_setup(reps=(1, 1, 4))
+    ann = abtem.AnnularDetector(inner=0, outer=30)
+
+    ref = _run(drv, sm, tp, scan, ann, atoms, double_channel=True,
+               collection_angle=35)
+    mp = _run(drv, sm, tp, scan, ann, atoms, double_channel=True,
+              collection_angle=35, partitions_s1=3, partitions_s2=3,
+              mag_preserve=True)
+    no = _run(drv, sm, tp, scan, ann, atoms, double_channel=True,
+              collection_angle=35, partitions_s1=3, partitions_s2=3,
+              mag_preserve=False)
+
+    tot = lambda a: float(np.asarray(a).sum())
+    r_mp = tot(mp) / tot(ref)
+    r_no = tot(no) / tot(ref)
+
+    assert r_no < r_mp                      # decoherence lowers intensity
+    assert abs(r_mp - 1.0) < abs(r_no - 1.0)  # mag_preserve is closer to exact scale
+    assert abs(r_mp - 1.0) < 0.02             # ... and recovers scale to ~1%
+
+
+# ------------------------------------------------------ focal back-prop helpers
+
+
+def test_focal_backprop_distance_modes():
+    from abtem.prism._bipartite import focal_backprop_distance
+
+    assert focal_backprop_distance(10.0, None) == 0.0
+    assert focal_backprop_distance(10.0, 0) == 0.0
+    assert focal_backprop_distance(10.0, "centroid") == 5.0
+    assert focal_backprop_distance(10.0, 0.3) == 3.0
+    with pytest.raises(ValueError):
+        focal_backprop_distance(10.0, "middle")
+
+
+def test_pad_window_recovers_inner():
+    from abtem.prism._bipartite import pad_window
+
+    padded, inner = pad_window(corner=5, length=8, margin=3, n=100)
+    assert len(padded) == 8 + 2 * 3
+    np.testing.assert_array_equal(padded[inner], 5 + np.arange(8))
+
+
+def test_pad_window_caps_to_full_axis():
+    from abtem.prism._bipartite import pad_window
+
+    padded, inner = pad_window(corner=0, length=24, margin=10, n=24)
+    assert len(padded) == 24                       # capped, not 44
+    np.testing.assert_array_equal(padded[inner], np.arange(24))
+
+
+def test_fresnel_margin_bounds():
+    from abtem.prism._bipartite import fresnel_margin
+
+    assert fresnel_margin(0.0, 0.037, 0.5, (0.2, 0.2), (24, 24)) == 0
+    m = fresnel_margin(20.0, 0.037, 0.5, (0.2, 0.2), (64, 64))
+    assert 4 <= m <= 32                             # positive, capped at min(gpts)//2
+
+
+# --------------------------------------------------- focal back-prop (driver)
+
+
+def _relL2(a, b):
+    a = np.asarray(a).ravel().astype(np.float64)
+    b = np.asarray(b).ravel().astype(np.float64)
+    return float(np.linalg.norm(a - b) / np.linalg.norm(b))
+
+
+def test_bipprism_focal_backprop_reduces_s1_error():
+    """S1 focal back-propagation lowers the on-atom probe reconstruction error
+    (paper Sec. 3.3.6, 2-3x for thick specimens). Isolate S1 by keeping S2 exact
+    over the collection disk (partitions_s2=None) and partitioning only S1."""
+    from abtem.inelastic.core_loss import (
+        prism_transition_potential_scan_beam_basis as drv,
+    )
+
+    # thicker slab -> more channelling -> larger S1 reconstruction error to reduce
+    sm, tp, scan, _, atoms = _prism_eels_setup(reps=(1, 1, 6))
+    ann = abtem.AnnularDetector(inner=0, outer=25)
+
+    ref = _run(drv, sm, tp, scan, ann, atoms, double_channel=True,
+               collection_angle=30)  # exact S1 & S2 over the disk
+    no_fb = _run(drv, sm, tp, scan, ann, atoms, double_channel=True,
+                 collection_angle=30, partitions_s1=2)
+    fb = _run(drv, sm, tp, scan, ann, atoms, double_channel=True,
+              collection_angle=30, partitions_s1=2, focal_backprop="centroid")
+
+    err_no = _relL2(no_fb, ref)
+    err_fb = _relL2(fb, ref)
+    assert np.all(np.isfinite(fb))
+    assert err_fb < err_no          # focal back-prop improves S1 reconstruction
+    assert err_fb < 0.5 * err_no + 1e-6  # ... substantially (paper: 2-3x)
+
+
+def test_bipprism_focal_backprop_noop_without_s1_partition():
+    """focal_backprop only touches the S1 partition; with partitions_s1=None it is
+    a no-op (S2's parallel detector beams have no crossover plane)."""
+    from abtem.inelastic.core_loss import (
+        prism_transition_potential_scan_beam_basis as drv,
+    )
+
+    sm, tp, scan, _, atoms = _prism_eels_setup()
+    ann = abtem.AnnularDetector(inner=0, outer=30)
+    base = _run(drv, sm, tp, scan, ann, atoms, double_channel=True,
+                collection_angle=35, partitions_s2=4)
+    with_fb = _run(drv, sm, tp, scan, ann, atoms, double_channel=True,
+                   collection_angle=35, partitions_s2=4, focal_backprop="centroid")
+    np.testing.assert_allclose(with_fb, base, rtol=1e-6, atol=1e-10)
+
+
+def test_bipprism_focal_backprop_public_api():
+    """focal_backprop flows through SMatrix.transition_potential_scan and (with
+    partition kwargs) auto-selects the beam-basis backend."""
+    from abtem.inelastic.core_loss import (
+        prism_transition_potential_scan_beam_basis as drv,
+    )
+
+    sm, tp, scan, _, atoms = _prism_eels_setup(reps=(1, 1, 4))
+    ann = abtem.AnnularDetector(inner=0, outer=25)
+    direct = np.asarray(
+        drv(sm, tp, scan, ann, sites=atoms, double_channel=True,
+            collection_angle=30, partitions_s1=3, focal_backprop="centroid").array
+    )
+    pub = np.asarray(
+        sm.transition_potential_scan(
+            tp, scan=scan, detectors=ann, sites=atoms, double_channel=True,
+            collection_angle=30, partitions_s1=3, focal_backprop="centroid",
+            lazy=False,
+        ).array
+    )
+    np.testing.assert_allclose(pub, direct, rtol=1e-5, atol=1e-8)

--- a/test/test_ionization.py
+++ b/test/test_ionization.py
@@ -11,6 +11,8 @@ with CuPy installed the GPU code paths in ``fast_roll`` /
 ``gpu`` is a ``pytest.param`` defined in ``test/utils.py`` that skips when
 CuPy isn't present.
 """
+import warnings
+
 import ase
 import numpy as np
 import pytest
@@ -479,6 +481,63 @@ def test_prism_eels_beam_basis_matches_multislice_at_interp_1(device, double_cha
 
     assert arr_multislice.shape == arr_beam_basis.shape
     np.testing.assert_allclose(arr_beam_basis, arr_multislice, rtol=1e-4, atol=1e-6)
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+@pytest.mark.parametrize("double_channel", [False, True])
+def test_prism_eels_beam_basis_handles_undersampled_scan(device, double_channel):
+    """A scan too coarse relative to ``interpolation`` can leave an ionization
+    site with NO scan position inside its PRISM window (extent /
+    interpolation, cropped to half that per axis) -- that site contributes
+    exactly zero and must be skipped rather than reaching the empty-batch FFT
+    that CuPy (unlike NumPy) rejects with 'Invalid number of FFT data points
+    (0)'. Regression test: this must not raise, must warn exactly once (not
+    once per site/slice), and must stay finite.
+    """
+    from abtem.inelastic.core_loss import prism_transition_potential_scan_beam_basis
+
+    unit_atoms = ase.build.bulk("Si", cubic=True)
+    atoms = unit_atoms * (2, 2, 2)
+    slice_thickness = float(unit_atoms.cell[2, 2])
+
+    potential = abtem.Potential(
+        atoms, gpts=(32, 32), slice_thickness=slice_thickness, device=device
+    )
+    energy = 100e3
+    tp = _make_synthetic_tp(14, (32, 32), potential.extent, energy=energy)
+    detector = abtem.FlexibleAnnularDetector(to_cpu=True)
+    # A 2x2 scan over the whole (2x2-tiled) cell is far coarser than the
+    # interpolation=4 PRISM window -- deliberately triggers the empty mask.
+    scan = abtem.GridScan(
+        start=(0, 0), end=potential.extent, gpts=(2, 2), endpoint=False
+    )
+    s_matrix = abtem.SMatrix(
+        potential=potential, energy=energy, semiangle_cutoff=20.0,
+        interpolation=4, downsample=False, device=device,
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        res = prism_transition_potential_scan_beam_basis(
+            s_matrix,
+            transition_potentials=tp,
+            scan=scan,
+            detectors=detector,
+            sites=atoms,
+            double_channel=double_channel,
+        )
+        undersampled_warnings = [
+            w for w in caught
+            if issubclass(w.category, UserWarning)
+            and "no scan position within its PRISM window" in str(w.message)
+        ]
+
+    arr = np.asarray(res.array)
+    assert len(undersampled_warnings) == 1, (
+        f"expected exactly one undersampled-scan warning, got "
+        f"{len(undersampled_warnings)}"
+    )
+    assert np.all(np.isfinite(arr))
 
 
 @pytest.mark.parametrize("device", ["cpu", gpu])


### PR DESCRIPTION
## Summary

Adds the **BiP-PRISM** (bi-partitioned PRISM) algorithm for core-loss STEM-EELS on top of the PRISM-EELS beam-basis driver, following *"The BiP-PRISM algorithm for fast and scalable core-loss STEM-EELS simulations"* (Algorithm 5).

The dual-scattering-matrix beam-basis driver already computes the exact map `I(ρ) = Σ_q |a_q(ρ)|²`, but builds the detector matrix `S₂` over the full reciprocal grid (`O(G²)`). BiP-PRISM instead builds **both** the probe-forming matrix `S₁` and the detector matrix `S₂` on a sparse set of hex-ring **parent beams** and reconstructs the full beam sets locally at each ionized atom by windowed natural-neighbor interpolation with magnitude preservation. Resident matrix construction and memory then scale with the parent count rather than the full beam / detector set, which is what makes full-resolution maps and momentum-resolved qEELS tractable on consumer GPUs.

Based on top of #289 (PRISM-EELS MVP); the diff here is only the BiP-PRISM addition.

## What's added

**New module `abtem/prism/_bipartite.py`:**
- `select_parent_beams` — hex-ring parent selection (DC + `n_radial` rings, snapped to the nearest beam, deduplicated; indices into the beam set so the full-parent limit is exact).
- `natural_neighbor_weights` — vectorised Delaunay-barycentric partition-of-unity weights (exact at the parents, nearest-fallback outside the hull).
- `windowed_reconstruct` — per-atom reconstruction on a crop window: de-tilt parents → NNW combine → magnitude-preserve → re-tilt.
- `focal_backprop_distance` / `pad_window` / `fresnel_margin` — S₁ focal back-propagation helpers.

**`prism_transition_potential_scan_beam_basis` (`abtem/inelastic/core_loss.py`) gains:**
- `partitions_s1` / `partitions_s2` / `n_angular` — build `S₁` / `S₂` on parent beams.
- `mag_preserve` — magnitude-preserving reconstruction that recovers the absolute intensity the convex complex average would otherwise lose to decoherence.
- `collection_angle` — restrict `S₂` to the detector-collection disk (the map regime): leaves the detector-integrated map unchanged while making the `S₂` partition accurate at low parent counts and cheaper to build.
- `focal_backprop` — S₁-only accuracy lever that reconstructs at the scattering-centroid plane before propagating to the ionization plane.

With every new argument left at its default, the driver reproduces the previous exact beam-basis result **bit-for-bit**.

**`SMatrix.transition_potential_scan`** exposes the feature via a `reduction` switch (`"real_space"` | `"beam_basis"` | `"bipartite"`) plus the partition / collection / focal kwargs; the eager, lazy and frozen-phonon paths are wired, and passing any partition kwarg auto-selects the beam-basis backend.

```python
measurement = s_matrix.transition_potential_scan(
    transition_potential,
    scan=scan,
    detectors=AnnularDetector(inner=0, outer=theta),
    double_channel=True,
    collection_angle=theta + 5,   # limit S2 to the detector disk
    partitions_s1=4,              # hex-ring parents for S1
    partitions_s2=4,              # hex-ring parents for S2
    focal_backprop="centroid",    # optional S1 accuracy lever
)
```

## Validation

New `test/test_bipprism.py` (23 tests) covers:
- the geometry / reconstruction helpers (full-parent identity, partition of unity, phase-convention roundtrip);
- **no-partition limit is bit-exact** vs the existing beam-basis path (already gated against `Probe.transition_potential_scan` multislice at `interpolation=1`);
- partitioned results **converge monotonically to the exact map** as the parent count grows (Alg. 5 full-parent limit);
- detector-disk `S₂` partitioning reaches **Pearson > 0.99 at `n_radial = 4`**, and limiting `S₂` to a disk that covers the detector leaves the map unchanged;
- **magnitude-preserving** reconstruction recovers absolute scale that the plain complex average loses (the loss grows with thickness);
- **focal back-propagation** reduces the S₁ reconstruction error (~3× at 6 slices, growing with thickness);
- public-API dispatch and eager/lazy equivalence.

The existing `test/test_ionization.py` suite is unchanged and continues to pass (no regressions).

## Notes

- Follow-ups not included here: explicit qEELS / 4D-cube output modes, the peel-once `S₂` + fold-weights-into-contraction optimisation (the MVP reconstructs the full columns on the crop window, which proves correctness but does not yet realise the full `O((B_{p,1}+B_{p,2})·G)` memory scaling), and a numerical cross-check against the reference implementation.
- Tested on CPU (Python 3.11, numpy 1.26, zarr 3.0.8). The GPU path follows the existing `xp`/backend abstractions but was not exercised here.
