### PR TITLE
Fix single-point GridScan failing when built lazily

### DIFF
--- a/abtem/scan.py
+++ b/abtem/scan.py
@@ -881,7 +881,15 @@ class GridScan(HasGrid2DMixin, BaseScan):
 
         if self._start is not None and self._end is not None:
             extent = (self._end[0] - self._start[0], self._end[1] - self._start[1])
-            if all(d <= 0.0 for d in extent):
+
+            # A scan with a single position along every axis is degenerate: its extent
+            # is zero, but the position is still well defined. This occurs both for a
+            # user-defined one-point scan and when such a scan is partitioned into
+            # blocks for lazy evaluation.
+            single_point = gpts is not None and bool(np.all(np.array(gpts) == 1))
+            degenerate = all(d == 0.0 for d in extent)
+
+            if all(d <= 0.0 for d in extent) and not (degenerate and single_point):
                 raise ValueError(f"scan extent must be positive, got {extent}")
         else:
             extent = None

--- a/test/test_scan.py
+++ b/test/test_scan.py
@@ -1,12 +1,15 @@
 import numpy as np
 import pytest
 import strategies as abtem_st
+from ase.build import bulk
 from hypothesis import given
 from hypothesis import strategies as st
+from utils import gpu
 
 from abtem.core.axes import PositionsAxis
 from abtem.detectors import AnnularDetector, FlexibleAnnularDetector, PixelatedDetector
-from abtem.scan import CustomScan, LineScan
+from abtem.potentials.iam import Potential
+from abtem.scan import CustomScan, GridScan, LineScan
 from abtem.waves import Probe
 
 
@@ -100,6 +103,61 @@ def test_custom_scan_detector_ensemble_shape(detector_cls, kwargs):
     measurement = detector.detect(waves)
     # The scan positions axis must appear somewhere in the measurement shape
     assert measurement.ensemble_shape == (3,)
+
+
+# --- GridScan tests ---
+
+
+@pytest.mark.parametrize("endpoint", [True, False])
+def test_single_point_grid_scan_partition_round_trip(endpoint):
+    """A GridScan with gpts=(1, 1) has a degenerate extent, but a well-defined
+    position. Partitioning it into blocks and rebuilding the scan from those blocks
+    must not raise and must give back the same position."""
+    scan = GridScan(
+        start=(1.0, 1.0), end=(1.0 + 4.05, 1.0 + 4.05), gpts=(1, 1), endpoint=endpoint
+    )
+
+    blocks = scan._partition_args(chunks=(1, 1), lazy=False)
+    args = tuple(block[0] for block in blocks)
+    block_scan = scan._from_partitioned_args()(*args).item()
+
+    assert block_scan.shape == (1, 1)
+    assert np.allclose(block_scan.get_positions(), scan.get_positions())
+    assert np.allclose(block_scan.get_positions().ravel(), (1.0, 1.0))
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+@pytest.mark.parametrize("endpoint", [True, False])
+def test_single_point_grid_scan_lazy(device, endpoint):
+    """Regression test: building the wave functions of a one-point GridScan lazily used
+    to raise "scan extent must be positive" from the partitioning path. The lazy result
+    must match the eager one and the equivalent CustomScan."""
+    potential = Potential(
+        bulk("Al", "fcc", a=4.05, cubic=True), gpts=64, slice_thickness=1.0
+    )
+    scan = GridScan(
+        start=(1.0, 1.0), end=(1.0 + 4.05, 1.0 + 4.05), gpts=(1, 1), endpoint=endpoint
+    )
+
+    def multislice(scan, lazy):
+        probe = Probe(energy=100e3, semiangle_cutoff=15.0, device=device)
+        probe.grid.match(potential)
+        waves = probe.build(scan=scan, lazy=lazy).multislice(potential).compute()
+        return waves.to_cpu()
+
+    lazy_waves = multislice(scan, lazy=True)
+    eager_waves = multislice(scan, lazy=False)
+    custom_waves = multislice(CustomScan([[1.0, 1.0]]), lazy=False)
+
+    assert lazy_waves.shape == (1, 1) + potential.gpts
+    assert np.allclose(lazy_waves.array, eager_waves.array)
+    assert np.allclose(lazy_waves.array.reshape(custom_waves.shape), custom_waves.array)
+
+
+def test_grid_scan_zero_extent_rejected():
+    """A degenerate extent is only allowed for a single-point scan."""
+    with pytest.raises(ValueError, match="scan extent must be positive"):
+        GridScan(start=(1.0, 1.0), end=(1.0, 1.0), gpts=(4, 4))
 
 
 # def test_source_offset():


### PR DESCRIPTION
## Problem

A `GridScan` with a single scan point fails when the wave functions are built lazily:

```python
import abtem
from abtem.scan import GridScan
from ase.build import bulk

pot = abtem.Potential(bulk("Al", "fcc", a=4.05, cubic=True), gpts=64, slice_thickness=1.0)
scan = GridScan(start=(1.0, 1.0), end=(1.0 + 4.05, 1.0 + 4.05), gpts=(1, 1), endpoint=True)
p = abtem.Probe(energy=100e3, semiangle_cutoff=15.0)
p.grid.match(pot)
p.build(scan=scan, lazy=True).multislice(pot).compute()
```

```
ValueError: scan extent must be positive, got (0.0, 0.0)
```

`lazy=False` works, and a one-position `CustomScan` works in both modes.

## Cause

With `gpts=1` and `endpoint=True`, `Grid` computes `sampling = extent / (gpts - 1)` through a safe divide, giving `0.0`. `GridScan._partition_args` derives each block as

```python
start = self.start[i] + start_chunk * self.sampling[i]
end = start + self.sampling[i] * chunk
```

so with zero sampling the block collapses to `start == end`. `_from_partitioned_args_func` then re-enters `GridScan.__init__`, which rejected the resulting zero extent. Eager builds never take the partitioning path, hence the `lazy` asymmetry.

## Fix

A scan with a single position along every axis is degenerate, but its position is still well defined. The constructor now accepts a zero extent when `gpts` is 1 on every axis. Negative extents, and zero extents with `gpts > 1`, still raise as before.

## Verification

The lazy result is bit-identical to the eager one and to an equivalent one-position `CustomScan`, and the `ScanAxis` metadata (sampling, offset, endpoint) matches the eager path in both endpoint modes.

New tests in `test/test_scan.py`:

- `test_single_point_grid_scan_partition_round_trip` — partition → rebuild returns the same position, both endpoint modes.
- `test_single_point_grid_scan_lazy` — full `Probe.build(...).multislice(...)`, parametrised over `endpoint` and over `["cpu", gpu]`, asserting lazy == eager == `CustomScan`.
- `test_grid_scan_zero_extent_rejected` — the exemption does not leak to `gpts=(4, 4)`.

Both `endpoint=True` tests fail on the unpatched `scan.py` and pass with it. The `endpoint=False` variants passed before the fix too — that path was already sound; they are included for coverage.

Suite run over `test_scan.py test_grid.py test_waves.py test_measure.py test_simulate.py test_prism.py test_detect.py`: 394 passed, 319 skipped, plus one unrelated flake in `test_prism.py::test_prism_matches_probe[cpu-True]` (a hypothesis-drawn `np.allclose` comparison) that did not reproduce in 9 subsequent runs; instrumenting `GridScan.__init__` confirms that test constructs no `GridScan` at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)