### PR TITLE
Fix LinearAxis losing its offset under dask ensemble chunk partitioning

### DIFF
--- a/abtem/core/axes.py
+++ b/abtem/core/axes.py
@@ -160,9 +160,20 @@ class AxisMetadata:
         )
 
     def _to_blocks(self, chunks):
+        # Mirrors `ArrayObject._partition_ensemble_axes_metadata`'s
+        # `axis[slic] if hasattr(axis, "__getitem__") else axis.copy()`
+        # fallback. Any axis whose metadata depends on WHICH range of the
+        # array it covers (e.g. LinearAxis's offset) must define
+        # __getitem__ to shift that dependent state per block -- without it,
+        # every block silently gets an identical copy of the GLOBAL axis,
+        # including state that is only valid for the first block.
+        # `OrdinalAxis` overrides this method directly rather than relying
+        # on the fallback, since its `values` tuple needs no per-block
+        # adjustment beyond slicing, which `__getitem__` already does.
         arr = np.empty((len(chunks[0]),), dtype=object)
+        has_getitem = hasattr(self, "__getitem__")
         for i, slic in iterate_chunk_ranges(chunks):
-            arr[i] = copy(self)
+            arr[i] = self[slic] if has_getitem else copy(self)
         arr = da.from_array(arr, chunks=1)
         return arr
 
@@ -235,6 +246,70 @@ class LinearAxis(AxisMetadata):
         return tuple(
             np.linspace(self.offset, self.offset + self.sampling * n, n, endpoint=False)
         )
+
+    def __getitem__(self, item):
+        """Return the axis restricted to a contiguous sub-range, with `offset`
+        shifted to match.
+
+        Without this, `_partition_ensemble_axes_metadata` (dask ensemble
+        partitioning) falls back to `hasattr(axis, "__getitem__")` being
+        False and uses `axis.copy()` instead: every chunk gets an identical
+        copy of the GLOBAL axis, including its global `offset`, regardless
+        of which chunk it actually is. A `LinearAxis` (offset + sampling)
+        does not store its own length, so unlike `OrdinalAxis.__getitem__`
+        (which slices an explicit `values` tuple), only `offset` needs to
+        change here -- the number of points continues to come from the
+        array's own shape wherever this axis is used.
+
+        Only simple, positive-step, non-empty slices/indices -- which is all
+        `iterate_chunk_ranges` chunk partitioning ever produces -- are
+        represented exactly; anything else raises TypeError rather than
+        silently returning an axis with the wrong offset. TypeError
+        specifically: `ArrayObject._get_ensemble_axes_metadata_items`
+        (general user-facing indexing, e.g. `waves[::-1]`) already wraps
+        `axis[item]` in `try/except TypeError` and falls back to a plain
+        copy for whatever an axis can't represent exactly -- the same
+        fallback this axis relied on before it had a `__getitem__` at all.
+        Chunk partitioning is unaffected either way, since it never
+        constructs a slice this doesn't support.
+        """
+        kwargs = dataclasses.asdict(self)
+
+        # `iterate_chunk_ranges` always yields a tuple of slices, one per
+        # axis, even when partitioning a single axis on its own (as
+        # `_to_blocks` does) -- numpy's indexing unwraps a length-1 tuple to
+        # its element automatically, which is what makes this transparent
+        # for `OrdinalAxis` (a plain array index); do the same here.
+        if isinstance(item, tuple):
+            if len(item) != 1:
+                raise TypeError(
+                    f"{type(self).__name__} indices must be a single "
+                    f"int/slice or a length-1 tuple of one, got {item!r}"
+                )
+            item = item[0]
+
+        if isinstance(item, Number):
+            start = item
+        elif isinstance(item, slice):
+            if item.step not in (None, 1):
+                raise TypeError(
+                    f"{type(self).__name__} does not support a strided "
+                    f"slice, got step={item.step}"
+                )
+            start = item.start or 0
+            if start < 0 or (item.stop is not None and item.stop <= start):
+                raise TypeError(
+                    f"{type(self).__name__} does not support a negative "
+                    f"or empty slice, got {item}"
+                )
+        else:
+            raise TypeError(
+                f"{type(self).__name__} indices must be an int or a simple "
+                f"positive-step slice, got {type(item).__name__}"
+            )
+
+        kwargs["offset"] = self.offset + start * self.sampling
+        return self.__class__(**kwargs)
 
     def to_ordinal_axis(self, n):
         values = tuple(self.coordinates(n))
@@ -420,6 +495,21 @@ class TiltAxis(OrdinalAxis):
             "base_tilt_x": self.values[item][0],
             "base_tilt_y": self.values[item][1],
         }
+
+
+@dataclass(eq=False, repr=False, unsafe_hash=True)
+class SpinAxis(OrdinalAxis):
+    """
+    Labeled axis holding the two components of a spinor wave function.
+
+    The two components are mixed by the Pauli multislice solver, unlike
+    ordinary ensemble axes whose members evolve independently, so this
+    axis must never be split across dask chunks. Locate it by isinstance,
+    never by position.
+    """
+
+    label: str = "spin"
+    values: tuple = ("up", "down")
 
 
 @dataclass(eq=False, repr=False, unsafe_hash=True)

--- a/test/test_axes.py
+++ b/test/test_axes.py
@@ -1,0 +1,133 @@
+"""Tests for abtem.core.axes, focused on LinearAxis (offset + sampling)
+metadata under dask ensemble chunk partitioning.
+
+Background: `ArrayObject._partition_ensemble_axes_metadata` and
+`AxisMetadata._to_blocks` both partition an axis's metadata per dask chunk
+via `axis[slic] if hasattr(axis, "__getitem__") else axis.copy()`.
+`OrdinalAxis` (an explicit `values` tuple) has always supported this
+correctly. `LinearAxis` and its subclasses (`RealSpaceAxis`, `ScanAxis`,
+`ReciprocalSpaceAxis`) previously had no `__getitem__` at all, so every
+chunk silently received an identical copy of the GLOBAL axis, including its
+global `offset` -- any code that read a chunk's own axis metadata to recover
+where that chunk sits (rather than just its size) got the wrong answer for
+every chunk but the first, without any error.
+"""
+import dataclasses
+
+import numpy as np
+import pytest
+
+from abtem.core.axes import LinearAxis, OrdinalAxis, RealSpaceAxis, ScanAxis
+from abtem.core.chunks import iterate_chunk_ranges, validate_chunks
+
+
+@pytest.mark.parametrize("axis_cls", [LinearAxis, RealSpaceAxis, ScanAxis])
+def test_linear_axis_getitem_shifts_offset(axis_cls):
+    axis = axis_cls(offset=10.0, sampling=0.5)
+
+    sliced = axis[3:6]
+
+    assert sliced.offset == pytest.approx(10.0 + 3 * 0.5)
+    assert sliced.sampling == axis.sampling
+
+
+def test_linear_axis_getitem_with_int():
+    axis = RealSpaceAxis(offset=10.0, sampling=0.5)
+
+    sliced = axis[4]
+
+    assert sliced.offset == pytest.approx(10.0 + 4 * 0.5)
+
+
+def test_linear_axis_getitem_with_length_one_tuple():
+    """`iterate_chunk_ranges` always yields a tuple of slices, even when
+    partitioning a single axis on its own -- this is what `_to_blocks`
+    passes through, so it must be handled the same as the bare slice."""
+    axis = RealSpaceAxis(offset=10.0, sampling=0.5)
+
+    assert axis[(slice(3, 6),)].offset == axis[3:6].offset
+
+
+@pytest.mark.parametrize(
+    "bad_item",
+    [slice(None, None, -1), slice(None, None, 2), slice(-3, None), slice(5, 2)],
+)
+def test_linear_axis_getitem_rejects_unsupported_slices(bad_item):
+    """Strided, negative, or empty slices cannot be represented by shifting
+    `offset` alone. This must raise TypeError specifically (not e.g.
+    NotImplementedError): `ArrayObject._get_ensemble_axes_metadata_items`
+    catches TypeError to fall back to a plain copy for whatever an axis
+    can't represent exactly -- the same fallback this axis relied on before
+    it had a `__getitem__` at all. Any other exception type would break
+    general indexing instead of falling back gracefully."""
+    axis = RealSpaceAxis(offset=10.0, sampling=0.5)
+
+    with pytest.raises(TypeError):
+        axis[bad_item]
+
+
+def test_linear_axis_getitem_rejects_unsupported_types():
+    axis = RealSpaceAxis(offset=10.0, sampling=0.5)
+
+    with pytest.raises(TypeError):
+        axis[np.array([0, 2, 3])]
+
+
+def test_linear_axis_to_blocks_partitions_offset_per_chunk():
+    """The regression this file exists for: partitioning a LinearAxis into
+    multiple dask chunks must give each chunk its own, chunk-local offset --
+    not an identical copy of the global one."""
+    n = 8
+    axis = RealSpaceAxis(offset=100.0, sampling=0.25)
+    chunks = validate_chunks(shape=(n,), chunks=((3, 3, 2),))
+
+    blocks = axis._to_blocks(chunks).compute()
+
+    assert len(blocks) == 3
+    starts = [0, 3, 6]
+    for block, start in zip(blocks, starts):
+        assert block.offset == pytest.approx(100.0 + start * 0.25)
+        assert block.sampling == axis.sampling
+
+
+def test_linear_axis_to_blocks_matches_direct_coordinates():
+    """Cross-check against the axis's own `coordinates()`: each chunk's
+    partitioned axis, re-expanded, must reproduce exactly the corresponding
+    slice of the full axis's coordinates."""
+    n = 11
+    axis = ScanAxis(offset=-2.5, sampling=0.4)
+    full_coordinates = np.array(axis.coordinates(n))
+
+    chunks = validate_chunks(shape=(n,), chunks=((3, 4, 4),))
+    blocks = axis._to_blocks(chunks).compute()
+
+    for (_, (slic,)), block in zip(iterate_chunk_ranges(chunks), blocks):
+        chunk_len = slic.stop - slic.start
+        block_coordinates = np.array(block.coordinates(chunk_len))
+        np.testing.assert_allclose(block_coordinates, full_coordinates[slic])
+
+
+def test_ordinal_axis_still_partitions_correctly():
+    """OrdinalAxis relied on `__getitem__` (via numpy indexing an explicit
+    `values` array) before this fix and must be unaffected by it."""
+    values = tuple(range(10, 20))
+    axis = OrdinalAxis(values=values)
+    chunks = validate_chunks(shape=(len(values),), chunks=((4, 4, 2),))
+
+    blocks = axis._to_blocks(chunks).compute()
+
+    assert [b.values for b in blocks] == [
+        values[0:4],
+        values[4:8],
+        values[8:10],
+    ]
+
+
+def test_linear_axis_copy_still_works():
+    """`.copy()` (used by the general fallback and elsewhere) must remain
+    unaffected by adding `__getitem__`."""
+    axis = RealSpaceAxis(offset=10.0, sampling=0.5, label="x")
+    copied = axis.copy()
+
+    assert copied is not axis
+    assert dataclasses.asdict(copied) == dataclasses.asdict(axis)


### PR DESCRIPTION
## Summary

- `LinearAxis` (offset + sampling; base of `RealSpaceAxis`, `ScanAxis`, `ReciprocalSpaceAxis`) had no `__getitem__`, so both places that partition ensemble-axis metadata per dask chunk (`ArrayObject._partition_ensemble_axes_metadata` and `AxisMetadata._to_blocks`) fell back to `axis.copy()` -- every chunk silently got an identical copy of the *global* axis, including its global `offset`, regardless of which chunk it actually was.
- This is silent, not a crash: a chunk's own axis metadata still looks valid, it just describes the wrong range. Any code chunked over such an axis that reads the per-chunk metadata to recover where that chunk sits (not just its size) -- e.g. to reconstruct absolute coordinates for a `GridScan` chunk -- silently gets every chunk but the first wrong. Verified directly on an 8x8 `GridScan`: every chunk reported the same offset as chunk `(0,0,0)`.
- Adds `LinearAxis.__getitem__`, shifting `offset` for the contiguous, positive-step sub-ranges chunk partitioning actually constructs. Anything else raises `TypeError`, which `_get_ensemble_axes_metadata_items` (general indexing, e.g. `waves[::-1]`) already catches to fall back to a plain copy -- the same fallback this axis relied on before.
- Also fixes `AxisMetadata._to_blocks`'s generic implementation to actually use `__getitem__` when available (mirroring `_partition_ensemble_axes_metadata`) rather than unconditionally copying -- `LinearAxis.__getitem__` alone isn't sufficient, since `_to_blocks` is a second, separate metadata-partitioning path used by `ArrayObject.apply_transform`.

## Test plan

- [x] New `test/test_axes.py`: direct unit coverage of `LinearAxis.__getitem__` (offset shifting, int/slice/tuple forms, rejection of strided/negative/fancy indices), `_to_blocks` per-chunk partitioning correctness (cross-checked against `coordinates()`), and that `OrdinalAxis`/`.copy()` are unaffected.
- [x] Full existing suite: 914 passed, 617 skipped, only the 7 pre-existing `test_gpaw.py` failures (confirmed present on `origin/dev` before this change too -- unrelated `ValueError: NxNxN grid too small`).
- [x] flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
