### PR TITLE
Fix nondeterministic atom loss in orthogonalize_cell; harden Gram-Schmidt fallback (#291)

### DIFF
--- a/abtem/atoms.py
+++ b/abtem/atoms.py
@@ -792,6 +792,30 @@ def best_orthogonal_cell(
     return np.linalg.norm(cell, axis=0)
 
 
+def _snap_scaled_positions_to_cell_boundary(atoms: Atoms, tolerance: float) -> None:
+    """
+    Snap scaled positions that are within `tolerance` (in Angstrom, along the
+    relevant lattice vector) of a cell boundary to exactly 0.
+
+    Relaxed structures from DFT or machine-learned potentials often leave atoms
+    that are physically on a cell boundary or corner with a tiny numerical
+    residual, e.g. a scaled coordinate of -1e-9 instead of exactly 0. Since
+    `ase.build.tools.cut` (used to build the orthogonal supercell) computes
+    scaled positions with a plain `% 1.0`, such a residual wraps to just below
+    1.0 rather than staying just above 0.0 depending on its sign, and is then
+    silently excluded by `cut`'s boundary mask. This makes `orthogonalize_cell`
+    non-deterministic under sub-tolerance numerical noise, dropping atoms for
+    some inputs but not others even though they represent the same structure.
+    """
+    scaled = atoms.get_scaled_positions(wrap=False)
+    lengths = atoms.cell.lengths()
+    lengths[lengths == 0] = 1.0
+    eps = tolerance / lengths
+    near_boundary = np.abs(scaled - np.round(scaled)) < eps
+    scaled[near_boundary] = np.round(scaled[near_boundary])
+    atoms.set_scaled_positions(scaled % 1.0)
+
+
 def orthogonalize_cell(
     atoms: Atoms,
     max_repetitions: int = 5,
@@ -883,23 +907,66 @@ def orthogonalize_cell(
         if is_cell_orthogonal(atoms.cell):
             if return_transform:
                 return atoms, (np.zeros(3), np.ones(3), np.zeros(3))
+            elif return_transform_matrix:
+                return atoms, np.eye(3)
             else:
                 return atoms
-        # Early-exit bug: diag==box with non-orthogonal cell -> GS fallback
-        if not return_transform and not return_transform_matrix:
-            from numpy import dot
-            _cell = np.array(atoms.cell, dtype=float)
-            v1, v2, v3 = _cell[0], _cell[1], _cell[2]
-            v2_new = v2 - dot(v2, v1) / dot(v1, v1) * v1
-            from ase import Atoms as _Atoms
-            atoms = _Atoms(symbols=atoms.get_chemical_symbols(),
-                           positions=atoms.get_positions().copy(),
-                           cell=np.array([v1, v2_new, v3]), pbc=atoms.pbc)
-            atoms.wrap()
+
+        # `best_orthogonal_cell` computes box lengths as norms of (possibly
+        # repeated) lattice vectors. For a near-orthorhombic cell whose
+        # off-diagonal components are smaller than about 2e-8 relative to the
+        # corresponding diagonal entry, those norms round to the exact
+        # diagonal entries in float64, so `diag(cell) == box` can be True
+        # even though `is_cell_orthogonal` (tol=1e-12) still correctly
+        # reports the cell as non-orthogonal. This is a relative, not
+        # absolute, effect: a 5000 A cell can carry noise up to ~1e-4 A and
+        # still trip it, while a 5 A cell only does so below ~1e-7 A. No
+        # repetition is needed in this case, just removal of the numerical
+        # residual, so remove it by zeroing the off-diagonal components
+        # directly, rather than falling through to the general repeat-and-cut
+        # path below (which assumes real repetition is needed to reach
+        # `box`).
+        #
+        # A Gram-Schmidt process on the three vectors would only guarantee
+        # they end up mutually orthogonal, not axis-aligned: if the noise
+        # sits in the first vector (whose direction seeds the process), the
+        # result is a valid orthogonal box rotated slightly off the
+        # coordinate axes, which is not what the rest of this function
+        # assumes. Since reaching this branch already means every
+        # off-diagonal component is at or below float64's ~2e-8 relative
+        # rounding floor (see above), zeroing them directly is both simpler
+        # and correct; anything larger is guarded against below rather than
+        # silently discarded.
+        cell = np.array(atoms.cell, dtype=float)
+        off_diagonal = cell[~np.eye(3, dtype=bool)]
+        max_off_diagonal = np.max(np.abs(off_diagonal))
+        relative_off_diagonal = max_off_diagonal / atoms.cell.lengths().max()
+        if relative_off_diagonal > 1e-6:
+            raise RuntimeError(
+                "Cell is not orthogonal and the off-diagonal components "
+                f"({max_off_diagonal:.3e} A, {relative_off_diagonal:.3e} "
+                "relative to the cell size) are too large to be numerical "
+                "noise; refusing to silently drop them. This should not "
+                "normally happen; please report this cell."
+            )
+
+        orthogonal_cell = np.diag(np.diag(cell))
+
+        atoms = atoms.copy()
+        atoms.set_cell(orthogonal_cell)
+        atoms.wrap()
+
+        if return_transform:
+            return atoms, (np.zeros(3), np.ones(3), np.zeros(3))
+        elif return_transform_matrix:
+            return atoms, np.eye(3)
+        else:
             return atoms
 
     if np.any(atoms.cell.lengths() < tolerance):
         raise RuntimeError("Cell vectors must have non-zero length.")
+
+    _snap_scaled_positions_to_cell_boundary(atoms, tolerance)
 
     inv = np.linalg.inv(atoms.cell)
     vectors = np.dot(np.diag(box), inv)

--- a/test/test_structures.py
+++ b/test/test_structures.py
@@ -1,9 +1,15 @@
 import numpy as np
 import pytest
-from ase import build
+from ase import Atoms, build
 from ase.build import bulk
 
-from abtem.atoms import cut_cell, merge_close_atoms, orthogonalize_cell, shrink_cell
+from abtem.atoms import (
+    cut_cell,
+    is_cell_orthogonal,
+    merge_close_atoms,
+    orthogonalize_cell,
+    shrink_cell,
+)
 
 
 def fcc(orthogonal=False):
@@ -101,3 +107,84 @@ def test_cut(structure):
     cut_atoms = cut_cell(atoms, cell=np.diag(orthogonalized_atoms.cell) - 1e-12)
 
     assert_atoms_close(orthogonalized_atoms, cut_atoms)
+
+
+def mos2():
+    atoms = build.mx2(
+        formula="MoS2", kind="2H", a=3.18, thickness=3.19, size=(1, 1, 1), vacuum=6
+    )
+    atoms.pbc = True
+    return atoms
+
+
+@pytest.mark.parametrize("perturbation", [-1e-9, -1e-6, -1e-4, 1e-9, 1e-6, 1e-4])
+def test_orthogonalize_cell_does_not_drop_boundary_atom(perturbation):
+    # Regression test: the Mo atom in this hexagonal cell sits exactly on the
+    # cell origin, a corner shared by two faces of the resulting orthogonal
+    # supercell. Relaxed DFT/MLIP structures routinely leave such
+    # high-symmetry atoms with a tiny numerical residual instead of exactly
+    # zero (e.g. -1e-9 instead of 0.0). Depending on its sign, that residual
+    # used to determine whether orthogonalize_cell silently dropped the atom
+    # (via ase.build.tools.cut's boundary mask), instead of correctly
+    # duplicating it across both faces.
+    atoms = mos2()
+    reference = orthogonalize_cell(atoms.copy())
+
+    perturbed = atoms.copy()
+    perturbed.positions[0, :2] += perturbation
+    orthogonalized = orthogonalize_cell(perturbed)
+
+    assert len(orthogonalized) == len(reference)
+
+
+def _near_orthorhombic_cell(noise):
+    # `orthogonalize_cell` zeroes any cell component below 1e-6 A before doing
+    # anything else, so the off-diagonal noise here has to survive that (i.e.
+    # be >= 1e-6) while still being small enough, relative to the cell size,
+    # that `best_orthogonal_cell`'s float64 norm computation rounds it away
+    # and reports box lengths exactly equal to the (still not-quite-zero)
+    # diagonal. That combination only occurs for large cells, hence the
+    # unusually large lattice constants below.
+    cell = np.diag([5000.0, 6000.0, 7000.0]) + noise
+    return Atoms("H", positions=[[1.0, 1.0, 1.0]], cell=cell, pbc=True)
+
+
+@pytest.mark.parametrize(
+    "noise",
+    [
+        np.array([[0.0, 5e-5, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),  # in v1
+        np.array([[0.0, 0.0, 0.0], [5e-5, 0.0, 0.0], [0.0, 0.0, 0.0]]),  # in v2
+        np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [5e-5, 5e-5, 0.0]]),  # in v3
+    ],
+)
+def test_orthogonalize_cell_near_orthorhombic_fallback_removes_all_noise(noise):
+    # Regression test: `orthogonalize_cell` takes a fallback path when
+    # `best_orthogonal_cell`'s box lengths round (in float64) to exactly the
+    # cell's diagonal, which can happen for near-orthorhombic cells with tiny
+    # off-diagonal noise. The fallback used to only correct the second
+    # lattice vector against the first (via a partial Gram-Schmidt), silently
+    # leaving the cell non-orthogonal if the noise instead sat in the first
+    # or third vector.
+    atoms = _near_orthorhombic_cell(noise)
+    orthogonalized = orthogonalize_cell(atoms)
+
+    assert is_cell_orthogonal(orthogonalized.cell)
+    assert np.allclose(np.diag(orthogonalized.cell), (5000.0, 6000.0, 7000.0))
+
+
+def test_orthogonalize_cell_near_orthorhombic_fallback_raises_for_real_shear(monkeypatch):
+    # If a genuinely large (non-noise) shear ever coincides with `diag(cell)
+    # == box`, the fallback must refuse to silently discard it rather than
+    # returning a structure with the wrong periodicity.
+    import abtem.atoms as atoms_module
+
+    monkeypatch.setattr(
+        atoms_module,
+        "best_orthogonal_cell",
+        lambda cell, max_repetitions=5: np.array([5.0, 6.0, 7.0]),
+    )
+    cell = np.array([[5.0, 0.0, 0.0], [0.5, 6.0, 0.0], [0.0, 0.0, 7.0]])
+    atoms = Atoms("H", positions=[[1.0, 1.0, 1.0]], cell=cell, pbc=True)
+
+    with pytest.raises(RuntimeError):
+        orthogonalize_cell(atoms)


### PR DESCRIPTION
## Summary

Fixes two bugs in `orthogonalize_cell` ([abtem/atoms.py](abtem/atoms.py)):

1. **Nondeterministic atom loss at cell boundaries.** Atoms sitting exactly on a periodic cell boundary (a common outcome of relaxed DFT/MLIP structures at high-symmetry sites) could be silently dropped when building the orthogonal supercell. `ase.build.tools.cut` recomputes scaled positions with a plain `% 1.0`, so a tiny negative numerical residual (e.g. `-1e-9` instead of exactly `0.0`) wraps to just below `1.0` instead of staying near `0.0`, and is then excluded by `cut`'s boundary mask. This meant `orthogonalize_cell`'s output depended on the sign of sub-tolerance noise in the input structure rather than the structure itself — the same hexagonal 2D material relaxed with different codes could come out with a hole in the lattice or not, purely by luck of which side of zero the residual landed on. Fixed by snapping near-boundary scaled positions to exactly 0 before cutting.

2. **Incomplete Gram-Schmidt fallback (follow-up to #291).** #291 added a fallback for the case where `best_orthogonal_cell`'s box lengths round (in float64) to the cell's diagonal despite genuine sub-precision non-orthogonality. That implementation only corrected the second lattice vector against the first, silently leaving the cell non-orthogonal if the noise instead sat in the first or third vector (Gram-Schmidt only guarantees mutual orthogonality of the three vectors, not axis-alignment, if the seed vector itself carries the noise), and did not support `return_transform_matrix`. Replaced with a direct zeroing of the off-diagonal components, guarded by a check that what's being removed is negligible relative to the cell size — raising instead of silently discarding it if not.

## Test plan

- [x] New regression tests in [test/test_structures.py](test/test_structures.py) covering both bugs, generated from `ase.build.mx2` rather than checked-in structure files:
  - `test_orthogonalize_cell_does_not_drop_boundary_atom`: perturbs the Mo atom of a primitive 2H-MoS2 cell by tiny positive/negative residuals and checks the orthogonalized cell always has the correct atom count.
  - `test_orthogonalize_cell_near_orthorhombic_fallback_removes_all_noise`: injects noise into each of the three lattice vectors in turn and checks the result is fully axis-aligned.
  - `test_orthogonalize_cell_near_orthorhombic_fallback_raises_for_real_shear`: confirms a genuinely large (non-noise) shear raises rather than being silently discarded.
- [x] Confirmed all three new atom-loss regression cases fail on the pre-fix code and pass after the fix (verified by stashing the fix and re-running).
- [x] Full `test/test_structures.py` suite passes (30/30).
- [x] Broader `potential`/`atoms`/`structure`-matching test subset passes (182/182; the only failures in that sweep are 4 pre-existing, unrelated GPAW grid-size errors reproduced identically on unmodified `dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
