### PR TITLE
Multi gpu hardening

### DIFF
--- a/abtem/array.py
+++ b/abtem/array.py
@@ -430,7 +430,7 @@ class ComputableList(list):
         if is_gpu:
             kwargs = _resolve_gpu_scheduler(dict(kwargs))
 
-        with _compute_context(
+        with _nested_compute_guard(kwargs), _compute_context(
             progress_bar, profiler=False, resource_profiler=False
         ) as (_, profiler, resource_profiler):
             arrays = dask.compute([array for _, array in arrays_to_write], **kwargs)[0]
@@ -584,6 +584,27 @@ def _resolve_gpu_scheduler(kwargs: dict) -> dict:
     return kwargs
 
 
+@contextmanager
+def _nested_compute_guard(kwargs: dict):
+    """Extend a forced synchronous scheduler to nested computes.
+
+    Passing ``scheduler="synchronous"`` to ``dask.compute`` governs only that
+    call's graph. A task body may itself call ``.compute()`` -- e.g.
+    ``CrystalPotential.generate_slices`` pooling a lazy multi-configuration
+    ``potential_unit`` -- and a nested compute reads the process-wide default
+    scheduler: the threaded one, which must not execute CuPy tasks
+    concurrently. Mirror the forced choice into the dask configuration for the
+    duration of the outer compute. When no scheduler is forced (a distributed
+    client is in charge, or the caller chose one), the configuration is left
+    alone so client routing is unaffected.
+    """
+    if kwargs.get("scheduler") == "synchronous":
+        with dask.config.set(scheduler="synchronous"):
+            yield
+    else:
+        yield
+
+
 def _compute(
     array_objects: list[ArrayObjectType],
     progress_bar: Optional[bool] = None,
@@ -598,7 +619,7 @@ def _compute(
     if is_gpu:
         kwargs = _resolve_gpu_scheduler(kwargs)
 
-    with _compute_context(
+    with _nested_compute_guard(kwargs), _compute_context(
         progress_bar, profiler=profiler, resource_profiler=resource_profiler
     ) as (_, profiler, resource_profiler):
         arrays = dask.compute([wrapper.array for wrapper in array_objects], **kwargs)[0]

--- a/abtem/array.py
+++ b/abtem/array.py
@@ -552,18 +552,29 @@ def _resolve_gpu_scheduler(kwargs: dict) -> dict:
     except ValueError:
         client = None
 
+    multi_gpu = config.get("dask.multi-gpu", False)
+
     # Start a dask-cuda cluster spanning all visible GPUs when multi-GPU is
     # enabled, no client is already handling the computation, and the user has
     # not explicitly requested a scheduler.
-    if (
-        client is None
-        and "scheduler" not in kwargs
-        and config.get("dask.multi-gpu", False)
-        and cp.cuda.runtime.getDeviceCount() > 1
-    ):
-        client = ensure_cuda_cluster()
+    if client is None and "scheduler" not in kwargs and multi_gpu:
+        if cp.cuda.runtime.getDeviceCount() > 1:
+            client = ensure_cuda_cluster()
+        else:
+            warnings.warn(
+                "dask.multi-gpu is enabled but only one GPU is visible; "
+                "computing on a single GPU with the synchronous scheduler.",
+                UserWarning,
+            )
 
     if not is_gpu_dask_client(client) and "scheduler" not in kwargs:
+        if client is not None and multi_gpu:
+            warnings.warn(
+                "dask.multi-gpu is enabled but the active dask client is not a "
+                "single-threaded one-worker-per-GPU (dask-cuda) client; "
+                "falling back to the synchronous scheduler on a single GPU.",
+                UserWarning,
+            )
         kwargs["scheduler"] = "synchronous"
 
     return kwargs

--- a/abtem/array.py
+++ b/abtem/array.py
@@ -331,7 +331,6 @@ class ComputableList(list):
 
         if is_zip:
             # Use ZipStore for .zip files
-            @dask.delayed
             def write_to_zipstore(
                 computed_arrays,
                 url,
@@ -372,16 +371,10 @@ class ComputableList(list):
 
                 return url
 
-            delayed_arrays = [
-                (i, dask.delayed(array.compute)()) for i, array in arrays_to_write
-            ]
-            delayed_write = write_to_zipstore(
-                delayed_arrays, url, metadata_list, overwrite, compressors=compressors
-            )
+            write_func = write_to_zipstore
 
         else:
             # Use directory store for non-.zip files
-            @dask.delayed
             def write_to_directory(computed_arrays, url, metadata_list, overwrite):
                 import shutil
 
@@ -411,33 +404,42 @@ class ComputableList(list):
 
                 return url
 
+            write_func = write_to_directory
+
+        if not compute:
             delayed_arrays = [
                 (i, dask.delayed(array.compute)()) for i, array in arrays_to_write
             ]
-            delayed_write = write_to_directory(
+            return dask.delayed(write_func)(
                 delayed_arrays, url, metadata_list, overwrite
             )
 
-        if not compute:
-            return delayed_write
-
-        # On GPU, force the synchronous scheduler to avoid multiple dask tasks
-        # running in parallel, each loading potential chunks + wave arrays into
-        # VRAM simultaneously. We must use dask.config.set() (via the guard) rather
-        # than just passing scheduler= to dask.compute(), because the delayed graph
-        # contains inner array.compute() calls that would otherwise use dask's
-        # default threaded scheduler. The guard makes an exception for an active
-        # single-threaded dask-cuda client, which already runs one task per GPU.
+        # Compute the arrays first -- resolving the GPU execution context the
+        # same way as ArrayObject.compute, so the opt-in multi-GPU cluster
+        # (``dask.multi-gpu``) is started on this path too -- then write the
+        # gathered results eagerly. Writing through a delayed task that itself
+        # calls array.compute() would nest a compute inside a scheduler task:
+        # the synchronous scheduler then needs a global config override to
+        # reach the nested call, and under a distributed client the nested
+        # compute would run on the local scheduler inside a single worker,
+        # serializing the whole computation onto one GPU.
         is_gpu = config.get("device") == "gpu" or any(
             _is_gpu_array_object(obj) for obj in self
         )
         if is_gpu:
-            check_cupy_is_installed()
+            kwargs = _resolve_gpu_scheduler(dict(kwargs))
 
-        with _gpu_scheduler_guard(is_gpu), _compute_context(
+        with _compute_context(
             progress_bar, profiler=False, resource_profiler=False
         ) as (_, profiler, resource_profiler):
-            output = dask.compute(delayed_write, **kwargs)[0]
+            arrays = dask.compute([array for _, array in arrays_to_write], **kwargs)[0]
+
+        output = write_func(
+            [(i, array) for (i, _), array in zip(arrays_to_write, arrays)],
+            url,
+            metadata_list,
+            overwrite,
+        )
 
         profilers = tuple(p for p in (profiler, resource_profiler) if p is not None)
         if profilers:
@@ -518,20 +520,30 @@ def _is_gpu_array_object(obj) -> bool:
     return hasattr(obj, "device") and obj.device == "gpu"
 
 
-@contextmanager
-def _gpu_scheduler_guard(is_gpu: bool):
-    """Guard nested/implicit GPU computes against the threaded scheduler.
+def _resolve_gpu_scheduler(kwargs: dict) -> dict:
+    """Resolve the dask scheduler for a GPU computation.
 
-    On GPU, force the synchronous scheduler so that nested ``array.compute()``
-    calls cannot fall back to dask's default threaded scheduler and load multiple
-    potential/wave chunks into a single GPU's memory at once. When a single-
-    threaded dask-cuda client is active (one worker pinned per GPU), that per-GPU
-    exclusivity already holds inside each worker, so the work is left to the
-    client to distribute across the cluster instead of being forced synchronous.
+    Starts the opt-in multi-GPU cluster (``dask.multi-gpu``) when more than one
+    GPU is visible and no client or explicit scheduler is already in charge.
+    When no suitable single-threaded dask-cuda client ends up handling the
+    computation, the synchronous scheduler is selected instead: the threaded
+    scheduler and multi-threaded workers share a single CUDA context per
+    process, which cannot be used with CuPy, and concurrent tasks would load
+    multiple potential/wave chunks into a single GPU's memory at once.
+
+    Parameters
+    ----------
+    kwargs : dict
+        Keyword arguments destined for ``dask.compute``. A ``scheduler`` key
+        set by the caller is always respected.
+
+    Returns
+    -------
+    dict
+        The keyword arguments, with ``scheduler="synchronous"`` injected when
+        no suitable client is available.
     """
-    if not is_gpu:
-        yield
-        return
+    check_cupy_is_installed()
 
     from distributed import get_client
 
@@ -540,11 +552,21 @@ def _gpu_scheduler_guard(is_gpu: bool):
     except ValueError:
         client = None
 
-    if is_gpu_dask_client(client):
-        yield
-    else:
-        with dask.config.set(scheduler="synchronous"):
-            yield
+    # Start a dask-cuda cluster spanning all visible GPUs when multi-GPU is
+    # enabled, no client is already handling the computation, and the user has
+    # not explicitly requested a scheduler.
+    if (
+        client is None
+        and "scheduler" not in kwargs
+        and config.get("dask.multi-gpu", False)
+        and cp.cuda.runtime.getDeviceCount() > 1
+    ):
+        client = ensure_cuda_cluster()
+
+    if not is_gpu_dask_client(client) and "scheduler" not in kwargs:
+        kwargs["scheduler"] = "synchronous"
+
+    return kwargs
 
 
 def _compute(
@@ -559,31 +581,7 @@ def _compute(
     )
 
     if is_gpu:
-        check_cupy_is_installed()
-
-        from distributed import get_client
-
-        try:
-            client = get_client()
-        except ValueError:
-            client = None
-
-        # Start a dask-cuda cluster spanning all visible GPUs when multi-GPU is
-        # enabled, no client is already handling the computation, and the user has
-        # not explicitly requested a scheduler.
-        if (
-            client is None
-            and "scheduler" not in kwargs
-            and config.get("dask.multi-gpu", False)
-            and cp.cuda.runtime.getDeviceCount() > 1
-        ):
-            client = ensure_cuda_cluster()
-
-        # The threaded scheduler and multi-threaded workers cannot be used with CuPy;
-        # fall back to synchronous execution unless a suitable (dask-cuda) client is
-        # handling the computation.
-        if not is_gpu_dask_client(client) and "scheduler" not in kwargs:
-            kwargs["scheduler"] = "synchronous"
+        kwargs = _resolve_gpu_scheduler(kwargs)
 
     with _compute_context(
         progress_bar, profiler=profiler, resource_profiler=resource_profiler

--- a/abtem/array.py
+++ b/abtem/array.py
@@ -41,6 +41,7 @@ from abtem.core.axes import (
     axis_to_dict,
 )
 from abtem.core.backend import (
+    push_config_to_workers,
     check_cupy_is_installed,
     copy_to_device,
     cp,
@@ -576,6 +577,9 @@ def _resolve_gpu_scheduler(kwargs: dict) -> dict:
                 UserWarning,
             )
         kwargs["scheduler"] = "synchronous"
+
+    if is_gpu_dask_client(client):
+        push_config_to_workers(client)
 
     return kwargs
 

--- a/abtem/array.py
+++ b/abtem/array.py
@@ -41,7 +41,6 @@ from abtem.core.axes import (
     axis_to_dict,
 )
 from abtem.core.backend import (
-    push_config_to_workers,
     check_cupy_is_installed,
     copy_to_device,
     cp,
@@ -49,6 +48,7 @@ from abtem.core.backend import (
     ensure_cuda_cluster,
     get_array_module,
     is_gpu_dask_client,
+    push_config_to_workers,
 )
 from abtem.core.chunks import Chunks, iterate_chunk_ranges, validate_chunks
 from abtem.core.ensemble import Ensemble, _wrap_with_array, unpack_blockwise_args
@@ -243,6 +243,11 @@ class ComputableList(list):
             For directory stores, use .zarr extension or a directory path.
         compute : bool
             If true compute immediately; return dask.delayed.Delayed otherwise.
+            Note that the returned delayed write nests an ``array.compute()``
+            executed under whatever scheduler is active when the caller
+            finally computes it -- the multi-GPU bootstrap and the forced
+            synchronous GPU scheduler apply only to ``compute=True``. On GPU,
+            prefer ``compute=True`` or compute the result before saving.
         overwrite : bool
             If given array already exists, overwrite=False will cause an error, where
             overwrite=True will replace the existing data.

--- a/abtem/array.py
+++ b/abtem/array.py
@@ -427,6 +427,8 @@ class ComputableList(list):
         is_gpu = config.get("device") == "gpu" or any(
             _is_gpu_array_object(obj) for obj in self
         )
+        _push_config_to_active_client()
+
         if is_gpu:
             kwargs = _resolve_gpu_scheduler(dict(kwargs))
 
@@ -605,6 +607,24 @@ def _nested_compute_guard(kwargs: dict):
         yield
 
 
+def _push_config_to_active_client():
+    """Mirror the configuration onto an active distributed client's workers.
+
+    The silently-defaulted-configuration bug is not specific to the multi-GPU
+    cluster: any distributed client (a CPU LocalCluster, a SLURMCluster, ...)
+    executes tasks in worker processes that never saw the client's
+    ``abtem.config.set``. Deduplicated inside push_config_to_workers, so
+    calling this on every dispatch is cheap.
+    """
+    try:
+        from distributed import get_client
+
+        client = get_client()
+    except (ImportError, ValueError):
+        return
+    push_config_to_workers(client)
+
+
 def _compute(
     array_objects: list[ArrayObjectType],
     progress_bar: Optional[bool] = None,
@@ -615,6 +635,8 @@ def _compute(
     is_gpu = config.get("device") == "gpu" or any(
         _is_gpu_array_object(obj) for obj in array_objects
     )
+
+    _push_config_to_active_client()
 
     if is_gpu:
         kwargs = _resolve_gpu_scheduler(kwargs)

--- a/abtem/core/abtem.yaml
+++ b/abtem/core/abtem.yaml
@@ -40,6 +40,7 @@ cupy:
   # > 0   — bound cached workspace to this many bytes (e.g. "512 MB").
   # -1    — unlimited (CuPy default; fastest but accumulates workspace,
   #          which on Bluestein-fallback grid sizes can reach tens of GB).
+  # null  — same as -1 (no bound).
   fft-cache-size: auto
 mkl:
   # The number of threads to use for mkl

--- a/abtem/core/abtem.yaml
+++ b/abtem/core/abtem.yaml
@@ -34,8 +34,9 @@ cupy:
   # 0 MB  — disable caching entirely (workspace freed after every FFT call;
   #          use when VRAM is tight and large-grid OOMs occur).
   # > 0   — bound cached workspace to this many bytes (e.g. "512 MB").
-  # -1    — unlimited (CuPy default; fastest but accumulates workspace).
-  fft-cache-size: -1
+  # -1    — unlimited (CuPy default; fastest but accumulates workspace,
+  #          which on Bluestein-fallback grid sizes can reach tens of GB).
+  fft-cache-size: 2 GB
 mkl:
   # The number of threads to use for mkl
   threads: 2

--- a/abtem/core/abtem.yaml
+++ b/abtem/core/abtem.yaml
@@ -21,6 +21,13 @@ dask:
   # Automatically distribute gpu computations over all visible gpus by starting a
   # dask-cuda cluster. Requires the optional dask-cuda package.
   multi-gpu: false
+  # Optional RMM memory-pool size per multi-gpu worker (e.g. "20 GB").
+  # null disables the RMM pool.
+  multi-gpu-rmm-pool: null
+  # Optional subset of GPUs for the multi-gpu cluster, as a list of device
+  # indices (e.g. [0, 1]) or a comma-separated string (e.g. "0,1").
+  # null spans all visible GPUs.
+  multi-gpu-devices: null
 cupy:
   # Maximum GPU memory (bytes) used by the cuFFT plan cache.
   # https://docs.cupy.dev/en/stable/user_guide/fft.html#fft-plan-cache

--- a/abtem/core/abtem.yaml
+++ b/abtem/core/abtem.yaml
@@ -31,12 +31,16 @@ dask:
 cupy:
   # Maximum GPU memory (bytes) used by the cuFFT plan cache.
   # https://docs.cupy.dev/en/stable/user_guide/fft.html#fft-plan-cache
+  # auto  — 25% of the device's total memory, resolved per device: scales
+  #          with the card like the auto-sized batches whose plans it holds,
+  #          keeping live plans hot while capping stale-plan retention. A
+  #          ceiling, not a reservation — unused headroom costs no memory.
   # 0 MB  — disable caching entirely (workspace freed after every FFT call;
   #          use when VRAM is tight and large-grid OOMs occur).
   # > 0   — bound cached workspace to this many bytes (e.g. "512 MB").
   # -1    — unlimited (CuPy default; fastest but accumulates workspace,
   #          which on Bluestein-fallback grid sizes can reach tens of GB).
-  fft-cache-size: 2 GB
+  fft-cache-size: auto
 mkl:
   # The number of threads to use for mkl
   threads: 2

--- a/abtem/core/backend.py
+++ b/abtem/core/backend.py
@@ -171,12 +171,45 @@ def get_cuda_cluster_client():
 
 _pushed_config_token = None
 
+_CONFIG_PLUGIN_NAME = "abtem-config"
+
 
 def _apply_config_snapshot(snapshot):
-    from abtem.core.config import config as config_dict
+    import copy
 
-    config_dict.clear()
-    config_dict.update(snapshot)
+    from abtem.core.config import config as config_dict
+    from abtem.core.config import config_lock
+
+    snapshot = copy.deepcopy(snapshot)
+    with config_lock:
+        # Update before pruning: readers that do not take the lock (config.get)
+        # then always observe a fully-populated dict, never the empty window a
+        # clear-then-update would open to a concurrently executing task.
+        config_dict.update(snapshot)
+        for key in [k for k in config_dict if k not in snapshot]:
+            del config_dict[key]
+
+
+def _make_config_plugin(snapshot):
+    from distributed.diagnostics.plugin import WorkerPlugin
+
+    class _AbtemConfigPlugin(WorkerPlugin):
+        """Apply the client's abTEM configuration snapshot on every worker.
+
+        Plugin ``setup`` runs on all current workers at registration time and
+        on every worker that joins or is restarted later (e.g. by a Nanny) --
+        coverage a one-shot ``client.run`` cannot provide.
+        """
+
+        name = _CONFIG_PLUGIN_NAME
+
+        def __init__(self, snapshot):
+            self._snapshot = snapshot
+
+        def setup(self, worker=None):
+            _apply_config_snapshot(self._snapshot)
+
+    return _AbtemConfigPlugin(snapshot)
 
 
 def push_config_to_workers(client):
@@ -186,19 +219,27 @@ def push_config_to_workers(client):
     ``get_dtype`` reads ``precision`` at call time, for example -- but worker
     processes only ever see the defaults: ``abtem.config.set`` in the client
     does not reach them, silently changing results (a float64 computation
-    dispatched to default-configured workers runs in float32). Push a snapshot
-    of the merged configuration before dispatching work; repeated pushes of an
-    unchanged configuration are skipped.
+    dispatched to default-configured workers runs in float32).
+
+    The snapshot is carried by a named worker plugin, so workers that join or
+    restart later also receive it; when the configuration changes,
+    re-registering under the same name replaces the plugin and re-runs its
+    setup on all workers. Repeated pushes of an unchanged configuration to the
+    same client (keyed on ``client.id``) are skipped.
     """
     global _pushed_config_token
 
     import copy
 
     snapshot = copy.deepcopy(config)
-    token = (id(client), repr(snapshot))
+    token = (getattr(client, "id", None) or id(client), repr(snapshot))
     if token == _pushed_config_token:
         return
-    client.run(_apply_config_snapshot, snapshot)
+    plugin = _make_config_plugin(snapshot)
+    try:
+        client.register_plugin(plugin, name=_CONFIG_PLUGIN_NAME)
+    except AttributeError:  # distributed without Client.register_plugin
+        client.register_worker_plugin(plugin, name=_CONFIG_PLUGIN_NAME)
     _pushed_config_token = token
 
 

--- a/abtem/core/backend.py
+++ b/abtem/core/backend.py
@@ -105,7 +105,23 @@ def ensure_cuda_cluster():
     except Exception:  # noqa: BLE001 -- fall back to dask-cuda's default sizing
         pass
 
-    _cuda_cluster_client = Client(LocalCUDACluster(**cluster_kwargs))
+    try:
+        _cuda_cluster_client = Client(LocalCUDACluster(**cluster_kwargs))
+    except RuntimeError as exc:
+        # dask-cuda starts worker processes with the 'spawn' method (fork is
+        # unsafe with a live CUDA context), so the workers re-import the main
+        # module. Without an entry-point guard that re-runs the script in every
+        # worker, which multiprocessing reports with a cryptic bootstrapping
+        # error (typically alongside a port-8787-in-use complaint).
+        if "bootstrapping phase" in str(exc):
+            raise RuntimeError(
+                "Starting the multi-GPU cluster failed because the worker "
+                "processes re-imported the main module before it finished "
+                "executing. dask-cuda starts workers with the 'spawn' method, "
+                "so the script's entry point must be guarded with "
+                "'if __name__ == \"__main__\":'."
+            ) from exc
+        raise
 
     logger.info(
         "dask.multi-gpu: started a dask-cuda LocalCUDACluster; computations "

--- a/abtem/core/backend.py
+++ b/abtem/core/backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import warnings
 from numbers import Number
 from types import ModuleType
@@ -42,6 +43,8 @@ except ImportError:
 
 
 ArrayModule = Union[ModuleType, str]
+
+logger = logging.getLogger(__name__)
 
 
 def check_cupy_is_installed():
@@ -104,7 +107,34 @@ def ensure_cuda_cluster():
 
     _cuda_cluster_client = Client(LocalCUDACluster(**cluster_kwargs))
 
+    logger.info(
+        "dask.multi-gpu: started a dask-cuda LocalCUDACluster; computations "
+        "will be distributed with one worker per visible GPU."
+    )
+
     return _cuda_cluster_client
+
+
+def get_cuda_cluster_client():
+    """
+    Return the dask-cuda cluster client started by ``ensure_cuda_cluster``.
+
+    Returns the running client, or None when no cluster has been started or the
+    previous one was shut down. Unlike ``ensure_cuda_cluster`` this never starts
+    a cluster, which makes it suitable for inspecting whether multi-GPU
+    execution is active (e.g. from benchmark or verification scripts).
+
+    Returns
+    -------
+    distributed.Client or None
+        The client connected to the running dask-cuda cluster, if any.
+    """
+    if (
+        _cuda_cluster_client is not None
+        and getattr(_cuda_cluster_client, "status", None) == "running"
+    ):
+        return _cuda_cluster_client
+    return None
 
 
 def is_gpu_dask_client(client) -> bool:

--- a/abtem/core/backend.py
+++ b/abtem/core/backend.py
@@ -14,6 +14,7 @@ import scipy  # type: ignore
 import scipy.ndimage  # type: ignore
 
 from abtem.core.config import config
+from abtem.core.config import get as _config_get
 
 try:
     import cupy as cp  # type: ignore
@@ -104,6 +105,21 @@ def ensure_cuda_cluster():
             cluster_kwargs["memory_limit"] = int(0.85 * MEMORY_LIMIT / n_gpus)
     except Exception:  # noqa: BLE001 -- fall back to dask-cuda's default sizing
         pass
+
+    # Optional RMM memory pool per worker (e.g. "20 GB"), forwarded to
+    # dask-cuda; a pre-grown pool avoids allocator churn on memory-intensive
+    # workloads.
+    rmm_pool = _config_get("dask.multi-gpu-rmm-pool", None)
+    if rmm_pool:
+        cluster_kwargs["rmm_pool_size"] = rmm_pool
+
+    # Optional subset of GPUs to span, as a list of device indices or a
+    # comma-separated string. By default the cluster spans all visible GPUs.
+    devices = _config_get("dask.multi-gpu-devices", None)
+    if devices:
+        if not isinstance(devices, str):
+            devices = ",".join(str(d) for d in devices)
+        cluster_kwargs["CUDA_VISIBLE_DEVICES"] = devices
 
     try:
         _cuda_cluster_client = Client(LocalCUDACluster(**cluster_kwargs))

--- a/abtem/core/backend.py
+++ b/abtem/core/backend.py
@@ -169,6 +169,39 @@ def get_cuda_cluster_client():
     return None
 
 
+_pushed_config_token = None
+
+
+def _apply_config_snapshot(snapshot):
+    from abtem.core.config import config as config_dict
+
+    config_dict.clear()
+    config_dict.update(snapshot)
+
+
+def push_config_to_workers(client):
+    """Mirror this process's abTEM configuration onto the client's workers.
+
+    abTEM resolves configuration inside tasks, in the worker process --
+    ``get_dtype`` reads ``precision`` at call time, for example -- but worker
+    processes only ever see the defaults: ``abtem.config.set`` in the client
+    does not reach them, silently changing results (a float64 computation
+    dispatched to default-configured workers runs in float32). Push a snapshot
+    of the merged configuration before dispatching work; repeated pushes of an
+    unchanged configuration are skipped.
+    """
+    global _pushed_config_token
+
+    import copy
+
+    snapshot = copy.deepcopy(config)
+    token = (id(client), repr(snapshot))
+    if token == _pushed_config_token:
+        return
+    client.run(_apply_config_snapshot, snapshot)
+    _pushed_config_token = token
+
+
 def is_gpu_dask_client(client) -> bool:
     """
     Check whether a distributed client can safely execute CuPy computations.

--- a/abtem/core/chunks.py
+++ b/abtem/core/chunks.py
@@ -471,15 +471,21 @@ def estimate_potential_chunk_size(
     slice_bytes = gpts[0] * gpts[1] * dtype.itemsize
 
     if device == "gpu":
-        # The radix check cannot fail and needs no GPU -- keep it outside the
-        # try below, whose silent fallback is only for a missing/failing CUDA
-        # memory probe.
-        from abtem.core.fft import is_fast_fft_size
-
-        overhead = 6
-        if not all(is_fast_fft_size(n) for n in gpts):
-            overhead = 12
-
+        # Deliberately no Bluestein-overhead factor here, unlike the sibling
+        # estimate_scan_batch_size.  Every FFT that touches a potential slice
+        # is a single, unbatched 2D transform: build() and generate_slices()
+        # emit one slice at a time (see _FieldBuilder.build), the projection
+        # integrals in integrals.py transform a bare (ny, nx) array, and
+        # multislice_step bandlimits one transmission function per step.  The
+        # cuFFT workspace for those transforms is therefore constant in
+        # chunk_size, while effective_per_slice below is multiplied by it --
+        # folding an FFT-unfriendliness factor in would halve the chunk on a
+        # Bluestein grid to pay for a cost that does not grow with it.  The
+        # probe batch is the only quantity whose FFT is batched over the
+        # dimension being sized, which is why the factor belongs to
+        # estimate_scan_batch_size alone.  What residual Bluestein cost there
+        # is (one cached plan) this function already sees: it runs at
+        # computation time and reads the live free-VRAM figure below.
         try:
             import cupy as cp
 
@@ -598,9 +604,12 @@ def estimate_scan_batch_size(
     per_probe_bytes = int(np.prod(gpts)) * np.dtype(dtype).itemsize
 
     if device == "gpu":
-        # The radix check cannot fail and needs no GPU -- keep it outside the
-        # try below, whose silent fallback is only for a missing/failing CUDA
-        # memory probe.
+        # ``gpts`` is the wavefunction grid every probe lives on, not the scan
+        # grid: the scan positions form the FFT *batch* dimension, so only the
+        # transform lengths (ny, nx) decide whether cuFFT falls back to
+        # Bluestein.  The radix check cannot fail and needs no GPU -- keep it
+        # outside the try below, whose silent fallback is only for a
+        # missing/failing CUDA memory probe.
         from abtem.core.fft import is_fast_fft_size
 
         overhead = 6

--- a/abtem/core/chunks.py
+++ b/abtem/core/chunks.py
@@ -471,6 +471,15 @@ def estimate_potential_chunk_size(
     slice_bytes = gpts[0] * gpts[1] * dtype.itemsize
 
     if device == "gpu":
+        # The radix check cannot fail and needs no GPU -- keep it outside the
+        # try below, whose silent fallback is only for a missing/failing CUDA
+        # memory probe.
+        from abtem.core.fft import is_fast_fft_size
+
+        overhead = 6
+        if not all(is_fast_fft_size(n) for n in gpts):
+            overhead = 12
+
         try:
             import cupy as cp
 
@@ -589,6 +598,15 @@ def estimate_scan_batch_size(
     per_probe_bytes = int(np.prod(gpts)) * np.dtype(dtype).itemsize
 
     if device == "gpu":
+        # The radix check cannot fail and needs no GPU -- keep it outside the
+        # try below, whose silent fallback is only for a missing/failing CUDA
+        # memory probe.
+        from abtem.core.fft import is_fast_fft_size
+
+        overhead = 6
+        if not all(is_fast_fft_size(n) for n in gpts):
+            overhead = 12
+
         try:
             import cupy as cp
 
@@ -617,17 +635,11 @@ def estimate_scan_batch_size(
             # memory and sizes the potential chunk to fit in what remains.
             # Both functions now use the same pool-aware effective_free so
             # the two estimates operate on a consistent VRAM picture.
-            from abtem.core.fft import is_fast_fft_size
-
-            overhead = 6
-            if not all(is_fast_fft_size(n) for n in gpts):
-                overhead = 12
-
             probe_budget = int(effective_free * 0.50)
             per_probe_effective = max(1, int(per_probe_bytes * overhead))
             n_probes = max(1, probe_budget // per_probe_effective)
             return _nearest_power_of_two(n_probes)
-        except (ImportError, Exception):
+        except Exception:  # noqa: BLE001 -- no CUDA memory probe available
             chunk_bytes = parse_bytes(config.get("dask.chunk-size-gpu", "512 MB"))
     else:
         chunk_bytes = parse_bytes(config.get("dask.chunk-size", "128 MB"))

--- a/abtem/core/chunks.py
+++ b/abtem/core/chunks.py
@@ -605,15 +605,26 @@ def estimate_scan_batch_size(
             # A 6× overhead factor accounts for transient copies during
             # transmission-function multiply, FFT workspaces, and cuFFT plan
             # buffers.  Empirically: 4096² uses ~756 MB/probe (5.6× raw
-            # wavefunction), 2048² uses ~147 MB/probe (4.4×).
+            # wavefunction), 2048² uses ~147 MB/probe (4.4×).  Those numbers
+            # hold for fast-radix grids; a grid length with a prime factor
+            # larger than 7 pushes cuFFT onto the Bluestein algorithm, whose
+            # power-of-two-padded internal buffers roughly double the
+            # transient footprint (observed >13× raw per probe on a
+            # 2623×2271 complex128 grid), so the factor is doubled there.
             #
             # estimate_potential_chunk_size runs at *computation* time, when
             # the probe batch is already resident; it sees the reduced free
             # memory and sizes the potential chunk to fit in what remains.
             # Both functions now use the same pool-aware effective_free so
             # the two estimates operate on a consistent VRAM picture.
+            from abtem.core.fft import is_fast_fft_size
+
+            overhead = 6
+            if not all(is_fast_fft_size(n) for n in gpts):
+                overhead = 12
+
             probe_budget = int(effective_free * 0.50)
-            per_probe_effective = max(1, int(per_probe_bytes * 6))
+            per_probe_effective = max(1, int(per_probe_bytes * overhead))
             n_probes = max(1, probe_budget // per_probe_effective)
             return _nearest_power_of_two(n_probes)
         except (ImportError, Exception):

--- a/abtem/core/fft.py
+++ b/abtem/core/fft.py
@@ -37,6 +37,90 @@ except ImportError:
     cp = None
 
 
+_FAST_FFT_PRIMES = (2, 3, 5, 7)
+
+
+def is_fast_fft_size(n: int) -> bool:
+    """
+    Whether an FFT of length ``n`` runs on fast radix kernels.
+
+    FFT libraries only ship optimized kernels for lengths whose prime factors
+    are small (2, 3, 5 and 7 are supported everywhere). A length with a larger
+    prime factor triggers a generic fallback -- on cuFFT the Bluestein
+    algorithm, which pads internally to a power of two, costing several times
+    the arithmetic and, on GPU, a workspace of several times the transform
+    size.
+
+    Parameters
+    ----------
+    n : int
+        The transform length.
+
+    Returns
+    -------
+    bool
+        True if ``n`` factorizes completely into 2, 3, 5 and 7.
+    """
+    n = int(n)
+    if n < 1:
+        return False
+    for p in _FAST_FFT_PRIMES:
+        while n % p == 0:
+            n //= p
+    return n == 1
+
+
+def next_fast_fft_size(n: int) -> int:
+    """
+    The smallest length >= ``n`` whose prime factors are all in {2, 3, 5, 7}.
+
+    Useful for choosing grid sizes (``gpts``) that avoid the slow
+    large-workspace Bluestein fallback on GPU.
+
+    Parameters
+    ----------
+    n : int
+        The minimum transform length.
+
+    Returns
+    -------
+    int
+        The next fast transform length.
+    """
+    n = max(1, int(n))
+    while not is_fast_fft_size(n):
+        n += 1
+    return n
+
+
+_warned_slow_fft_shapes: set = set()
+
+# Bluestein overhead only matters for large transforms; small odd-sized arrays
+# (e.g. interpolated measurements) are not worth a warning.
+_SLOW_FFT_WARN_MIN_ELEMENTS = 1024 * 1024
+
+
+def _warn_slow_fft_size(shape):
+    """Warn once per large 2D transform shape whose lengths force Bluestein."""
+    dims = tuple(int(n) for n in shape[-2:])
+    if len(dims) < 2 or dims in _warned_slow_fft_shapes:
+        return
+    _warned_slow_fft_shapes.add(dims)
+    if dims[0] * dims[1] < _SLOW_FFT_WARN_MIN_ELEMENTS:
+        return
+    if all(is_fast_fft_size(n) for n in dims):
+        return
+    suggestion = " x ".join(str(next_fast_fft_size(n)) for n in dims)
+    warnings.warn(
+        f"FFT size {dims[0]} x {dims[1]} contains prime factors larger than 7; "
+        "cuFFT falls back to the Bluestein algorithm, which is several times "
+        "slower and allocates a workspace of several times the array size. "
+        f"Consider adjusting the grid to {suggestion}, e.g. by setting gpts "
+        "explicitly instead of the sampling.",
+        UserWarning,
+    )
+
+
 def _raise_fft_lib_not_present(lib_name: str):
     raise RuntimeError(
         f"FFT library {lib_name} not present. Install this package or change the FFT"
@@ -262,6 +346,7 @@ def _fft_dispatch(
 
     if isinstance(x, cp.ndarray):
         _configure_cufft_cache()
+        _warn_slow_fft_size(x.shape)
         return getattr(cp.fft, func_name)(x, **kwargs)
 
 

--- a/abtem/core/fft.py
+++ b/abtem/core/fft.py
@@ -290,20 +290,31 @@ def _configure_cufft_cache():
                      Plans are reused for repeated same-shape transforms but the
                      total persistent workspace is bounded.
     * ``-1``       — unlimited (CuPy default, plans cached indefinitely).
+    * ``auto``     — 25 % of the device's total memory, resolved per device.
 
-    The abTEM default is ``2 GB``: enough to keep the plans of a typical
-    multislice hot, while bounding the workspace retained by plans for
-    Bluestein-fallback transform sizes, which can otherwise accumulate to
-    tens of GB across the distinct batch shapes of a scan.
+    The abTEM default is ``auto``. The bound must scale with the card: batch
+    auto-sizing targets ~8 % of VRAM per batch and the live plan workspace is
+    ~1x the batch bytes on fast-radix shapes (~2x on Bluestein shapes), so the
+    live working set of a production scan is ~10-17 % of VRAM on any card — a
+    fixed byte bound either evicts live plans on large cards (a flat 2 GB was
+    measured to cost ~7 % on a 40 GB A100) or is needlessly tight on small
+    ones. 25 % clears the live set with margin, while still capping the stale
+    workspace an unlimited cache accumulates across the distinct batch shapes
+    of successive computations. The limit is a ceiling, not a reservation —
+    unused headroom costs no memory.
     """
     global _CUFFT_CACHE_STATE
-    raw = config.get("cupy.fft-cache-size", "2 GB")
+    raw = config.get("cupy.fft-cache-size", "auto")
 
-    # Fast path: config hasn't changed since we last applied it.
-    if _CUFFT_CACHE_STATE is not None and _CUFFT_CACHE_STATE[0] == raw:
+    # The plan cache and the resolved "auto" limit are per device, so the
+    # applied state is keyed on the current device as well as the raw value.
+    device = cp.cuda.Device()
+    if _CUFFT_CACHE_STATE is not None and _CUFFT_CACHE_STATE[0] == (raw, device.id):
         return
 
-    if isinstance(raw, str):
+    if raw == "auto":
+        limit = device.mem_info[1] // 4
+    elif isinstance(raw, str):
         from dask.utils import parse_bytes
         limit = parse_bytes(raw)
     else:
@@ -316,7 +327,7 @@ def _configure_cufft_cache():
         cache.set_memsize(limit)
     # limit < 0 → leave at CuPy default (unlimited)
 
-    _CUFFT_CACHE_STATE = (raw, limit)
+    _CUFFT_CACHE_STATE = ((raw, device.id), limit)
 
 
 def _fft_dispatch(

--- a/abtem/core/fft.py
+++ b/abtem/core/fft.py
@@ -330,6 +330,53 @@ def _configure_cufft_cache():
     _CUFFT_CACHE_STATE = ((raw, device.id), limit)
 
 
+_warned_plan_cache_bypass = False
+
+
+def _cupy_fft_with_cache_fallback(func, x, **kwargs):
+    """Run a CuPy FFT, bypassing the plan cache for oversized plans.
+
+    A bounded plan cache refuses to admit a single plan larger than its
+    memsize bound, and CuPy raises instead of running the transform uncached
+    (CUDA only; the ROCm path does not track plan memsize). Retry such calls
+    with the cache temporarily disabled: the plan is built, used and
+    discarded, costing replanning time per call instead of a crash.
+    """
+    global _warned_plan_cache_bypass
+    try:
+        return func(x, **kwargs)
+    except RuntimeError as exc:
+        if "plan memsize is too large" not in str(exc).lower():
+            raise
+    cache = cp.fft.config.get_plan_cache()
+    size = cache.get_size()
+    memsize = cache.get_memsize()
+    if not _warned_plan_cache_bypass:
+        _warned_plan_cache_bypass = True
+        # The exceeded bound is positive in practice (CuPy only raises the
+        # too-large error for bounded caches); guard the arithmetic anyway.
+        bound = f" of {memsize / 1e9:.1f} GB" if memsize > 0 else ""
+        suggested = f"{2 * memsize / 1e9:.0f} GB" if memsize > 0 else "32 GB"
+        warnings.warn(
+            f"A single cuFFT plan for shape {x.shape} exceeds the plan-cache "
+            f"bound{bound}; running the transform uncached, which replans on "
+            "every call for this shape. To avoid the replanning cost, either "
+            "raise the bound, e.g. abtem.config.set({'cupy.fft-cache-size': "
+            f"'{suggested}'"
+            "}) (-1 = unlimited), or reduce the wave-function batch size, "
+            "e.g. probe.scan(..., max_batch=8). Grid sizes with prime "
+            "factors larger than 7 (Bluestein fallback) make plans several "
+            "times larger -- an FFT-friendly gpts choice avoids this "
+            "entirely."
+        )
+    cache.set_size(0)
+    try:
+        return func(x, **kwargs)
+    finally:
+        cache.set_size(size)
+        cache.set_memsize(memsize)
+
+
 def _fft_dispatch(
     x: U,
     func_name: str,
@@ -363,7 +410,9 @@ def _fft_dispatch(
     if isinstance(x, cp.ndarray):
         _configure_cufft_cache()
         _warn_slow_fft_size(x.shape)
-        return getattr(cp.fft, func_name)(x, **kwargs)
+        return _cupy_fft_with_cache_fallback(
+            getattr(cp.fft, func_name), x, **kwargs
+        )
 
 
 @overload

--- a/abtem/core/fft.py
+++ b/abtem/core/fft.py
@@ -312,7 +312,9 @@ def _configure_cufft_cache():
     if _CUFFT_CACHE_STATE is not None and _CUFFT_CACHE_STATE[0] == (raw, device.id):
         return
 
-    if raw == "auto":
+    if raw is None:
+        limit = -1  # null = no bound, matching the sibling keys' convention
+    elif raw == "auto":
         limit = device.mem_info[1] // 4
     elif isinstance(raw, str):
         from dask.utils import parse_bytes
@@ -324,8 +326,16 @@ def _configure_cufft_cache():
     if limit == 0:
         cache.set_size(0)       # disable caching entirely
     elif limit > 0:
+        if cache.get_size() == 0:
+            cache.set_size(16)  # re-enable a previously disabled cache
         cache.set_memsize(limit)
-    # limit < 0 → leave at CuPy default (unlimited)
+    else:
+        # Explicitly restore "unlimited": an earlier bound (e.g. from the
+        # "auto" default) must be undoable at runtime -- the oversized-plan
+        # warning recommends exactly this.
+        if cache.get_size() == 0:
+            cache.set_size(16)
+        cache.set_memsize(-1)
 
     _CUFFT_CACHE_STATE = ((raw, device.id), limit)
 

--- a/abtem/core/fft.py
+++ b/abtem/core/fft.py
@@ -290,9 +290,14 @@ def _configure_cufft_cache():
                      Plans are reused for repeated same-shape transforms but the
                      total persistent workspace is bounded.
     * ``-1``       — unlimited (CuPy default, plans cached indefinitely).
+
+    The abTEM default is ``2 GB``: enough to keep the plans of a typical
+    multislice hot, while bounding the workspace retained by plans for
+    Bluestein-fallback transform sizes, which can otherwise accumulate to
+    tens of GB across the distinct batch shapes of a scan.
     """
     global _CUFFT_CACHE_STATE
-    raw = config.get("cupy.fft-cache-size", "0 MB")
+    raw = config.get("cupy.fft-cache-size", "2 GB")
 
     # Fast path: config hasn't changed since we last applied it.
     if _CUFFT_CACHE_STATE is not None and _CUFFT_CACHE_STATE[0] == raw:

--- a/abtem/multislice.py
+++ b/abtem/multislice.py
@@ -724,11 +724,18 @@ def multislice_and_detect(
         enabled=pbar, total=int(n_slices), leave=False, desc="multislice"
     )
 
-    waves_input = waves.copy()
+    # Keep a pristine reference to the incoming batch. It is only ever read:
+    # each potential configuration below works on its own copy, so no copy is
+    # needed here -- copying would just hold a redundant duplicate of the
+    # batch in memory for the whole loop (a full extra batch of VRAM on GPU).
+    waves_input = waves
 
     for potential_index, potential_configuration in _generate_potential_configurations(
         potential
     ):
+        # The incoming batch may be a task input shared with other tasks
+        # (e.g. frozen-phonon configurations partitioned across tasks), so the
+        # in-place multislice steps must operate on a copy.
         waves = waves_input.copy()
         exit_plane_index = 0
 

--- a/test/test_fft.py
+++ b/test/test_fft.py
@@ -1,0 +1,70 @@
+"""Tests for FFT helpers, in particular fast-radix transform-size handling."""
+
+import warnings
+
+import pytest
+
+from abtem.core.fft import (
+    _warn_slow_fft_size,
+    _warned_slow_fft_shapes,
+    is_fast_fft_size,
+    next_fast_fft_size,
+)
+
+
+@pytest.mark.parametrize(
+    "n, expected",
+    [
+        (1, True),
+        (2048, True),  # 2^11
+        (2625, True),  # 3 * 5^3 * 7
+        (2688, True),  # 2^7 * 3 * 7
+        (2304, True),  # 2^8 * 3^2
+        (2623, False),  # 43 * 61 -> Bluestein
+        (2271, False),  # 3 * 757 -> Bluestein
+        (11, False),
+        (0, False),
+    ],
+)
+def test_is_fast_fft_size(n, expected):
+    assert is_fast_fft_size(n) is expected
+
+
+@pytest.mark.parametrize(
+    "n, expected",
+    [
+        (1, 1),
+        (2048, 2048),  # already fast
+        (2623, 2625),  # 3 * 5^3 * 7
+        (2271, 2304),  # 2^8 * 3^2
+    ],
+)
+def test_next_fast_fft_size(n, expected):
+    assert next_fast_fft_size(n) == expected
+
+
+def test_warn_slow_fft_size_warns_once_per_shape():
+    _warned_slow_fft_shapes.clear()
+    with pytest.warns(UserWarning, match="Bluestein"):
+        _warn_slow_fft_size((4, 2623, 2271))
+    # memoized: the same shape does not warn again
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _warn_slow_fft_size((4, 2623, 2271))
+
+
+def test_warn_slow_fft_size_silent_for_fast_shapes():
+    _warned_slow_fft_shapes.clear()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _warn_slow_fft_size((256, 256))
+
+
+def test_warn_slow_fft_size_silent_for_small_shapes():
+    """Small transforms (e.g. interpolated measurements) never warn, even when
+    their lengths would force the Bluestein path."""
+    _warned_slow_fft_shapes.clear()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _warn_slow_fft_size((36, 29))
+        _warn_slow_fft_size((4, 11, 20))

--- a/test/test_fft.py
+++ b/test/test_fft.py
@@ -68,3 +68,30 @@ def test_warn_slow_fft_size_silent_for_small_shapes():
         warnings.simplefilter("error")
         _warn_slow_fft_size((36, 29))
         _warn_slow_fft_size((4, 11, 20))
+
+
+def test_cufft_cache_auto_resolves_device_relative():
+    cp = pytest.importorskip("cupy")
+    try:
+        if cp.cuda.runtime.getDeviceCount() < 1:
+            pytest.skip("no GPU available")
+    except Exception:
+        pytest.skip("no usable CUDA/HIP runtime")
+
+    from abtem.core import config
+    from abtem.core import fft as abtem_fft
+
+    expected = cp.cuda.Device().mem_info[1] // 4
+
+    abtem_fft._CUFFT_CACHE_STATE = None
+    with config.set({"cupy.fft-cache-size": "auto"}):
+        abtem_fft._configure_cufft_cache()
+        assert abtem_fft._CUFFT_CACHE_STATE is not None
+        assert abtem_fft._CUFFT_CACHE_STATE[1] == expected
+        assert cp.fft.config.get_plan_cache().get_memsize() == expected
+
+    # -1 must still mean unlimited (no memsize bound applied).
+    abtem_fft._CUFFT_CACHE_STATE = None
+    with config.set({"cupy.fft-cache-size": -1}):
+        abtem_fft._configure_cufft_cache()
+        assert abtem_fft._CUFFT_CACHE_STATE[1] == -1

--- a/test/test_fft.py
+++ b/test/test_fft.py
@@ -131,3 +131,48 @@ def test_unrelated_runtime_error_propagates():
 
     with pytest.raises(RuntimeError, match="something else"):
         abtem_fft._cupy_fft_with_cache_fallback(fake_fft, object())
+
+
+def test_cufft_cache_config_edge_values():
+    cp = pytest.importorskip("cupy")
+    try:
+        if cp.cuda.runtime.getDeviceCount() < 1:
+            pytest.skip("no GPU available")
+    except Exception:
+        pytest.skip("no usable CUDA/HIP runtime")
+
+    from abtem.core import config
+    from abtem.core import fft as abtem_fft
+
+    cache = cp.fft.config.get_plan_cache()
+
+    # -1 must undo an earlier bound (the oversized-plan warning recommends it).
+    abtem_fft._CUFFT_CACHE_STATE = None
+    with config.set({"cupy.fft-cache-size": "auto"}):
+        abtem_fft._configure_cufft_cache()
+        assert cache.get_memsize() > 0
+    abtem_fft._CUFFT_CACHE_STATE = None
+    with config.set({"cupy.fft-cache-size": -1}):
+        abtem_fft._configure_cufft_cache()
+        assert cache.get_memsize() == -1
+
+    # null means "no bound" rather than crashing.
+    abtem_fft._CUFFT_CACHE_STATE = None
+    with config.set({"cupy.fft-cache-size": None}):
+        abtem_fft._configure_cufft_cache()
+        assert cache.get_memsize() == -1
+
+    # A positive bound re-enables a previously disabled cache.
+    abtem_fft._CUFFT_CACHE_STATE = None
+    with config.set({"cupy.fft-cache-size": "0 MB"}):
+        abtem_fft._configure_cufft_cache()
+        assert cache.get_size() == 0
+    abtem_fft._CUFFT_CACHE_STATE = None
+    with config.set({"cupy.fft-cache-size": "1 GB"}):
+        abtem_fft._configure_cufft_cache()
+        assert cache.get_size() > 0
+        assert cache.get_memsize() == 10**9
+
+    # Restore the shipped default for subsequent tests.
+    abtem_fft._CUFFT_CACHE_STATE = None
+    abtem_fft._configure_cufft_cache()

--- a/test/test_fft.py
+++ b/test/test_fft.py
@@ -95,3 +95,39 @@ def test_cufft_cache_auto_resolves_device_relative():
     with config.set({"cupy.fft-cache-size": -1}):
         abtem_fft._configure_cufft_cache()
         assert abtem_fft._CUFFT_CACHE_STATE[1] == -1
+
+
+def test_oversized_plan_bypasses_cache():
+    cp = pytest.importorskip("cupy")
+
+    from abtem.core import fft as abtem_fft
+
+    calls = []
+
+    def fake_fft(x, **kwargs):
+        calls.append(cp.fft.config.get_plan_cache().get_size())
+        if len(calls) == 1:
+            raise RuntimeError("The plan memsize is too large.")
+        return x
+
+    abtem_fft._warned_plan_cache_bypass = False
+    x = cp.zeros((2, 8, 8), dtype="complex64")
+    with pytest.warns(UserWarning, match="uncached"):
+        out = abtem_fft._cupy_fft_with_cache_fallback(fake_fft, x)
+
+    assert out is x
+    assert len(calls) == 2
+    assert calls[1] == 0  # the retry ran with the cache disabled
+    assert cp.fft.config.get_plan_cache().get_size() > 0  # and it was restored
+
+
+def test_unrelated_runtime_error_propagates():
+    pytest.importorskip("cupy")
+
+    from abtem.core import fft as abtem_fft
+
+    def fake_fft(x, **kwargs):
+        raise RuntimeError("something else entirely")
+
+    with pytest.raises(RuntimeError, match="something else"):
+        abtem_fft._cupy_fft_with_cache_fallback(fake_fft, object())

--- a/test/test_multigpu_logic.py
+++ b/test/test_multigpu_logic.py
@@ -513,6 +513,16 @@ def test_workers_see_identical_config():
             for snapshot in client.run(_worker_config_snapshot).values():
                 assert snapshot == client_config_dict
 
+            # The snapshot travels as a named worker plugin, so workers that
+            # join later (or are restarted by a Nanny) also receive it.
+            plugins = client.run(lambda dask_worker: list(dask_worker.plugins))
+            assert all("abtem-config" in names for names in plugins.values())
+
+            cluster.scale(2)
+            client.wait_for_workers(2)
+            for snapshot in client.run(_worker_config_snapshot).values():
+                assert snapshot == client_config_dict
+
             # A subsequent change must invalidate the push token and
             # propagate on the next dispatch.
             with config.set({"precision": "float32"}):
@@ -548,3 +558,22 @@ def test_forced_synchronous_scheduler_extends_to_nested_computes():
     with _nested_compute_guard({}):
         dask.compute(lazy, scheduler="synchronous")
     assert seen and all(s != "synchronous" for s in seen)
+
+
+def test_cpu_distributed_compute_pushes_config():
+    distributed = pytest.importorskip("distributed")
+    import numpy as np
+
+    from abtem.core import backend, config
+
+    backend._pushed_config_token = None
+    with distributed.LocalCluster(
+        n_workers=1, processes=True, threads_per_worker=1, dashboard_address=None
+    ) as cluster, distributed.Client(cluster) as client:
+        with config.set({"precision": "float64"}):
+            images = abtem.Images(
+                np.ones((8, 8), dtype=np.float32), sampling=1.0
+            ).ensure_lazy()
+            images.compute(progress_bar=False)
+
+            assert set(client.run(_worker_precision).values()) == {"float64"}

--- a/test/test_multigpu_logic.py
+++ b/test/test_multigpu_logic.py
@@ -1,8 +1,9 @@
 """Logic tests for abTEM's multi-GPU support that need no real multi-GPU hardware.
 
 Covers the client-suitability check, the memoized cluster lifecycle, and the
-scheduler-selection branches of ``_compute`` -- via mocks / a threaded CPU
-cluster -- so the behaviour is exercised on ordinary (single-GPU or CPU) CI.
+GPU execution-context resolution shared by ``_compute`` and the ``to_zarr``
+save path -- via mocks / a threaded CPU cluster -- so the behaviour is
+exercised on ordinary (single-GPU or CPU) CI.
 """
 
 import sys
@@ -210,33 +211,126 @@ def test_explicit_scheduler_skips_cluster(monkeypatch):
 
 
 # --------------------------------------------------------------------------
-# _gpu_scheduler_guard  (nested-compute guard, reconciled with #269's to_zarr)
+# _resolve_gpu_scheduler  (shared by ArrayObject.compute and the save paths)
 # --------------------------------------------------------------------------
 
 
-def test_gpu_scheduler_guard_cpu_no_override():
-    import dask
-
-    before = dask.config.get("scheduler", None)
-    with abtem.array._gpu_scheduler_guard(False):
-        assert dask.config.get("scheduler", None) == before  # untouched on CPU
+def _patch_no_cupy_check(monkeypatch):
+    monkeypatch.setattr(abtem.array, "check_cupy_is_installed", lambda: None)
 
 
-def test_gpu_scheduler_guard_no_client_forces_synchronous(monkeypatch):
-    import dask
+def test_resolve_gpu_scheduler_no_client_forces_synchronous(monkeypatch):
     import distributed
 
+    _patch_no_cupy_check(monkeypatch)
     monkeypatch.setattr(distributed, "get_client", _no_client)
-    with abtem.array._gpu_scheduler_guard(True):
-        assert dask.config.get("scheduler", None) == "synchronous"
+    with abtem.config.set({"dask.multi-gpu": False}):
+        kwargs = abtem.array._resolve_gpu_scheduler({})
+    assert kwargs.get("scheduler") == "synchronous"
 
 
-def test_gpu_scheduler_guard_cuda_client_not_forced(monkeypatch):
-    import dask
+def test_resolve_gpu_scheduler_cuda_client_left_in_charge(monkeypatch):
     import distributed
 
-    monkeypatch.setattr(distributed, "get_client", lambda *a, **k: mock.Mock(status="running"))
+    _patch_no_cupy_check(monkeypatch)
+    monkeypatch.setattr(
+        distributed, "get_client", lambda *a, **k: mock.Mock(status="running")
+    )
     monkeypatch.setattr(abtem.array, "is_gpu_dask_client", lambda c: True)
-    with abtem.array._gpu_scheduler_guard(True):
-        # a suitable dask-cuda client is left to distribute; not forced synchronous
-        assert dask.config.get("scheduler", None) != "synchronous"
+    kwargs = abtem.array._resolve_gpu_scheduler({})
+    assert "scheduler" not in kwargs
+
+
+def test_resolve_gpu_scheduler_explicit_scheduler_untouched(monkeypatch):
+    import distributed
+
+    _patch_no_cupy_check(monkeypatch)
+    monkeypatch.setattr(distributed, "get_client", _no_client)
+    started = []
+    monkeypatch.setattr(abtem.array, "ensure_cuda_cluster", lambda: started.append(1))
+    with abtem.config.set({"dask.multi-gpu": True}):
+        kwargs = abtem.array._resolve_gpu_scheduler({"scheduler": "synchronous"})
+    assert started == []  # user asked for a scheduler -> no cluster spun up
+    assert kwargs["scheduler"] == "synchronous"
+
+
+def test_resolve_gpu_scheduler_starts_cluster(monkeypatch):
+    import distributed
+
+    _patch_no_cupy_check(monkeypatch)
+    monkeypatch.setattr(distributed, "get_client", _no_client)
+    fake_client = mock.Mock(status="running")
+    started = []
+    monkeypatch.setattr(
+        abtem.array,
+        "ensure_cuda_cluster",
+        lambda: (started.append(1), fake_client)[1],
+    )
+    monkeypatch.setattr(abtem.array, "is_gpu_dask_client", lambda c: c is fake_client)
+    fake_cp = mock.Mock()
+    fake_cp.cuda.runtime.getDeviceCount.return_value = 2
+    monkeypatch.setattr(abtem.array, "cp", fake_cp)
+    with abtem.config.set({"dask.multi-gpu": True}):
+        kwargs = abtem.array._resolve_gpu_scheduler({})
+    assert started == [1]
+    assert "scheduler" not in kwargs  # the cluster client is left in charge
+
+
+# --------------------------------------------------------------------------
+# to_zarr resolves the GPU execution context (the save path must distribute
+# like .compute() does; previously it silently forced single-GPU synchronous
+# and never consulted dask.multi-gpu)
+# --------------------------------------------------------------------------
+
+
+def _build_lazy_cpu():
+    return abtem.Probe(energy=100e3, semiangle_cutoff=20, gpts=32, extent=5).build(
+        lazy=True
+    )
+
+
+def test_to_zarr_starts_cluster_when_multigpu(monkeypatch, tmp_path):
+    import distributed
+
+    _patch_no_cupy_check(monkeypatch)
+    monkeypatch.setattr(distributed, "get_client", _no_client)
+    started = []
+    monkeypatch.setattr(
+        abtem.array,
+        "ensure_cuda_cluster",
+        lambda: (started.append(1), mock.Mock(status="running"))[1],
+    )
+    # Report the (mock) cluster unsuitable so the write still runs on the
+    # local synchronous scheduler with the actually-CPU-backed test arrays.
+    monkeypatch.setattr(abtem.array, "is_gpu_dask_client", lambda c: False)
+    fake_cp = mock.Mock()
+    fake_cp.cuda.runtime.getDeviceCount.return_value = 2
+    monkeypatch.setattr(abtem.array, "cp", fake_cp)
+
+    waves = _build_lazy_cpu()
+    with abtem.config.set({"device": "gpu", "dask.multi-gpu": True}):
+        waves.to_zarr(str(tmp_path / "waves.zarr"), progress_bar=False)
+    assert started == [1]
+    assert (tmp_path / "waves.zarr").exists()
+
+
+def test_to_zarr_roundtrip_cpu(tmp_path):
+    waves = _build_lazy_cpu()
+    url = str(tmp_path / "waves.zarr")
+    waves.to_zarr(url, progress_bar=False)
+    loaded = abtem.from_zarr(url)
+    import numpy as np
+
+    np.testing.assert_allclose(
+        loaded.compute().array, waves.compute().array, rtol=1e-6
+    )
+
+
+def test_to_zarr_compute_false_returns_delayed(tmp_path):
+    from dask.delayed import Delayed
+
+    waves = _build_lazy_cpu()
+    delayed = waves.to_zarr(str(tmp_path / "waves.zarr"), compute=False)
+    assert isinstance(delayed, Delayed)
+    delayed.compute()
+    assert (tmp_path / "waves.zarr").exists()

--- a/test/test_multigpu_logic.py
+++ b/test/test_multigpu_logic.py
@@ -451,3 +451,72 @@ def test_to_zarr_compute_false_returns_delayed(tmp_path):
     assert isinstance(delayed, Delayed)
     delayed.compute()
     assert (tmp_path / "waves.zarr").exists()
+
+
+def _worker_precision():
+    from abtem.core import config
+
+    return config.get("precision")
+
+
+def test_push_config_to_workers():
+    distributed = pytest.importorskip("distributed")
+
+    from abtem.core import config
+    from abtem.core import backend
+
+    backend._pushed_config_token = None
+    with distributed.LocalCluster(
+        n_workers=1, processes=True, threads_per_worker=1, dashboard_address=None
+    ) as cluster, distributed.Client(cluster) as client:
+        assert set(client.run(_worker_precision).values()) == {"float32"}
+
+        with config.set({"precision": "float64"}):
+            backend.push_config_to_workers(client)
+            assert set(client.run(_worker_precision).values()) == {"float64"}
+
+            # An unchanged configuration is not pushed again.
+            token = backend._pushed_config_token
+            backend.push_config_to_workers(client)
+            assert backend._pushed_config_token is token
+
+
+def _worker_config_snapshot():
+    import copy
+
+    from abtem.core.config import config as config_dict
+
+    return copy.deepcopy(config_dict)
+
+
+def test_workers_see_identical_config():
+    distributed = pytest.importorskip("distributed")
+
+    from abtem.core import backend, config
+    from abtem.core.config import config as client_config_dict
+
+    backend._pushed_config_token = None
+    with distributed.LocalCluster(
+        n_workers=2, processes=True, threads_per_worker=1, dashboard_address=None
+    ) as cluster, distributed.Client(cluster) as client:
+        with config.set(
+            {
+                "precision": "float64",
+                "cupy.fft-cache-size": "3 GB",
+                "potential.slice-chunk-size": 7,
+            }
+        ):
+            backend.push_config_to_workers(client)
+
+            # Every worker must hold a config identical to the client's merged
+            # configuration -- not just the keys we changed.
+            for snapshot in client.run(_worker_config_snapshot).values():
+                assert snapshot == client_config_dict
+
+            # A subsequent change must invalidate the push token and
+            # propagate on the next dispatch.
+            with config.set({"precision": "float32"}):
+                backend.push_config_to_workers(client)
+                for snapshot in client.run(_worker_config_snapshot).values():
+                    assert snapshot == client_config_dict
+                    assert snapshot["precision"] == "float32"

--- a/test/test_multigpu_logic.py
+++ b/test/test_multigpu_logic.py
@@ -113,6 +113,36 @@ def test_ensure_cuda_cluster_requires_dask_cuda(monkeypatch):
         backend.ensure_cuda_cluster()
 
 
+def test_ensure_cuda_cluster_explains_missing_main_guard(monkeypatch):
+    """The cryptic multiprocessing spawn error is translated into guidance."""
+    monkeypatch.setattr(backend, "_cuda_cluster_client", None)
+
+    def raise_bootstrapping(self, **kwargs):
+        raise RuntimeError(
+            "An attempt has been made to start a new process before the "
+            "current process has finished its bootstrapping phase."
+        )
+
+    m = types.ModuleType("dask_cuda")
+    m.LocalCUDACluster = type("LocalCUDACluster", (), {"__init__": raise_bootstrapping})
+    monkeypatch.setitem(sys.modules, "dask_cuda", m)
+    with pytest.raises(RuntimeError, match="__main__"):
+        backend.ensure_cuda_cluster()
+
+
+def test_ensure_cuda_cluster_reraises_other_runtime_errors(monkeypatch):
+    monkeypatch.setattr(backend, "_cuda_cluster_client", None)
+
+    def raise_other(self, **kwargs):
+        raise RuntimeError("something else entirely")
+
+    m = types.ModuleType("dask_cuda")
+    m.LocalCUDACluster = type("LocalCUDACluster", (), {"__init__": raise_other})
+    monkeypatch.setitem(sys.modules, "dask_cuda", m)
+    with pytest.raises(RuntimeError, match="something else entirely"):
+        backend.ensure_cuda_cluster()
+
+
 # --------------------------------------------------------------------------
 # _compute scheduler selection on the GPU path  (needs cupy to build gpu meta)
 # --------------------------------------------------------------------------

--- a/test/test_multigpu_logic.py
+++ b/test/test_multigpu_logic.py
@@ -520,3 +520,31 @@ def test_workers_see_identical_config():
                 for snapshot in client.run(_worker_config_snapshot).values():
                     assert snapshot == client_config_dict
                     assert snapshot["precision"] == "float32"
+
+
+def test_forced_synchronous_scheduler_extends_to_nested_computes():
+    import dask
+    import dask.array as da
+    import numpy as np
+
+    from abtem.array import _nested_compute_guard
+
+    seen = []
+
+    def record(x):
+        seen.append(dask.config.get("scheduler", None))
+        return x
+
+    lazy = da.from_array(np.ones(2), chunks=1).map_blocks(record)
+    seen.clear()  # map_blocks meta-inference ran `record` once at build time
+
+    with _nested_compute_guard({"scheduler": "synchronous"}):
+        dask.compute(lazy)
+    assert set(seen) == {"synchronous"}
+
+    # The motivating gap: the kwargs route alone does not reach the config a
+    # nested compute would read.
+    seen.clear()
+    with _nested_compute_guard({}):
+        dask.compute(lazy, scheduler="synchronous")
+    assert seen and all(s != "synchronous" for s in seen)

--- a/test/test_multigpu_logic.py
+++ b/test/test_multigpu_logic.py
@@ -113,6 +113,43 @@ def test_ensure_cuda_cluster_requires_dask_cuda(monkeypatch):
         backend.ensure_cuda_cluster()
 
 
+def _fake_dask_cuda_capturing(captured):
+    m = types.ModuleType("dask_cuda")
+
+    def init(self, **kwargs):
+        captured.update(kwargs)
+
+    m.LocalCUDACluster = type("LocalCUDACluster", (), {"__init__": init})
+    return m
+
+
+def test_ensure_cuda_cluster_forwards_rmm_pool_and_devices(monkeypatch):
+    monkeypatch.setattr(backend, "_cuda_cluster_client", None)
+    captured = {}
+    monkeypatch.setitem(sys.modules, "dask_cuda", _fake_dask_cuda_capturing(captured))
+    monkeypatch.setattr(
+        "distributed.Client", lambda cluster: mock.Mock(status="running")
+    )
+    with abtem.config.set(
+        {"dask.multi-gpu-rmm-pool": "20 GB", "dask.multi-gpu-devices": [0, 2]}
+    ):
+        backend.ensure_cuda_cluster()
+    assert captured.get("rmm_pool_size") == "20 GB"
+    assert captured.get("CUDA_VISIBLE_DEVICES") == "0,2"
+
+
+def test_ensure_cuda_cluster_defaults_omit_optional_kwargs(monkeypatch):
+    monkeypatch.setattr(backend, "_cuda_cluster_client", None)
+    captured = {}
+    monkeypatch.setitem(sys.modules, "dask_cuda", _fake_dask_cuda_capturing(captured))
+    monkeypatch.setattr(
+        "distributed.Client", lambda cluster: mock.Mock(status="running")
+    )
+    backend.ensure_cuda_cluster()
+    assert "rmm_pool_size" not in captured
+    assert "CUDA_VISIBLE_DEVICES" not in captured
+
+
 def test_ensure_cuda_cluster_explains_missing_main_guard(monkeypatch):
     """The cryptic multiprocessing spawn error is translated into guidance."""
     monkeypatch.setattr(backend, "_cuda_cluster_client", None)

--- a/test/test_multigpu_logic.py
+++ b/test/test_multigpu_logic.py
@@ -276,6 +276,55 @@ def test_resolve_gpu_scheduler_starts_cluster(monkeypatch):
     assert "scheduler" not in kwargs  # the cluster client is left in charge
 
 
+def test_resolve_gpu_scheduler_warns_when_single_gpu(monkeypatch):
+    import distributed
+
+    _patch_no_cupy_check(monkeypatch)
+    monkeypatch.setattr(distributed, "get_client", _no_client)
+    started = []
+    monkeypatch.setattr(abtem.array, "ensure_cuda_cluster", lambda: started.append(1))
+    fake_cp = mock.Mock()
+    fake_cp.cuda.runtime.getDeviceCount.return_value = 1
+    monkeypatch.setattr(abtem.array, "cp", fake_cp)
+    with abtem.config.set({"dask.multi-gpu": True}):
+        with pytest.warns(UserWarning, match="only one GPU"):
+            kwargs = abtem.array._resolve_gpu_scheduler({})
+    assert started == []  # declined; and no longer silently
+    assert kwargs["scheduler"] == "synchronous"
+
+
+def test_resolve_gpu_scheduler_warns_on_unsuitable_client(monkeypatch):
+    import distributed
+
+    _patch_no_cupy_check(monkeypatch)
+    monkeypatch.setattr(
+        distributed, "get_client", lambda *a, **k: mock.Mock(status="running")
+    )
+    monkeypatch.setattr(abtem.array, "is_gpu_dask_client", lambda c: False)
+    with abtem.config.set({"dask.multi-gpu": True}):
+        with pytest.warns(UserWarning, match="not a single-threaded"):
+            kwargs = abtem.array._resolve_gpu_scheduler({})
+    assert kwargs["scheduler"] == "synchronous"
+
+
+# --------------------------------------------------------------------------
+# get_cuda_cluster_client  (public, side-effect-free accessor)
+# --------------------------------------------------------------------------
+
+
+def test_get_cuda_cluster_client_returns_running(monkeypatch):
+    running = mock.Mock(status="running")
+    monkeypatch.setattr(backend, "_cuda_cluster_client", running)
+    assert backend.get_cuda_cluster_client() is running
+
+
+def test_get_cuda_cluster_client_none_when_absent_or_dead(monkeypatch):
+    monkeypatch.setattr(backend, "_cuda_cluster_client", None)
+    assert backend.get_cuda_cluster_client() is None
+    monkeypatch.setattr(backend, "_cuda_cluster_client", mock.Mock(status="closed"))
+    assert backend.get_cuda_cluster_client() is None
+
+
 # --------------------------------------------------------------------------
 # to_zarr resolves the GPU execution context (the save path must distribute
 # like .compute() does; previously it silently forced single-GPU synchronous
@@ -289,6 +338,7 @@ def _build_lazy_cpu():
     )
 
 
+@pytest.mark.filterwarnings("ignore")
 def test_to_zarr_starts_cluster_when_multigpu(monkeypatch, tmp_path):
     import distributed
 

--- a/test/test_multigpu_logic.py
+++ b/test/test_multigpu_logic.py
@@ -467,7 +467,7 @@ def test_push_config_to_workers():
 
     backend._pushed_config_token = None
     with distributed.LocalCluster(
-        n_workers=1, processes=True, threads_per_worker=1, dashboard_address=None
+        n_workers=1, processes=True, threads_per_worker=1, dashboard_address=":0"
     ) as cluster, distributed.Client(cluster) as client:
         assert set(client.run(_worker_precision).values()) == {"float32"}
 
@@ -497,7 +497,7 @@ def test_workers_see_identical_config():
 
     backend._pushed_config_token = None
     with distributed.LocalCluster(
-        n_workers=2, processes=True, threads_per_worker=1, dashboard_address=None
+        n_workers=2, processes=True, threads_per_worker=1, dashboard_address=":0"
     ) as cluster, distributed.Client(cluster) as client:
         with config.set(
             {
@@ -568,7 +568,7 @@ def test_cpu_distributed_compute_pushes_config():
 
     backend._pushed_config_token = None
     with distributed.LocalCluster(
-        n_workers=1, processes=True, threads_per_worker=1, dashboard_address=None
+        n_workers=1, processes=True, threads_per_worker=1, dashboard_address=":0"
     ) as cluster, distributed.Client(cluster) as client:
         with config.set({"precision": "float64"}):
             images = abtem.Images(

--- a/test/test_multislice_input.py
+++ b/test/test_multislice_input.py
@@ -1,0 +1,38 @@
+"""The multislice loop must never mutate the wave functions passed to it.
+
+The input batch may be a dask task input shared with other tasks (e.g. when
+frozen-phonon configurations are partitioned across tasks), so
+multislice_and_detect works on per-configuration copies. These tests pin that
+invariant so the copies can be kept to the minimum (one per configuration,
+no additional pristine duplicate of the batch).
+"""
+
+import numpy as np
+from ase.build import bulk
+
+import abtem
+
+
+def _probe_waves(potential):
+    probe = abtem.Probe(energy=100e3, semiangle_cutoff=20)
+    probe.grid.match(potential)
+    return probe.build(lazy=False)
+
+
+def test_multislice_does_not_mutate_input_waves():
+    atoms = bulk("Si", cubic=True) * (1, 1, 2)
+    potential = abtem.Potential(atoms, gpts=(32, 32), slice_thickness=2)
+    waves = _probe_waves(potential)
+    before = waves.array.copy()
+    waves.multislice(potential)
+    np.testing.assert_array_equal(waves.array, before)
+
+
+def test_multislice_does_not_mutate_input_waves_frozen_phonons():
+    atoms = bulk("Si", cubic=True) * (1, 1, 2)
+    phonons = abtem.FrozenPhonons(atoms, num_configs=2, sigmas=0.1, seed=13)
+    potential = abtem.Potential(phonons, gpts=(32, 32), slice_thickness=2)
+    waves = _probe_waves(potential)
+    before = waves.array.copy()
+    waves.multislice(potential)
+    np.testing.assert_array_equal(waves.array, before)

--- a/test/test_potential_chunking.py
+++ b/test/test_potential_chunking.py
@@ -1,12 +1,19 @@
 """Tests verifying that potential chunking does not affect numerical results."""
 
+import sys
+import types
+
 import numpy as np
 import pytest
 from ase.build import bulk
 
 from abtem import PlaneWave, Potential
 from abtem.core import config as abtem_config
-from abtem.core.chunks import _nearest_power_of_two, estimate_potential_chunk_size
+from abtem.core.chunks import (
+    _nearest_power_of_two,
+    estimate_potential_chunk_size,
+    estimate_scan_batch_size,
+)
 from abtem.core.complex import complex_exponential
 from abtem.potentials.iam import CrystalPotential, PotentialArray
 
@@ -64,6 +71,47 @@ class TestEstimatePotentialChunkSize:
         small = estimate_potential_chunk_size((64, 64), device="cpu")
         large = estimate_potential_chunk_size((512, 512), device="cpu")
         assert large <= small
+
+
+def _install_fake_cupy(monkeypatch, free, total, pool_used=0):
+    """Install a minimal cupy stand-in exposing the memory-probing API."""
+    fake = types.ModuleType("cupy")
+    fake.get_default_memory_pool = lambda: types.SimpleNamespace(
+        used_bytes=lambda: pool_used
+    )
+    fake.cuda = types.SimpleNamespace(
+        Device=lambda: types.SimpleNamespace(mem_info=(free, total))
+    )
+    monkeypatch.setitem(sys.modules, "cupy", fake)
+
+
+class TestEstimateScanBatchSize:
+    """Unit tests for the VRAM-aware scan-batch estimator (GPU path mocked)."""
+
+    def test_fast_radix_grid(self, monkeypatch):
+        _install_fake_cupy(monkeypatch, free=40_000_000_000, total=40_000_000_000)
+        # budget = 20 GB; per probe = 2048² x 16 B x 6 -> 49 probes -> pow2 32
+        assert estimate_scan_batch_size((2048, 2048), np.complex128, "gpu") == 32
+
+    def test_bluestein_grid_uses_doubled_overhead(self, monkeypatch):
+        _install_fake_cupy(monkeypatch, free=40_000_000_000, total=40_000_000_000)
+        # 2623 = 43*61 and 2271 = 3*757 force the Bluestein FFT fallback;
+        # per probe = 2623*2271 x 16 B x 12 -> 17 probes -> pow2 16.
+        # (The 6x factor would have given 34 -> 32.)
+        assert estimate_scan_batch_size((2623, 2271), np.complex128, "gpu") == 16
+
+    def test_pool_usage_reduces_batch(self, monkeypatch):
+        _install_fake_cupy(
+            monkeypatch,
+            free=40_000_000_000,
+            total=40_000_000_000,
+            pool_used=30_000_000_000,
+        )
+        # effective free = min(free, total - pool_used) = 10 GB -> budget 5 GB
+        assert estimate_scan_batch_size((2048, 2048), np.complex128, "gpu") <= 16
+
+    def test_cpu_falls_back_to_chunk_size(self):
+        assert estimate_scan_batch_size((2048, 2048), np.complex128, "cpu") >= 1
 
 
 class TestChunkedSlicesCorrectness:

--- a/test/test_potential_chunking.py
+++ b/test/test_potential_chunking.py
@@ -54,6 +54,18 @@ class TestNearestPowerOfTwo:
         assert _nearest_power_of_two(n) == expected
 
 
+def _install_fake_cupy(monkeypatch, free, total, pool_used=0):
+    """Install a minimal cupy stand-in exposing the memory-probing API."""
+    fake = types.ModuleType("cupy")
+    fake.get_default_memory_pool = lambda: types.SimpleNamespace(
+        used_bytes=lambda: pool_used
+    )
+    fake.cuda = types.SimpleNamespace(
+        Device=lambda: types.SimpleNamespace(mem_info=(free, total))
+    )
+    monkeypatch.setitem(sys.modules, "cupy", fake)
+
+
 class TestEstimatePotentialChunkSize:
     """Unit tests for estimate_potential_chunk_size."""
 
@@ -72,17 +84,23 @@ class TestEstimatePotentialChunkSize:
         large = estimate_potential_chunk_size((512, 512), device="cpu")
         assert large <= small
 
+    def test_gpu_chunk_size_depends_only_on_slice_bytes(self, monkeypatch):
+        """An FFT-unfriendly grid must not shrink the potential chunk.
 
-def _install_fake_cupy(monkeypatch, free, total, pool_used=0):
-    """Install a minimal cupy stand-in exposing the memory-probing API."""
-    fake = types.ModuleType("cupy")
-    fake.get_default_memory_pool = lambda: types.SimpleNamespace(
-        used_bytes=lambda: pool_used
-    )
-    fake.cuda = types.SimpleNamespace(
-        Device=lambda: types.SimpleNamespace(mem_info=(free, total))
-    )
-    monkeypatch.setitem(sys.modules, "cupy", fake)
+        Unlike the probe batch, potential slices are built and bandlimited one
+        at a time, so the Bluestein workspace is constant in the chunk size --
+        see the comment in ``estimate_potential_chunk_size``.  2623 = 43*61 and
+        2271 = 3*757 force the Bluestein fallback; 2625 = 3*5^3*7 and
+        2268 = 2^2*3^4*7 do not, and the two grids differ in area by 0.06 %.
+        Both must give the same chunk, fixed by bytes alone:
+        int(0.35 * 40 GB / (2623*2271*4 * 5)) = 117.  A doubled overhead like
+        the one in ``estimate_scan_batch_size`` would give 58.
+        """
+        _install_fake_cupy(monkeypatch, free=40_000_000_000, total=40_000_000_000)
+        dtype = np.dtype(np.float32)
+        bluestein = estimate_potential_chunk_size((2623, 2271), "gpu", dtype)
+        fast = estimate_potential_chunk_size((2625, 2268), "gpu", dtype)
+        assert bluestein == fast == 117
 
 
 class TestEstimateScanBatchSize:


### PR DESCRIPTION
Hi!

While running a large HAADF simulation on Perlmutter with `dask.multi-gpu` enabled (introduced in PR #269), a 40 GB A100 OOM'ed after 24 seconds while three other GPUs sat idle. It turned out that saving a lazy result with `to_zarr()` never started the multi-GPU cluster. Instead the flag is silently ignored on that path and the whole scan runs serially on one GPU. A `compute()` before `to_zarr()` correctly used multiple GPUs and allowed the calculation to complete, but the user would expect that the `compute()` is not necessary in this case, since it is not necessary on single GPUs or CPUs. Claude and I traced this and a series of related problems, which this PR fixes, one commit per issue.

The overarching theme is making the default `to_zarr` path work, and making abTEM say what it is doing when it cannot:

- `to_zarr()` now distributes across GPUs exactly like `.compute()`
- the client's configuration now actually reaches the workers — previously `abtem.config.set` never did, so e.g. a float64 computation dispatched to workers silently ran in float32. This affects the existing compute path too, and is probably the most important fix in here
- more robust automatic VRAM handling: a more conservative batch estimate on FFT-unfriendly grids, a device-relative bound on the cuFFT plan cache (with a safe fallback for single plans bigger than the bound), and removal of a redundant copy of every wave batch in multislice
- warnings whenever abTEM falls back to something you did not ask for (multi-GPU requested but not used, a missing `__main__` guard, FFT-unfriendly grid sizes), plus config keys for an RMM pool and GPU subsets.

Everything is benchmarked in the description below: the workload that crashed in 24 seconds now completes in 13 minutes on 4 GPUs (or ~50 minutes on a single GPU), results are bit-identical between branches and consistent between execution modes, and there are no measured speed regressions.

Best,
Paul


---------------
# Claude's summary
Follow-up to #269's opt-in multi-GPU support. A production HAADF scan on a Perlmutter 4×A100 node crashed with `dask.multi-gpu: true`: saving the lazy result with `to_zarr()` silently ignored the flag, ran the entire scan on one GPU, and OOM'd it. This PR fixes that and everything else found while chasing it — one commit per issue, every claim benchmarked.

<details>
<summary><b>The original failure log</b> (Perlmutter, 4×A100 node — trimmed to the relevant frames)</summary>

The script follows the natural pattern — enable multi-GPU, build a scan, save the result:

```python
abtem.config.set({"device": "gpu", "precision": "float64", "dask.multi-gpu": True})

potential = abtem.Potential(atoms, sampling=0.05, slice_thickness=atoms.cell[2, 2] / 4)
probe = abtem.Probe(energy=60e3, semiangle_cutoff=31.5)
detector = abtem.AnnularDetector(inner=70, outer=220)
scan = abtem.GridScan(start=(0, 0), end=(1, 1), fractional=True, potential=potential)

measurement = probe.scan(potential, scan=scan, detectors=detector)
measurement.to_zarr(ostr)   # <-- never consults dask.multi-gpu
```

Despite four visible GPUs and the flag enabled, the whole scan ran serially on GPU 0 and exhausted it within seconds:

```text
Traceback (most recent call last):
  File ".../simscript.py", line 46, in main
    measurement.to_zarr(ostr)
  File "abtem/array.py", line 440, in to_zarr
    output = dask.compute(delayed_write, **kwargs)[0]
  ...
  File "abtem/multislice.py", line 732, in multislice_and_detect
    waves = waves_input.copy()
  ...
cupy.cuda.memory.OutOfMemoryError: Out of memory allocating 2,859,279,872 bytes
                                   (allocated so far: 41,337,662,976 bytes)

real    0m24.467s
```

Each ingredient of this crash maps to a commit below: the ignored flag, the oversized batches on an FFT-unfriendly grid, the redundant copy, the unbounded FFT plan cache — and the fact that nothing in the output hinted at any of it.

</details>

## What is fixed

### Correctness

- **`to_zarr()` now distributes.** The multi-GPU cluster bootstrap lived only in `.compute()`; `to_zarr()` on a lazy result forced the synchronous scheduler instead. It now computes through the same scheduler resolution as `.compute()` and writes the result eagerly (`compute=False` still returns the delayed write, unchanged; its nested compute runs under the caller's scheduler — documented in the docstring — so on GPU prefer `compute=True`).
- **Client configuration now reaches the workers.** dask-cuda workers spawn fresh and see only the yaml defaults; `abtem.config.set` in the client never reached them. Because abTEM resolves configuration inside tasks (`get_dtype` reads `precision` at call time), any distributed run with non-default configuration silently used the defaults — our float64 scans were actually computed in float32. The client's merged configuration is now pushed on every dispatch to **any** distributed client (the multi-GPU cluster or a user-provided CPU cluster), carried by a named worker plugin so that workers joining or restarting later receive it too. This bug predates the PR and affects the existing compute path on `dev` too.

### Automatic VRAM handling

- **More conservative batch sizing on FFT-unfriendly grids.** The 6× per-probe overhead estimate — per probe, on the wavefunction grid; the scan positions are the FFT batch dimension and play no part in it — was calibrated on fast-radix grids; on the Bluestein-fallback 2623×2271 grid the real footprint measured ~13×, so the auto-sized batches exhausted the card. Such grids now use 12×.
- **The cuFFT plan cache is bounded: `auto` = 25 % of device memory, per device** (was unlimited). Bluestein-grid plans are large — measured 11.0 GB for one complex128 16-probe batch, 7.2× the batch bytes — so unbounded retention across the several batch shapes of a scan wastes tens of GB. For a single plan larger than the bound, CuPy does not evict or degrade gracefully — it raises a hard `RuntimeError` ("the plan memsize is too large") that aborts the computation (CUDA only; the ROCm path does not track plan memsize). Such plans now run uncached instead, at replanning cost, with a `UserWarning` that names the shape, the bound, and both remedies (raise `cupy.fft-cache-size`, or reduce `max_batch`).
- **A redundant copy of every incoming wave batch in multislice is removed** — one full batch of VRAM saved per task. Results are unchanged (tested).

### Diagnostics and configuration

- abTEM now warns whenever it falls back to something the user did not ask for: multi-GPU requested but declined (with the reason), a missing `if __name__ == "__main__"` guard (dask-cuda spawns workers; the stock error is cryptic), and grid sizes that force cuFFT's slow Bluestein fallback (with a suggested fast size).
- Public `backend.get_cuda_cluster_client()` accessor; new config keys `dask.multi-gpu-rmm-pool` and `dask.multi-gpu-devices` forwarded to the cluster. The fft-size helpers commit is shared verbatim with #347 — whichever PR merges first, the other rebases clean.

## Behavior changes to weigh in review

1. The plan-cache default: `auto` = 25 % of device memory (was unlimited; `-1` restores it).
2. The 12× overhead factor halves auto-sized batches on Bluestein grids only.
3. New `UserWarning`s (multi-GPU declined; slow FFT grid; oversized plan run uncached).
4. Client configuration now reaches workers (any distributed client, not only the multi-GPU cluster) — distributed results change to what the user actually configured.

## Benchmarks

**The production workload** (101,871-position HAADF scan, 2623×2271 grid, float64) on a 40 GB A100 node:

| | 1 GPU | 4 GPUs |
|---|---|---|
| dev | **OOM after 24 s** | no path: `to_zarr()` stays serial; only a manual `.compute()` before saving distributes — and then **silently in float32** |
| this branch | completes: 3089 s | completes: **799 s (3.86×)** |

The 3.86× matches the compute path's previously validated 3.90× scaling — and is itself the end-to-end verification of the configuration fix: before it, distributed runs appeared "12.9× faster than serial", which is impossible at equal precision. Checksums are bit-identical between branches on every benchmark case, serial and distributed runs agree, and repeated runs reproduce within ±0.2 %.

**Everyday single-GPU scans are unaffected.** A100, shipped defaults, medians (run-to-run variance is a few percent):

| case | dev | this branch |
|---|---|---|
| GPU scan 336², 64 positions | 28.7 ms | 30.4 ms |
| GPU scan 2625×2304, 16 positions | 121.6 ms | 120.3 ms |
| GPU scan 2623×2271 (Bluestein), 16 positions | 174.3 ms | 174.0 ms |
| GPU to_zarr 336², 64 positions | 37.5 ms | 36.6 ms |
| CPU scan 336², 16 positions | 198.9 ms | 207.7 ms |
| CPU scan 2625×2304, 4 positions | 3869 ms | 3864 ms |

The same comparison on a local dev machine (AMD Radeon 8050S iGPU via CuPy/ROCm hipFFT; CPU = FFTW, single thread), same-session dev baseline, shipped defaults:

| case | dev | this branch |
|---|---|---|
| GPU scan 336², 64 positions | 55.6 ms | 48.6 ms |
| GPU scan 2625×2304, 16 positions | 1133 ms | 1127 ms |
| GPU scan 2623×2271 (Bluestein), 16 positions | 1519 ms | 1473 ms |
| GPU to_zarr 336², 64 positions | 58.1 ms | 54.0 ms |
| CPU scan 336², 16 positions | 129.9 ms | 123.5 ms |
| CPU scan 2625×2304, 4 positions | 2496 ms | 2477 ms |

Parity or better on every case (up to −13 %); the small-grid gains come from the removed batch copy. Result checksums are bit-identical between branches on both machines.

The plan-cache default was tuned by A/B measurement: an earlier flat 2 GB bound cost 6–8 % on the large fast-grid case by evicting its plans; the device-relative `auto` default restores parity (the 120.3 ms above).

## Testing

- Each commit carries unit tests; `test_multigpu_logic.py` includes process-cluster tests asserting every worker's configuration is identical to the client's (including workers added by scaling up), re-propagation after a change, config push on the CPU compute path, and that a forced synchronous scheduler reaches nested computes.
- Full battery (`test_array`, `test_waves`, `test_scan`, `test_measure`, `test_potential_chunking`, `test_multigpu*`, `test_fft`, `test_copy`, `test_import`): passing on CPU and on a single-GPU ROCm box; the known `test_realspace_multislice[gpu]` failures there pre-exist on unmodified `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)