### PR TITLE
Fast-FFT grid sizing: opt-in rounding, combined with commensurate auto-sampling from PR 274

### DIFF
--- a/abtem/bloch/dynamical.py
+++ b/abtem/bloch/dynamical.py
@@ -47,7 +47,7 @@ from abtem.core.constants import kappa
 from abtem.core.diagnostics import TqdmWrapper
 from abtem.core.energy import energy2sigma, energy2wavelength
 from abtem.core.ensemble import Ensemble, _wrap_with_array, unpack_blockwise_args
-from abtem.core.fft import fft_interpolate
+from abtem.core.fft import fft_interpolate, warn_if_slow_gpu_fft
 from abtem.core.grid import Grid
 from abtem.core.utils import CopyMixin, get_dtype
 from abtem.distributions import BaseDistribution, validate_distribution
@@ -282,6 +282,12 @@ def structure_factor_to_potential(
     """
     xp = get_array_module(structure_factor)
     structure_factor = structure_factor_1d_to_3d(structure_factor, hkl, gpts)
+    # Deliberately xp.fft rather than abtem.core.fft.ifftn: the FFTW backend
+    # behind that wrapper only ever transforms the trailing two axes, so it
+    # would silently turn this 3D transform into a 2D one on CPU. The slow-FFT
+    # diagnostic is requested explicitly instead -- this grid follows from
+    # g_max and the cell, so it is essentially never a fast length.
+    warn_if_slow_gpu_fft(structure_factor, "ifftn")
     potential = xp.fft.ifftn(structure_factor)
     potential = potential * np.prod(potential.shape) / kappa
     potential -= potential.min()

--- a/abtem/core/abtem.yaml
+++ b/abtem/core/abtem.yaml
@@ -43,6 +43,13 @@ fftw:
   planning_timelimit: 60
   # Whether to allow falling back to not using wisdom if the cache fails
   allow_fallback: true
+grid:
+  # Round gpts derived from a requested sampling up to the next fast FFT length
+  # (all prime factors in {2, 3, 5, 7}). The realized sampling then becomes at
+  # most the requested one, never coarser. Explicitly given gpts are never
+  # altered. Fast lengths avoid the slow, memory-hungry Bluestein FFT fallback
+  # on GPU and speed up CPU FFTs as well.
+  round-to-fast-fft: false
 warnings:
   # Show the dask warning about the blockwise performance when the number are increased dramatically
   dask-blockwise-performance: false

--- a/abtem/core/abtem.yaml
+++ b/abtem/core/abtem.yaml
@@ -44,12 +44,15 @@ fftw:
   # Whether to allow falling back to not using wisdom if the cache fails
   allow_fallback: true
 grid:
-  # Round gpts derived from a requested sampling up to the next fast FFT length
-  # (all prime factors in {2, 3, 5, 7}). The realized sampling then becomes at
-  # most the requested one, never coarser. Explicitly given gpts are never
-  # altered. Fast lengths avoid the slow, memory-hungry Bluestein FFT fallback
-  # on GPU and speed up CPU FFTs as well.
-  round-to-fast-fft: false
+  # Round automatically derived gpts up to the next fast FFT length (all prime
+  # factors in {2, 3, 5, 7}). Fast lengths avoid the slow, memory-hungry
+  # Bluestein FFT fallback on GPU and speed up CPU FFTs as well. Rounding is
+  # upward only, so a grid derived from a numeric sampling never comes out
+  # coarser than requested. gpts given explicitly are never altered.
+  #   'auto'  round only grids abTEM derives on its own (sampling='auto')
+  #   true    additionally round gpts derived from a numeric sampling
+  #   false   never round
+  round-to-fast-fft: auto
 warnings:
   # Show the dask warning about the blockwise performance when the number are increased dramatically
   dask-blockwise-performance: false

--- a/abtem/core/fft.py
+++ b/abtem/core/fft.py
@@ -182,7 +182,8 @@ def _warn_slow_fft_size(shape, func_name: str = "fft2", kwargs=None):
     # user sets with gpts; for anything else (e.g. the 3D structure-factor
     # grid, which follows from g_max and the cell) that advice would be wrong.
     remedy = (
-        ", e.g. by setting gpts explicitly instead of the sampling"
+        ", e.g. with abtem.config.set({'grid.round-to-fast-fft': True}) or by "
+        "setting gpts explicitly instead of the sampling"
         if len(lengths) == 2 and len(shape) >= 2 and tuple(shape[-2:]) == lengths
         else ""
     )

--- a/abtem/core/fft.py
+++ b/abtem/core/fft.py
@@ -199,6 +199,21 @@ def _warn_slow_fft_size(shape, func_name: str = "fft2", kwargs=None):
     )
 
 
+def warn_if_slow_gpu_fft(x, func_name: str = "fft2", **kwargs):
+    """
+    Emit the slow-FFT diagnostic for a transform run outside ``_fft_dispatch``.
+
+    A few transforms call ``xp.fft`` directly rather than through the wrappers
+    in this module -- ``structure_factor_to_potential`` does, because the FFTW
+    backend here only ever transforms the trailing two axes and would silently
+    turn its 3D transform into a 2D one. They still deserve the diagnostic, so
+    they can call this alongside. Only GPU arrays are considered: the Bluestein
+    workspace this warns about is a cuFFT concern.
+    """
+    if cp is not None and isinstance(x, cp.ndarray):
+        _warn_slow_fft_size(x.shape, func_name, kwargs)
+
+
 def _raise_fft_lib_not_present(lib_name: str):
     raise RuntimeError(
         f"FFT library {lib_name} not present. Install this package or change the FFT"

--- a/abtem/core/fft.py
+++ b/abtem/core/fft.py
@@ -1,5 +1,6 @@
 """Module for handling Fourier transforms and convolution in *ab*TEM."""
 
+import threading
 import warnings
 from itertools import product as _product
 from typing import Tuple, TypeVar, overload
@@ -103,6 +104,9 @@ def next_fast_fft_size(n: int) -> int:
 
 
 _warned_slow_fft_shapes: set = set()
+# _fft_dispatch runs concurrently in dask worker threads, so the check-then-add
+# on the shape set must be atomic or the same shape can warn more than once.
+_warned_slow_fft_shapes_lock = threading.Lock()
 
 # Bluestein overhead only matters for large transforms; small odd-sized arrays
 # (e.g. interpolated measurements) are not worth a warning.
@@ -112,9 +116,12 @@ _SLOW_FFT_WARN_MIN_ELEMENTS = 1024 * 1024
 def _warn_slow_fft_size(shape):
     """Warn once per large 2D transform shape whose lengths force Bluestein."""
     dims = tuple(int(n) for n in shape[-2:])
-    if len(dims) < 2 or dims in _warned_slow_fft_shapes:
+    if len(dims) < 2:
         return
-    _warned_slow_fft_shapes.add(dims)
+    with _warned_slow_fft_shapes_lock:
+        if dims in _warned_slow_fft_shapes:
+            return
+        _warned_slow_fft_shapes.add(dims)
     if dims[0] * dims[1] < _SLOW_FFT_WARN_MIN_ELEMENTS:
         return
     if all(is_fast_fft_size(n) for n in dims):

--- a/abtem/core/fft.py
+++ b/abtem/core/fft.py
@@ -37,6 +37,90 @@ except ImportError:
     cp = None
 
 
+_FAST_FFT_PRIMES = (2, 3, 5, 7)
+
+
+def is_fast_fft_size(n: int) -> bool:
+    """
+    Whether an FFT of length ``n`` runs on fast radix kernels.
+
+    FFT libraries only ship optimized kernels for lengths whose prime factors
+    are small (2, 3, 5 and 7 are supported everywhere). A length with a larger
+    prime factor triggers a generic fallback -- on cuFFT the Bluestein
+    algorithm, which pads internally to a power of two, costing several times
+    the arithmetic and, on GPU, a workspace of several times the transform
+    size.
+
+    Parameters
+    ----------
+    n : int
+        The transform length.
+
+    Returns
+    -------
+    bool
+        True if ``n`` factorizes completely into 2, 3, 5 and 7.
+    """
+    n = int(n)
+    if n < 1:
+        return False
+    for p in _FAST_FFT_PRIMES:
+        while n % p == 0:
+            n //= p
+    return n == 1
+
+
+def next_fast_fft_size(n: int) -> int:
+    """
+    The smallest length >= ``n`` whose prime factors are all in {2, 3, 5, 7}.
+
+    Useful for choosing grid sizes (``gpts``) that avoid the slow
+    large-workspace Bluestein fallback on GPU.
+
+    Parameters
+    ----------
+    n : int
+        The minimum transform length.
+
+    Returns
+    -------
+    int
+        The next fast transform length.
+    """
+    n = max(1, int(n))
+    while not is_fast_fft_size(n):
+        n += 1
+    return n
+
+
+_warned_slow_fft_shapes: set = set()
+
+# Bluestein overhead only matters for large transforms; small odd-sized arrays
+# (e.g. interpolated measurements) are not worth a warning.
+_SLOW_FFT_WARN_MIN_ELEMENTS = 1024 * 1024
+
+
+def _warn_slow_fft_size(shape):
+    """Warn once per large 2D transform shape whose lengths force Bluestein."""
+    dims = tuple(int(n) for n in shape[-2:])
+    if len(dims) < 2 or dims in _warned_slow_fft_shapes:
+        return
+    _warned_slow_fft_shapes.add(dims)
+    if dims[0] * dims[1] < _SLOW_FFT_WARN_MIN_ELEMENTS:
+        return
+    if all(is_fast_fft_size(n) for n in dims):
+        return
+    suggestion = " x ".join(str(next_fast_fft_size(n)) for n in dims)
+    warnings.warn(
+        f"FFT size {dims[0]} x {dims[1]} contains prime factors larger than 7; "
+        "cuFFT falls back to the Bluestein algorithm, which is several times "
+        "slower and allocates a workspace of several times the array size. "
+        f"Consider adjusting the grid to {suggestion}, e.g. by setting gpts "
+        "explicitly instead of the sampling.",
+        UserWarning,
+    )
+
+
 def _raise_fft_lib_not_present(lib_name: str):
     raise RuntimeError(
         f"FFT library {lib_name} not present. Install this package or change the FFT"
@@ -262,6 +346,7 @@ def _fft_dispatch(
 
     if isinstance(x, cp.ndarray):
         _configure_cufft_cache()
+        _warn_slow_fft_size(x.shape)
         return getattr(cp.fft, func_name)(x, **kwargs)
 
 

--- a/abtem/core/fft.py
+++ b/abtem/core/fft.py
@@ -104,14 +104,6 @@ def next_fast_fft_size(n: int) -> int:
     return n
 
 
-def _prev_fast_fft_size(n: int) -> int:
-    """The largest length <= ``n`` whose prime factors are all in {2, 3, 5, 7}."""
-    n = max(1, int(n))
-    while not is_fast_fft_size(n):
-        n -= 1
-    return n
-
-
 _warned_slow_fft_shapes: set = set()
 # _fft_dispatch runs concurrently in dask worker threads, so the check-then-add
 # on the shape set must be atomic or the same shape can warn more than once.
@@ -134,17 +126,27 @@ def _transform_lengths(shape, func_name: str = "fft2", kwargs=None) -> tuple[int
     """
     kwargs = kwargs or {}
     axes = kwargs.get("axes")
+    # An explicit `s` overrides the array lengths (None entries keep theirs).
+    s = kwargs.get("s")
 
     if axes is None:
         if func_name.endswith("fftn"):
-            axes = tuple(range(len(shape)))
+            # numpy and cupy apply `s` to the TRAILING len(s) axes when no axes
+            # are given, so deriving the axes from the array rank alone would
+            # pair `s` with the wrong ones.
+            count = len(s) if s is not None else len(shape)
+            axes = tuple(range(len(shape) - count, len(shape)))
         elif func_name.endswith("fft2"):
             axes = (-2, -1)
         else:
             axes = (kwargs.get("axis", -1),)
 
-    # An explicit `s` overrides the array lengths (None entries keep theirs).
-    s = kwargs.get("s")
+    # Drop axes the array does not have. cupy's fft2 quietly reduces the axes
+    # for arrays of fewer than two dimensions, and this runs ahead of every GPU
+    # transform: raising here would break a transform that would otherwise
+    # succeed, rather than merely skipping a diagnostic.
+    ndim = len(shape)
+    axes = tuple(axis for axis in axes if -ndim <= axis < ndim)
 
     lengths = []
     for i, axis in enumerate(axes):
@@ -182,8 +184,9 @@ def _warn_slow_fft_size(shape, func_name: str = "fft2", kwargs=None):
     # user sets with gpts; for anything else (e.g. the 3D structure-factor
     # grid, which follows from g_max and the cell) that advice would be wrong.
     remedy = (
-        ", e.g. with abtem.config.set({'grid.round-to-fast-fft': True}) or by "
-        "setting gpts explicitly instead of the sampling"
+        ", e.g. by setting gpts explicitly, or -- if this grid was derived from "
+        "a numeric sampling -- with "
+        "abtem.config.set({'grid.round-to-fast-fft': True})"
         if len(lengths) == 2 and len(shape) >= 2 and tuple(shape[-2:]) == lengths
         else ""
     )

--- a/abtem/core/fft.py
+++ b/abtem/core/fft.py
@@ -37,6 +37,13 @@ except ImportError:
     cp = None
 
 
+# Deliberately NOT scipy.fft.next_fast_len's set: scipy targets pocketfft,
+# whose kernels go up to radix 11, so next_fast_len returns 11-smooth lengths
+# (next_fast_len(121) == 121 == 11**2). cuFFT documents optimized kernels only
+# for sizes of the form 2^a * 3^b * 5^c * 7^d, so a factor-11 length falls off
+# exactly the GPU fast path this module exists to protect. {2, 3, 5, 7} is the
+# intersection guaranteed fast on every backend abTEM uses (FFTW, pocketfft,
+# MKL, cuFFT, hipFFT).
 _FAST_FFT_PRIMES = (2, 3, 5, 7)
 
 
@@ -75,7 +82,9 @@ def next_fast_fft_size(n: int) -> int:
     The smallest length >= ``n`` whose prime factors are all in {2, 3, 5, 7}.
 
     Useful for choosing grid sizes (``gpts``) that avoid the slow
-    large-workspace Bluestein fallback on GPU.
+    large-workspace Bluestein fallback on GPU. Stricter than
+    ``scipy.fft.next_fast_len``, which returns 11-smooth lengths (fast for
+    pocketfft on CPU, but off cuFFT's documented fast path).
 
     Parameters
     ----------

--- a/abtem/core/fft.py
+++ b/abtem/core/fft.py
@@ -1,5 +1,6 @@
 """Module for handling Fourier transforms and convolution in *ab*TEM."""
 
+import math
 import threading
 import warnings
 from itertools import product as _product
@@ -113,26 +114,75 @@ _warned_slow_fft_shapes_lock = threading.Lock()
 _SLOW_FFT_WARN_MIN_ELEMENTS = 1024 * 1024
 
 
-def _warn_slow_fft_size(shape):
-    """Warn once per large 2D transform shape whose lengths force Bluestein."""
-    dims = tuple(int(n) for n in shape[-2:])
-    if len(dims) < 2:
+def _transform_lengths(shape, func_name: str = "fft2", kwargs=None) -> tuple[int, ...]:
+    """
+    The array lengths a transform actually acts on.
+
+    Only the transformed axes matter for the Bluestein fallback: batch axes are
+    looped over, whatever their length. Which axes those are depends on the
+    function -- ``fftn`` transforms all of them unless ``axes`` says otherwise,
+    ``fft2`` the trailing two, ``fft`` a single one -- so reading the trailing
+    two axes unconditionally misreports every non-2D transform.
+    """
+    kwargs = kwargs or {}
+    axes = kwargs.get("axes")
+
+    if axes is None:
+        if func_name.endswith("fftn"):
+            axes = tuple(range(len(shape)))
+        elif func_name.endswith("fft2"):
+            axes = (-2, -1)
+        else:
+            axes = (kwargs.get("axis", -1),)
+
+    # An explicit `s` overrides the array lengths (None entries keep theirs).
+    s = kwargs.get("s")
+
+    lengths = []
+    for i, axis in enumerate(axes):
+        length = shape[axis]
+        if s is not None and i < len(s) and s[i] is not None:
+            length = s[i]
+        lengths.append(int(length))
+
+    return tuple(lengths)
+
+
+def _warn_slow_fft_size(shape, func_name: str = "fft2", kwargs=None):
+    """Warn once per large transform whose transformed lengths force Bluestein."""
+    lengths = _transform_lengths(shape, func_name, kwargs)
+
+    if not lengths:
         return
+
+    # Test cheaply first, and record only shapes that actually warn: the
+    # memo then holds at most one entry per warning ever emitted, and a run
+    # whose grid is fast never touches the lock on the FFT hot path.
+    if math.prod(lengths) < _SLOW_FFT_WARN_MIN_ELEMENTS:
+        return
+    if all(is_fast_fft_size(n) for n in lengths):
+        return
+
     with _warned_slow_fft_shapes_lock:
-        if dims in _warned_slow_fft_shapes:
+        if lengths in _warned_slow_fft_shapes:
             return
-        _warned_slow_fft_shapes.add(dims)
-    if dims[0] * dims[1] < _SLOW_FFT_WARN_MIN_ELEMENTS:
-        return
-    if all(is_fast_fft_size(n) for n in dims):
-        return
-    suggestion = " x ".join(str(next_fast_fft_size(n)) for n in dims)
+        _warned_slow_fft_shapes.add(lengths)
+
+    shown = " x ".join(str(n) for n in lengths)
+    suggestion = " x ".join(str(next_fast_fft_size(n)) for n in lengths)
+    # Only a 2D transform of the trailing axes is the wave-function grid the
+    # user sets with gpts; for anything else (e.g. the 3D structure-factor
+    # grid, which follows from g_max and the cell) that advice would be wrong.
+    remedy = (
+        ", e.g. by setting gpts explicitly instead of the sampling"
+        if len(lengths) == 2 and len(shape) >= 2 and tuple(shape[-2:]) == lengths
+        else ""
+    )
     warnings.warn(
-        f"FFT size {dims[0]} x {dims[1]} contains prime factors larger than 7; "
+        f"FFT size {shown} contains prime factors larger than 7; "
         "cuFFT falls back to the Bluestein algorithm, which is several times "
         "slower and allocates a workspace of several times the array size. "
-        f"Consider adjusting the grid to {suggestion}, e.g. by setting gpts "
-        "explicitly instead of the sampling.",
+        f"Consider adjusting the transformed grid to {suggestion}{remedy}.",
         UserWarning,
     )
 
@@ -362,7 +412,7 @@ def _fft_dispatch(
 
     if isinstance(x, cp.ndarray):
         _configure_cufft_cache()
-        _warn_slow_fft_size(x.shape)
+        _warn_slow_fft_size(x.shape, func_name, kwargs)
         return getattr(cp.fft, func_name)(x, **kwargs)
 
 

--- a/abtem/core/fft.py
+++ b/abtem/core/fft.py
@@ -104,6 +104,14 @@ def next_fast_fft_size(n: int) -> int:
     return n
 
 
+def _prev_fast_fft_size(n: int) -> int:
+    """The largest length <= ``n`` whose prime factors are all in {2, 3, 5, 7}."""
+    n = max(1, int(n))
+    while not is_fast_fft_size(n):
+        n -= 1
+    return n
+
+
 _warned_slow_fft_shapes: set = set()
 # _fft_dispatch runs concurrently in dask worker threads, so the check-then-add
 # on the shape set must be atomic or the same shape can warn more than once.

--- a/abtem/core/grid.py
+++ b/abtem/core/grid.py
@@ -14,6 +14,43 @@ from abtem.core.backend import device_name_from_array_module, get_array_module
 from abtem.core.utils import CopyMixin, EqualityMixin, get_dtype
 
 
+def _fast_fft_rounding_mode() -> str:
+    """
+    Normalize the ``grid.round-to-fast-fft`` configuration to a mode string.
+
+    Returns
+    -------
+    str
+        ``'never'``, ``'auto'`` (only grids abTEM derives on its own) or
+        ``'always'`` (additionally grids derived from a numeric sampling).
+    """
+    value = config.get("grid.round-to-fast-fft", "auto")
+
+    if value is True:
+        return "always"
+    if value is False:
+        return "never"
+    if isinstance(value, str) and value.lower() == "auto":
+        return "auto"
+
+    raise ValueError(
+        "configuration 'grid.round-to-fast-fft' must be True, False or 'auto', "
+        f"got {value!r}"
+    )
+
+
+def round_auto_derived_gpts() -> bool:
+    """
+    Whether grids abTEM derives on its own are rounded to fast FFT lengths.
+
+    This covers grids abTEM chooses without a user-supplied sampling, such as
+    ``Potential(..., sampling='auto')``. Grids derived from a numeric sampling
+    are governed separately (they are only rounded in the ``'always'`` mode),
+    because rounding those changes the result of an existing script.
+    """
+    return _fast_fft_rounding_mode() != "never"
+
+
 def validate_gpts(gpts: tuple[int, ...]) -> tuple[int, ...]:
     """
     Ensure that the prodived grid points are valid.
@@ -287,7 +324,7 @@ class Grid(CopyMixin, EqualityMixin):
                 for r, d, e in zip(extent, sampling, self._endpoint)
             )
 
-            if config.get("grid.round-to-fast-fft", False):
+            if _fast_fft_rounding_mode() == "always":
                 from abtem.core.fft import next_fast_fft_size
 
                 # Round upward only, so the realized sampling is never coarser

--- a/abtem/core/grid.py
+++ b/abtem/core/grid.py
@@ -498,6 +498,11 @@ class Grid(CopyMixin, EqualityMixin):
         ``True`` additionally rounds gpts derived from a numeric sampling;
         ``False`` disables it everywhere.
 
+        Grids that are never Fourier transformed (``fft_grid=False``, e.g. the
+        probe positions of a ``GridScan``) are returned unchanged: a fast
+        length buys them nothing, and changing them would change what is
+        simulated rather than how fast it runs.
+
         Returns
         -------
         tuple of int
@@ -506,6 +511,9 @@ class Grid(CopyMixin, EqualityMixin):
         from abtem.core.fft import next_fast_fft_size
 
         assert self.gpts is not None
+
+        if not self._fft_grid:
+            return self.gpts
 
         gpts = tuple(next_fast_fft_size(n) for n in self.gpts)
 

--- a/abtem/core/grid.py
+++ b/abtem/core/grid.py
@@ -157,8 +157,13 @@ class Grid(CopyMixin, EqualityMixin):
         lock_extent: bool = False,
         lock_gpts: bool = False,
         lock_sampling: bool = False,
+        fft_grid: bool = True,
     ):
         self._dimensions = dimensions
+        # Only a grid that is Fourier transformed benefits from a fast FFT
+        # length. A scan grid samples probe positions, so rounding it would
+        # silently change the number of probes and the scan step for nothing.
+        self._fft_grid = fft_grid
 
         if isinstance(endpoint, bool):
             endpoint = (endpoint,) * dimensions
@@ -324,7 +329,7 @@ class Grid(CopyMixin, EqualityMixin):
                 for r, d, e in zip(extent, sampling, self._endpoint)
             )
 
-            if _fast_fft_rounding_mode() == "always":
+            if self._fft_grid and _fast_fft_rounding_mode() == "always":
                 from abtem.core.fft import next_fast_fft_size
 
                 # Round upward only, so the realized sampling is never coarser

--- a/abtem/core/grid.py
+++ b/abtem/core/grid.py
@@ -287,6 +287,17 @@ class Grid(CopyMixin, EqualityMixin):
                 for r, d, e in zip(extent, sampling, self._endpoint)
             )
 
+            if config.get("grid.round-to-fast-fft", False):
+                from abtem.core.fft import next_fast_fft_size
+
+                # Round upward only, so the realized sampling is never coarser
+                # than requested. Endpoint grids are not periodic FFT grids and
+                # keep the exact ceil-derived size.
+                self._gpts = tuple(
+                    n if e else next_fast_fft_size(n)
+                    for n, e in zip(self._gpts, self._endpoint)
+                )
+
     def _adjust_sampling(
         self, extent: tuple[float, ...] | None, gpts: tuple[int, ...] | None
     ):
@@ -409,6 +420,36 @@ class Grid(CopyMixin, EqualityMixin):
             int(min(power ** np.ceil(np.log(n) / np.log(power)) for power in powers))
             for n in self.gpts
         )
+
+        self.gpts = gpts
+
+        return gpts
+
+    def round_to_fast_fft(self) -> tuple[int, ...]:
+        """
+        Round the grid gpts up to the nearest fast FFT lengths.
+
+        Fast lengths factorize completely into the primes 2, 3, 5 and 7, for
+        which FFT libraries (FFTW, pocketfft, MKL and cuFFT) ship optimized
+        kernels; any other length falls back to a slower generic algorithm --
+        on cuFFT the Bluestein algorithm, which additionally allocates a
+        workspace of several times the transform size. Rounding is always
+        upward, so the realized sampling is never coarser than before.
+
+        The same rounding can be applied automatically whenever gpts are
+        derived from a requested sampling by enabling the configuration option
+        ``grid.round-to-fast-fft``.
+
+        Returns
+        -------
+        tuple of int
+            The rounded gpts.
+        """
+        from abtem.core.fft import next_fast_fft_size
+
+        assert self.gpts is not None
+
+        gpts = tuple(next_fast_fft_size(n) for n in self.gpts)
 
         self.gpts = gpts
 

--- a/abtem/core/grid.py
+++ b/abtem/core/grid.py
@@ -434,14 +434,24 @@ class Grid(CopyMixin, EqualityMixin):
         self, powers: Optional[int | list[int]] = None
     ) -> tuple[int, ...]:
         """
-        Round the grid gpts up to the nearest value that is a power of n. Fourier
-        transforms are faster for arrays of whose size can be factored into small primes
-        (2, 3, 5 and 7).
+        Round the grid gpts up to a whole power of one of the given bases.
+
+        Each gpts becomes ``base ** k`` for whichever base gives the smallest
+        such value at or above it -- a *pure* power, not a product of several
+        bases, so 2623 rounds to 4096 rather than to 2625. That is a much
+        larger grid than fast FFTs actually require: see
+        :meth:`round_to_fast_fft`, which rounds to the nearest length whose
+        prime factors all lie in {2, 3, 5, 7} and is what "faster for arrays
+        whose size factorizes into small primes" normally means.
+
+        (For a handful of inputs that are already exact powers of 5 or 7 --
+        125, 15625, 16807 -- floating-point ``log`` rounds the exponent up and
+        the result overshoots to the next power.)
 
         Parameters
         ----------
-        powers : int
-            The gpts will be a power of this number.
+        powers : int or list of int, optional
+            The bases to consider. Default [2, 3, 5, 7].
         """
         if powers is None:
             powers = [2, 3, 5, 7]
@@ -473,9 +483,15 @@ class Grid(CopyMixin, EqualityMixin):
         workspace of several times the transform size. Rounding is always
         upward, so the realized sampling is never coarser than before.
 
-        The same rounding can be applied automatically whenever gpts are
-        derived from a requested sampling by enabling the configuration option
-        ``grid.round-to-fast-fft``.
+        Every gpts is rounded, including on an endpoint grid -- unlike the
+        automatic rounding, which leaves endpoint grids alone because they are
+        not periodic FFT grids.
+
+        Automatic rounding is governed by the configuration option
+        ``grid.round-to-fast-fft``: ``'auto'`` (the default) rounds the grids
+        abTEM derives on its own, such as ``Potential(sampling='auto')``;
+        ``True`` additionally rounds gpts derived from a numeric sampling;
+        ``False`` disables it everywhere.
 
         Returns
         -------

--- a/abtem/potentials/iam.py
+++ b/abtem/potentials/iam.py
@@ -1154,7 +1154,9 @@ class Potential(_FieldBuilderFromAtoms, BasePotential):
         Provide either "sampling" or "gpts". If 'auto', the grid points are chosen
         to be commensurate with the atom positions (closest to a default of 0.05 Å)
         and, whenever compatible with commensurability, a fast FFT size (all prime
-        factors in {2, 3, 5, 7}).
+        factors in {2, 3, 5, 7}); the commensurate grid nearest the target is kept
+        when it is already such a size. Set the configuration option
+        'grid.round-to-fast-fft' to False for the plain commensurate grid.
         For an `AtomsEnsemble` with more than one configuration (e.g. an MD
         trajectory), each configuration is an independent, generally
         non-commensurate snapshot, so commensurability is not attempted and the

--- a/abtem/potentials/iam.py
+++ b/abtem/potentials/iam.py
@@ -38,7 +38,7 @@ from abtem.core.chunks import Chunks, chunk_ranges, generate_chunks, validate_ch
 from abtem.core.complex import complex_exponential, complex_exponential_scaled
 from abtem.core.energy import Accelerator, HasAcceleratorMixin, energy2sigma
 from abtem.core.ensemble import Ensemble, _wrap_with_array, unpack_blockwise_args
-from abtem.core.grid import Grid, HasGrid2DMixin
+from abtem.core.grid import Grid, HasGrid2DMixin, round_auto_derived_gpts
 from abtem.core.utils import CopyMixin, EqualityMixin, get_dtype, itemset
 from abtem.inelastic.phonons import (
     AtomsEnsemble,
@@ -1273,10 +1273,9 @@ class Potential(_FieldBuilderFromAtoms, BasePotential):
                     extent = box[:2]
                 else:
                     extent = (float(cell[0, 0]), float(cell[1, 1]))
-                gpts = tuple(
-                    next_fast_fft_size(int(np.ceil(extent[i] / 0.05)))
-                    for i in range(2)
-                )
+                gpts = tuple(int(np.ceil(extent[i] / 0.05)) for i in range(2))
+                if round_auto_derived_gpts():
+                    gpts = tuple(next_fast_fft_size(n) for n in gpts)
             elif _require_cell_transform(cell, box=box, plane=plane, origin=origin):
                 if not isinstance(plane, str):
                     raise NotImplementedError
@@ -1294,7 +1293,10 @@ class Potential(_FieldBuilderFromAtoms, BasePotential):
                     allow_transform=True,
                 )
                 gpts = commensurate_gpts(
-                    extent, _auto_atoms.positions, target_sampling=0.05
+                    extent,
+                    _auto_atoms.positions,
+                    target_sampling=0.05,
+                    round_to_fast_fft=round_auto_derived_gpts(),
                 )
             else:
                 if box is not None:
@@ -1304,7 +1306,10 @@ class Potential(_FieldBuilderFromAtoms, BasePotential):
                     extent = (float(cell[0, 0]), float(cell[1, 1]))
                     _auto_atoms = atoms_obj
                 gpts = commensurate_gpts(
-                    extent, _auto_atoms.positions, target_sampling=0.05
+                    extent,
+                    _auto_atoms.positions,
+                    target_sampling=0.05,
+                    round_to_fast_fft=round_auto_derived_gpts(),
                 )
             sampling = None
 

--- a/abtem/potentials/iam.py
+++ b/abtem/potentials/iam.py
@@ -1152,11 +1152,13 @@ class Potential(_FieldBuilderFromAtoms, BasePotential):
     sampling : one or two float or 'auto', optional
         Sampling of the potential in `x` and `y` [Å].
         Provide either "sampling" or "gpts". If 'auto', the grid points are chosen
-        to be commensurate with the atom positions (closest to a default of 0.05 Å).
+        to be commensurate with the atom positions (closest to a default of 0.05 Å)
+        and, whenever compatible with commensurability, a fast FFT size (all prime
+        factors in {2, 3, 5, 7}).
         For an `AtomsEnsemble` with more than one configuration (e.g. an MD
         trajectory), each configuration is an independent, generally
         non-commensurate snapshot, so commensurability is not attempted and the
-        target sampling is used directly.
+        target sampling is used directly (rounded up to a fast FFT size).
     slice_thickness : float or sequence of float or 'auto', optional
         Thickness of the potential slices in the propagation direction in [Å]
         (default is 1 Å).
@@ -1263,12 +1265,18 @@ class Potential(_FieldBuilderFromAtoms, BasePotential):
                 # the same problem: the chosen grid is applied to every frame
                 # regardless, and searching for commensurate planes in one
                 # arbitrary frame is meaningless. Just use the target sampling
-                # directly.
+                # directly, rounded up to a fast FFT size (no commensurability
+                # constrains the grid here, so rounding is free).
+                from abtem.core.fft import next_fast_fft_size
+
                 if box is not None:
                     extent = box[:2]
                 else:
                     extent = (float(cell[0, 0]), float(cell[1, 1]))
-                gpts = tuple(int(np.ceil(extent[i] / 0.05)) for i in range(2))
+                gpts = tuple(
+                    next_fast_fft_size(int(np.ceil(extent[i] / 0.05)))
+                    for i in range(2)
+                )
             elif _require_cell_transform(cell, box=box, plane=plane, origin=origin):
                 if not isinstance(plane, str):
                     raise NotImplementedError

--- a/abtem/scan.py
+++ b/abtem/scan.py
@@ -895,7 +895,12 @@ class GridScan(HasGrid2DMixin, BaseScan):
             extent = None
 
         self._grid = Grid(
-            extent=extent, gpts=gpts, sampling=sampling, dimensions=2, endpoint=endpoint
+            extent=extent,
+            gpts=gpts,
+            sampling=sampling,
+            dimensions=2,
+            endpoint=endpoint,
+            fft_grid=False,
         )
 
     def __len__(self):

--- a/abtem/slicing.py
+++ b/abtem/slicing.py
@@ -116,6 +116,7 @@ def commensurate_gpts(
     positions: np.ndarray,
     target_sampling: float = 0.05,
     tolerance: float = 1e-3,
+    round_to_fast_fft: bool = True,
 ) -> tuple[int, int]:
     """
     Find grid points such that the sampling grid is commensurate with the atom
@@ -128,6 +129,14 @@ def commensurate_gpts(
     translations of the structure: a crystal that has been centered or otherwise
     shifted within the cell always yields the same p as the unshifted version.
 
+    When `round_to_fast_fft` is enabled the number of grid points additionally
+    factorizes completely into the primes 2, 3, 5 and 7 whenever that is
+    compatible with commensurability, so FFTs run on fast radix kernels instead
+    of the slow, memory-hungry Bluestein fallback.  The smallest such grid not
+    coarser than the target sampling is chosen; if the grid period p itself
+    contains a prime factor larger than 7 no multiple of it can be a fast FFT
+    length, and commensurability takes precedence.
+
     Parameters
     ----------
     extent : tuple of float
@@ -138,12 +147,83 @@ def commensurate_gpts(
         Target grid sampling [Å].
     tolerance : float
         Tolerance for identifying distinct atom planes [Å].
+    round_to_fast_fft : bool
+        If True (default), prefer grids that are also fast FFT sizes (all prime
+        factors in {2, 3, 5, 7}), at the cost of a sampling slightly finer than
+        commensurability alone would give.
 
     Returns
     -------
     tuple of int
         Number of grid points in x and y.
     """
+    from abtem.core.fft import is_fast_fft_size, next_fast_fft_size
+
+    def translational_period_count(unique_x: np.ndarray, L: float) -> int:
+        # Largest m such that the set of atom planes is invariant under a shift
+        # of L / m. Even when the intra-cell plane positions are irrational
+        # (no commensurate grid exists), a repeated unit cell still imposes
+        # this translational period, and symmetry-equivalent atoms only see
+        # identical discretised potentials if gpts is a multiple of m.
+        for m in range(len(unique_x), 1, -1):
+            shifted = np.sort((unique_x + L / m) % L)
+            idx = np.searchsorted(unique_x, shifted)
+            neighbors = np.stack(
+                [
+                    unique_x[np.clip(idx - 1, 0, len(unique_x) - 1)],
+                    unique_x[np.clip(idx, 0, len(unique_x) - 1)],
+                ]
+            )
+            distances = np.abs(neighbors - shifted)
+            distances = np.minimum(distances, L - distances)
+            if np.all(distances.min(axis=0) < tolerance):
+                return m
+        return 1
+
+    def fallback_gpts(n_target: int, unique_x=None, L=None) -> int:
+        # The GCD search found no commensurate period. When fast-FFT rounding
+        # is enabled, pick the fast size that (a) keeps gpts a multiple of the
+        # translational period count m of the plane set and (b) best aligns
+        # the planes with grid points: structures with an irrational internal
+        # parameter (e.g. rutile u = 0.306, brookite) have no exactly
+        # commensurate grid, but some fast sizes come much closer than others.
+        if not round_to_fast_fft:
+            return n_target
+        if unique_x is None or L is None or len(unique_x) <= 1:
+            return next_fast_fft_size(n_target)
+
+        m = translational_period_count(unique_x, L)
+        if not is_fast_fft_size(m):
+            # No multiple of m can be a fast FFT size; translational
+            # commensurability takes precedence, as in the main path.
+            return max(round(n_target / m), 1) * m
+
+        best = None
+        multiplier = -(-n_target // m)
+        while True:
+            multiplier = next_fast_fft_size(multiplier)
+            n = multiplier * m
+            # Score by ALIGNABILITY, not realized alignment: the smallest
+            # achievable max plane-to-gridpoint distance over all grid-origin
+            # phases. The plane residues x_i*n/L mod 1 must cluster near a
+            # common phase for the planes to sit near grid points; the tightest
+            # arc containing all residues is 1 - (largest circular gap), and
+            # centering the phase in that arc gives max distance (1 - gap)/2.
+            # Unlike distance-to-nearest-gridpoint at a fixed origin, this
+            # depends only on RELATIVE positions, so a rigidly translated
+            # structure gets the same grid (a tested invariant of the
+            # commensurate search that the fallback must preserve).
+            residues = np.sort(np.mod(unique_x * (n / L), 1.0))
+            gaps = np.diff(np.concatenate([residues, [residues[0] + 1.0]]))
+            alignability = (1.0 - float(np.max(gaps))) / 2.0
+            # Round the score so nearly-equal alignments prefer the smaller grid.
+            score = (round(alignability, 2), n)
+            if best is None or score < best[0]:
+                best = (score, n)
+            if n > n_target * 1.12:
+                return best[1]
+            multiplier += 1
+
     gpts = []
     for i in range(2):
         L = extent[i]
@@ -161,7 +241,7 @@ def commensurate_gpts(
         unique_x = x[unique_mask]
 
         if len(unique_x) <= 1:
-            gpts.append(n_target)
+            gpts.append(fallback_gpts(n_target, unique_x, L))
             continue
 
         # Spacings between consecutive unique planes, including the wrap-around gap
@@ -169,7 +249,7 @@ def commensurate_gpts(
 
         min_spacing = float(np.min(spacings))
         if min_spacing < tolerance:
-            gpts.append(n_target)
+            gpts.append(fallback_gpts(n_target, unique_x, L))
             continue
 
         # Check that every spacing is approximately an integer multiple of the
@@ -178,14 +258,22 @@ def commensurate_gpts(
         k = np.round(ratios).astype(int)
         if np.any(np.abs(ratios - k) > 0.05) or np.any(k < 1):
             # No clear commensurability — fall back to the raw target
-            gpts.append(n_target)
+            gpts.append(fallback_gpts(n_target, unique_x, L))
             continue
 
         # Primitive spacing refined as L / (total number of primitive periods).
         # Using L / sum(k) is more accurate than min_spacing alone because it
         # averages out any floating-point scatter in the individual spacings.
         n_periods = int(np.sum(k))
-        n_multiple = max(round(n_target / n_periods), 1) * n_periods
+        if round_to_fast_fft and is_fast_fft_size(n_periods):
+            # A multiple m * n_periods is a fast FFT size exactly when both
+            # factors are, so the smallest fast commensurate grid not coarser
+            # than the target uses the next fast multiplier. When n_periods
+            # itself has a prime factor larger than 7, no multiple can be fast
+            # and commensurability takes precedence (handled below).
+            n_multiple = next_fast_fft_size(-(-n_target // n_periods)) * n_periods
+        else:
+            n_multiple = max(round(n_target / n_periods), 1) * n_periods
         gpts.append(n_multiple)
 
     return tuple(gpts)

--- a/abtem/slicing.py
+++ b/abtem/slicing.py
@@ -111,6 +111,73 @@ def commensurate_slice_thickness(
     return result
 
 
+def _plane_set_invariant_under(
+    unique_x: np.ndarray, L: float, s: float, tolerance: float = 1e-3
+) -> bool:
+    """Whether shifting every atom plane by ``s`` maps the plane set onto itself."""
+    # Every plane, shifted by s, must land within tolerance of a plane.
+    # The plane set is periodic, so the nearest plane to a shifted point may
+    # lie across the wrap at 0 ≡ L: a point landing just below L is nearest
+    # to unique_x[0], and one landing below unique_x[0] is nearest to
+    # unique_x[-1]. Indexing modulo n picks up both; clipping the
+    # searchsorted index instead collapses the two neighbours onto the same
+    # end plane and silently misses the true nearest one. (The caller's
+    # `x > L - tolerance -> 0` snap bounds the input planes away from L, but
+    # not the shifted ones: floating-point cell transforms routinely put a
+    # shifted plane an ulp below L.)
+    n = len(unique_x)
+    shifted = (unique_x + s) % L
+    idx = np.searchsorted(unique_x, shifted)
+    neighbors = np.stack([unique_x[(idx - 1) % n], unique_x[idx % n]])
+    distances = np.abs(neighbors - shifted)
+    distances = np.minimum(distances, L - distances)
+    return bool(np.all(distances.min(axis=0) < tolerance))
+
+
+def _translational_period_count(
+    unique_x: np.ndarray, L: float, tolerance: float = 1e-3
+) -> int:
+    """The largest m for which the plane set is invariant under a shift of L / m."""
+    # Largest m such that the set of atom planes is invariant under a shift
+    # of L / m. Even when the intra-cell plane positions are irrational
+    # (no commensurate grid exists), a repeated unit cell still imposes
+    # this translational period, and symmetry-equivalent atoms only see
+    # identical discretised potentials if gpts is a multiple of m.
+    #
+    # A shift s mapping the plane set onto itself must map the first plane
+    # onto some plane, so the differences to the first plane are the only
+    # candidates -- and s must moreover be L / m for near-integer m. This
+    # prunes the search from every m in [2, n_planes] to the few
+    # difference-derived candidates, typically O(n log n) overall instead of
+    # O(n^2 log n). Candidates are tried in increasing s, so the first valid
+    # shift is the minimal period, i.e. the largest m.
+    #
+    # Each candidate is tested at the EXACT shift L / m rather than at the
+    # difference that suggested it: a period-m set is invariant under L / m by
+    # definition, while the difference carries the plane's own float noise and
+    # may sit up to 2.5 % away (the near-integer filter's width). Testing the
+    # exact shift also makes m the whole identity of a candidate, so distinct
+    # differences rounding to the same m can be collapsed -- without that, an
+    # off-period difference rounding to m could be tested and rejected first,
+    # suppressing the genuine L / m shift entirely.
+    deltas = np.sort((unique_x - unique_x[0]) % L)
+    tested: set[int] = set()
+    for delta in deltas:
+        if delta < tolerance:
+            continue
+        if delta > L / 2 + tolerance:
+            # m = L / delta must be >= 2, and deltas are sorted ascending.
+            break
+        m = L / delta
+        m_int = int(round(m))
+        if m_int < 2 or abs(m - m_int) > 0.05 or m_int in tested:
+            continue
+        tested.add(m_int)
+        if _plane_set_invariant_under(unique_x, L, L / m_int, tolerance):
+            return m_int
+    return 1
+
+
 def commensurate_gpts(
     extent: tuple[float, float],
     positions: np.ndarray,
@@ -159,55 +226,6 @@ def commensurate_gpts(
     """
     from abtem.core.fft import is_fast_fft_size, next_fast_fft_size
 
-    def plane_set_invariant_under(unique_x: np.ndarray, L: float, s: float) -> bool:
-        # Every plane, shifted by s, must land within tolerance of a plane.
-        shifted = np.sort((unique_x + s) % L)
-        idx = np.searchsorted(unique_x, shifted)
-        neighbors = np.stack(
-            [
-                unique_x[np.clip(idx - 1, 0, len(unique_x) - 1)],
-                unique_x[np.clip(idx, 0, len(unique_x) - 1)],
-            ]
-        )
-        distances = np.abs(neighbors - shifted)
-        distances = np.minimum(distances, L - distances)
-        return bool(np.all(distances.min(axis=0) < tolerance))
-
-    def translational_period_count(unique_x: np.ndarray, L: float) -> int:
-        # Largest m such that the set of atom planes is invariant under a shift
-        # of L / m. Even when the intra-cell plane positions are irrational
-        # (no commensurate grid exists), a repeated unit cell still imposes
-        # this translational period, and symmetry-equivalent atoms only see
-        # identical discretised potentials if gpts is a multiple of m.
-        #
-        # A shift s mapping the plane set onto itself must map the first plane
-        # onto some plane, so the only candidates are the differences to the
-        # first plane -- and s must moreover be L / m for near-integer m.
-        # Testing candidates in increasing s, the first valid shift is the
-        # minimal period, i.e. the largest m. This prunes the search from
-        # every m in [2, n_planes] to the few difference-derived candidates,
-        # typically O(n log n) overall instead of O(n^2 log n).
-        deltas = np.sort((unique_x - unique_x[0]) % L)
-        candidates_tried = 0
-        for s in deltas:
-            if s < tolerance or s > L / 2 + tolerance:
-                # m = L / s must be >= 2; deltas are sorted, so we could stop
-                # at the first s beyond L / 2, but the loop is cheap enough.
-                continue
-            m = L / s
-            m_int = int(round(m))
-            if m_int < 2 or abs(m - m_int) > 0.05:
-                continue
-            candidates_tried += 1
-            if candidates_tried > 64:
-                # Pathological sets can offer many near-integer-ratio
-                # differences that all fail the invariance test; treat such a
-                # structure as period-free rather than going quadratic.
-                return 1
-            if plane_set_invariant_under(unique_x, L, s):
-                return m_int
-        return 1
-
     def fallback_gpts(n_target: int, unique_x=None, L=None) -> int:
         # The GCD search found no commensurate period. When fast-FFT rounding
         # is enabled, pick the fast size that (a) keeps gpts a multiple of the
@@ -220,7 +238,7 @@ def commensurate_gpts(
         if unique_x is None or L is None or len(unique_x) <= 1:
             return next_fast_fft_size(n_target)
 
-        m = translational_period_count(unique_x, L)
+        m = _translational_period_count(unique_x, L, tolerance)
         if not is_fast_fft_size(m):
             # No multiple of m can be a fast FFT size; translational
             # commensurability takes precedence, as in the main path.

--- a/abtem/slicing.py
+++ b/abtem/slicing.py
@@ -111,6 +111,13 @@ def commensurate_slice_thickness(
     return result
 
 
+# How far above the target grid size the incommensurate fallback may go looking
+# for a better-aligned fast size. Structures with no commensurate grid trade a
+# few percent of extra pixels for a much smaller residual misalignment; beyond
+# this the trade stops being worth the memory and FFT time.
+_FALLBACK_MAX_OVERSHOOT = 1.12
+
+
 def _plane_set_invariant_under(
     unique_x: np.ndarray, L: float, s: float, tolerance: float = 1e-3
 ) -> bool:
@@ -224,7 +231,11 @@ def commensurate_gpts(
     tuple of int
         Number of grid points in x and y.
     """
-    from abtem.core.fft import is_fast_fft_size, next_fast_fft_size
+    from abtem.core.fft import (
+        _prev_fast_fft_size,
+        is_fast_fft_size,
+        next_fast_fft_size,
+    )
 
     def fallback_gpts(n_target: int, unique_x=None, L=None) -> int:
         # The GCD search found no commensurate period. When fast-FFT rounding
@@ -249,6 +260,14 @@ def commensurate_gpts(
         while True:
             multiplier = next_fast_fft_size(multiplier)
             n = multiplier * m
+            if best is not None and n > n_target * _FALLBACK_MAX_OVERSHOOT:
+                # The overshoot window is a real bound: a candidate outside it
+                # is not scored at all. Scoring it first and only then stopping
+                # let the largest candidate -- often the best aligned, since a
+                # finer grid resolves more phases -- win from outside the
+                # window, costing up to 38 % extra pixels for an improvement
+                # far below what the potential can resolve.
+                break
             # Score by ALIGNABILITY, not realized alignment: the smallest
             # achievable max plane-to-gridpoint distance over all grid-origin
             # phases. The plane residues x_i*n/L mod 1 must cluster near a
@@ -262,13 +281,20 @@ def commensurate_gpts(
             residues = np.sort(np.mod(unique_x * (n / L), 1.0))
             gaps = np.diff(np.concatenate([residues, [residues[0] + 1.0]]))
             alignability = (1.0 - float(np.max(gaps))) / 2.0
-            # Round the score so nearly-equal alignments prefer the smaller grid.
-            score = (round(alignability, 2), n)
+            # Compare candidates by misalignment in ANGSTROM, not in fractions
+            # of a grid spacing: a finer grid has a smaller spacing, so the same
+            # fractional alignability is physically better there and the two are
+            # not comparable as they stand. Rounding to 0.001 A -- far below
+            # what a projected potential resolves -- makes indistinguishable
+            # candidates tie, and the tie-break then takes the smaller grid.
+            misalignment = alignability * (L / n)
+            score = (round(misalignment, 3), n)
             if best is None or score < best[0]:
                 best = (score, n)
-            if n > n_target * 1.12:
-                return best[1]
             multiplier += 1
+
+        assert best is not None
+        return best[1]
 
     gpts = []
     for i in range(2):
@@ -311,15 +337,30 @@ def commensurate_gpts(
         # Using L / sum(k) is more accurate than min_spacing alone because it
         # averages out any floating-point scatter in the individual spacings.
         n_periods = int(np.sum(k))
+        # The commensurate grid nearest the target, i.e. the grid chosen when
+        # fast-FFT rounding is off.
+        nearest = max(round(n_target / n_periods), 1)
+
         if round_to_fast_fft and is_fast_fft_size(n_periods):
-            # A multiple m * n_periods is a fast FFT size exactly when both
-            # factors are, so the smallest fast commensurate grid not coarser
-            # than the target uses the next fast multiplier. When n_periods
-            # itself has a prime factor larger than 7, no multiple can be fast
+            # A multiple q * n_periods is a fast FFT size exactly when both
+            # factors are, so only the multiplier has to be moved -- and only
+            # when the nearest commensurate grid is not already fast. Enlarging
+            # an already-fast grid buys nothing: both are exactly commensurate,
+            # so the extra pixels improve no measurable quantity. When n_periods
+            # itself has a prime factor larger than 7 no multiple can be fast
             # and commensurability takes precedence (handled below).
-            n_multiple = next_fast_fft_size(-(-n_target // n_periods)) * n_periods
+            if is_fast_fft_size(nearest):
+                multiplier = nearest
+            else:
+                # Take whichever fast multiplier lands closer to the target,
+                # keeping the finer grid on a tie.
+                multiplier = min(
+                    (next_fast_fft_size(nearest), _prev_fast_fft_size(nearest)),
+                    key=lambda q: (abs(q * n_periods - n_target), -q),
+                )
+            n_multiple = multiplier * n_periods
         else:
-            n_multiple = max(round(n_target / n_periods), 1) * n_periods
+            n_multiple = nearest * n_periods
         gpts.append(n_multiple)
 
     return tuple(gpts)

--- a/abtem/slicing.py
+++ b/abtem/slicing.py
@@ -111,10 +111,14 @@ def commensurate_slice_thickness(
     return result
 
 
-# How far above the target grid size the incommensurate fallback may go looking
-# for a better-aligned fast size. Structures with no commensurate grid trade a
-# few percent of extra pixels for a much smaller residual misalignment; beyond
-# this the trade stops being worth the memory and FFT time.
+# How far above the target grid size the incommensurate fallback may look for a
+# better-aligned fast size. Alignment is a tie-break among nearby candidates,
+# not something to optimise: how closely the grid samples an atom column is set
+# by the requested sampling, which is the user's to choose, whereas what this
+# fallback exists to guarantee is that symmetry-equivalent atoms are sampled
+# ALIKE -- and that follows from gpts being a multiple of the translational
+# period, which every candidate here satisfies. So the window stays tight;
+# chasing the best-aligned candidate without one costs up to 38 % extra pixels.
 _FALLBACK_MAX_OVERSHOOT = 1.12
 
 
@@ -208,8 +212,9 @@ def commensurate_gpts(
     compatible with commensurability, so FFTs run on fast radix kernels instead
     of the slow, memory-hungry Bluestein fallback.  The multiple of p nearest
     the target sampling is kept when it is already such a length, and otherwise
-    the nearest one that is; if p itself contains a prime factor larger than 7
-    no multiple of it can be, and commensurability takes precedence.
+    the next one up -- so enabling this never coarsens the grid.  If p itself
+    contains a prime factor larger than 7 no multiple of it can be fast, and
+    commensurability takes precedence.
 
     Structures whose internal parameters are irrational (rutile, brookite) have
     no commensurate grid at all.  For those, `round_to_fast_fft` additionally
@@ -232,8 +237,9 @@ def commensurate_gpts(
         Tolerance for identifying distinct atom planes [Å].
     round_to_fast_fft : bool
         If True (default), prefer grids that are also fast FFT sizes (all prime
-        factors in {2, 3, 5, 7}). The realized sampling is then finer than
-        commensurability alone would give, by at most a few percent. Setting
+        factors in {2, 3, 5, 7}). The realized sampling is then never coarser
+        than commensurability alone would give, and at most a few percent
+        finer. Setting
         this to False reproduces the plain commensurate grid exactly, including
         for the incommensurate structures above, which then simply take the
         target size.
@@ -243,11 +249,7 @@ def commensurate_gpts(
     tuple of int
         Number of grid points in x and y.
     """
-    from abtem.core.fft import (
-        _prev_fast_fft_size,
-        is_fast_fft_size,
-        next_fast_fft_size,
-    )
+    from abtem.core.fft import is_fast_fft_size, next_fast_fft_size
 
     def fallback_gpts(n_target: int, unique_x=None, L=None) -> int:
         # The GCD search found no commensurate period. With fast-FFT rounding
@@ -276,12 +278,10 @@ def commensurate_gpts(
             multiplier = next_fast_fft_size(multiplier)
             n = multiplier * m
             if best is not None and n > n_target * _FALLBACK_MAX_OVERSHOOT:
-                # The overshoot window is a real bound: a candidate outside it
-                # is not scored at all. Scoring it first and only then stopping
-                # let the largest candidate -- often the best aligned, since a
-                # finer grid resolves more phases -- win from outside the
-                # window, costing up to 38 % extra pixels for an improvement
-                # far below what the potential can resolve.
+                # Candidates outside the window are not scored at all. Scoring
+                # the terminating candidate and only then stopping let the
+                # largest one -- often the best aligned, since a finer grid
+                # resolves more phases -- win from outside any window at all.
                 break
             # Score by ALIGNABILITY, not realized alignment: the smallest
             # achievable max plane-to-gridpoint distance over all grid-origin
@@ -364,15 +364,12 @@ def commensurate_gpts(
             # so the extra pixels improve no measurable quantity. When n_periods
             # itself has a prime factor larger than 7 no multiple can be fast
             # and commensurability takes precedence (handled below).
-            if is_fast_fft_size(nearest):
-                multiplier = nearest
-            else:
-                # Take whichever fast multiplier lands closer to the target,
-                # keeping the finer grid on a tie.
-                multiplier = min(
-                    (next_fast_fft_size(nearest), _prev_fast_fft_size(nearest)),
-                    key=lambda q: (abs(q * n_periods - n_target), -q),
-                )
+            # Rounding the multiplier up rather than to the nearer fast value
+            # keeps the grid from ever coming out coarser than it would with
+            # rounding off, so enabling this can only refine the sampling.
+            multiplier = nearest if is_fast_fft_size(nearest) else (
+                next_fast_fft_size(nearest)
+            )
             n_multiple = multiplier * n_periods
         else:
             n_multiple = nearest * n_periods

--- a/abtem/slicing.py
+++ b/abtem/slicing.py
@@ -309,6 +309,15 @@ def commensurate_gpts(
             multiplier += 1
 
         assert best is not None
+        if best[1] > n_target * _FALLBACK_MAX_OVERSHOOT:
+            # Candidates ascend, so the first one already overshoots and there
+            # is no in-window candidate to find: every fast multiple of m is
+            # this far above the target or further. Being a fast size is not
+            # worth that many extra pixels, so keep the period constraint on
+            # its own -- exactly what the branch above does when m itself is
+            # not a fast size. Without this the window is not a bound at all
+            # (m = 64 against a target of 72 lands on 128, +78 %).
+            return max(round(n_target / m), 1) * m
         return best[1]
 
     gpts = []

--- a/abtem/slicing.py
+++ b/abtem/slicing.py
@@ -159,25 +159,53 @@ def commensurate_gpts(
     """
     from abtem.core.fft import is_fast_fft_size, next_fast_fft_size
 
+    def plane_set_invariant_under(unique_x: np.ndarray, L: float, s: float) -> bool:
+        # Every plane, shifted by s, must land within tolerance of a plane.
+        shifted = np.sort((unique_x + s) % L)
+        idx = np.searchsorted(unique_x, shifted)
+        neighbors = np.stack(
+            [
+                unique_x[np.clip(idx - 1, 0, len(unique_x) - 1)],
+                unique_x[np.clip(idx, 0, len(unique_x) - 1)],
+            ]
+        )
+        distances = np.abs(neighbors - shifted)
+        distances = np.minimum(distances, L - distances)
+        return bool(np.all(distances.min(axis=0) < tolerance))
+
     def translational_period_count(unique_x: np.ndarray, L: float) -> int:
         # Largest m such that the set of atom planes is invariant under a shift
         # of L / m. Even when the intra-cell plane positions are irrational
         # (no commensurate grid exists), a repeated unit cell still imposes
         # this translational period, and symmetry-equivalent atoms only see
         # identical discretised potentials if gpts is a multiple of m.
-        for m in range(len(unique_x), 1, -1):
-            shifted = np.sort((unique_x + L / m) % L)
-            idx = np.searchsorted(unique_x, shifted)
-            neighbors = np.stack(
-                [
-                    unique_x[np.clip(idx - 1, 0, len(unique_x) - 1)],
-                    unique_x[np.clip(idx, 0, len(unique_x) - 1)],
-                ]
-            )
-            distances = np.abs(neighbors - shifted)
-            distances = np.minimum(distances, L - distances)
-            if np.all(distances.min(axis=0) < tolerance):
-                return m
+        #
+        # A shift s mapping the plane set onto itself must map the first plane
+        # onto some plane, so the only candidates are the differences to the
+        # first plane -- and s must moreover be L / m for near-integer m.
+        # Testing candidates in increasing s, the first valid shift is the
+        # minimal period, i.e. the largest m. This prunes the search from
+        # every m in [2, n_planes] to the few difference-derived candidates,
+        # typically O(n log n) overall instead of O(n^2 log n).
+        deltas = np.sort((unique_x - unique_x[0]) % L)
+        candidates_tried = 0
+        for s in deltas:
+            if s < tolerance or s > L / 2 + tolerance:
+                # m = L / s must be >= 2; deltas are sorted, so we could stop
+                # at the first s beyond L / 2, but the loop is cheap enough.
+                continue
+            m = L / s
+            m_int = int(round(m))
+            if m_int < 2 or abs(m - m_int) > 0.05:
+                continue
+            candidates_tried += 1
+            if candidates_tried > 64:
+                # Pathological sets can offer many near-integer-ratio
+                # differences that all fail the invariance test; treat such a
+                # structure as period-free rather than going quadratic.
+                return 1
+            if plane_set_invariant_under(unique_x, L, s):
+                return m_int
         return 1
 
     def fallback_gpts(n_target: int, unique_x=None, L=None) -> int:

--- a/abtem/slicing.py
+++ b/abtem/slicing.py
@@ -206,10 +206,19 @@ def commensurate_gpts(
     When `round_to_fast_fft` is enabled the number of grid points additionally
     factorizes completely into the primes 2, 3, 5 and 7 whenever that is
     compatible with commensurability, so FFTs run on fast radix kernels instead
-    of the slow, memory-hungry Bluestein fallback.  The smallest such grid not
-    coarser than the target sampling is chosen; if the grid period p itself
-    contains a prime factor larger than 7 no multiple of it can be a fast FFT
-    length, and commensurability takes precedence.
+    of the slow, memory-hungry Bluestein fallback.  The multiple of p nearest
+    the target sampling is kept when it is already such a length, and otherwise
+    the nearest one that is; if p itself contains a prime factor larger than 7
+    no multiple of it can be, and commensurability takes precedence.
+
+    Structures whose internal parameters are irrational (rutile, brookite) have
+    no commensurate grid at all.  For those, `round_to_fast_fft` additionally
+    selects among fast sizes within a few percent of the target the one whose
+    grid the atom planes come closest to sitting on, subject to keeping the
+    grid a multiple of the plane set's translational period -- without which
+    symmetry-equivalent atoms in different unit cells would discretise
+    differently.  This is the only case in which the returned grid is not the
+    one closest to `target_sampling`.
 
     Parameters
     ----------
@@ -223,8 +232,11 @@ def commensurate_gpts(
         Tolerance for identifying distinct atom planes [Å].
     round_to_fast_fft : bool
         If True (default), prefer grids that are also fast FFT sizes (all prime
-        factors in {2, 3, 5, 7}), at the cost of a sampling slightly finer than
-        commensurability alone would give.
+        factors in {2, 3, 5, 7}). The realized sampling is then finer than
+        commensurability alone would give, by at most a few percent. Setting
+        this to False reproduces the plain commensurate grid exactly, including
+        for the incommensurate structures above, which then simply take the
+        target size.
 
     Returns
     -------
@@ -238,12 +250,15 @@ def commensurate_gpts(
     )
 
     def fallback_gpts(n_target: int, unique_x=None, L=None) -> int:
-        # The GCD search found no commensurate period. When fast-FFT rounding
-        # is enabled, pick the fast size that (a) keeps gpts a multiple of the
+        # The GCD search found no commensurate period. With fast-FFT rounding
+        # off this is simply the target size (the base branch's behaviour).
+        # With it on, pick the fast size that (a) keeps gpts a multiple of the
         # translational period count m of the plane set and (b) best aligns
         # the planes with grid points: structures with an irrational internal
         # parameter (e.g. rutile u = 0.306, brookite) have no exactly
         # commensurate grid, but some fast sizes come much closer than others.
+        # Note this ties the period constraint in (a) to the rounding flag, so
+        # that `round_to_fast_fft=False` reproduces the base branch exactly.
         if not round_to_fast_fft:
             return n_target
         if unique_x is None or L is None or len(unique_x) <= 1:
@@ -329,7 +344,7 @@ def commensurate_gpts(
         ratios = spacings / min_spacing
         k = np.round(ratios).astype(int)
         if np.any(np.abs(ratios - k) > 0.05) or np.any(k < 1):
-            # No clear commensurability — fall back to the raw target
+            # No clear commensurability — take the incommensurate fallback
             gpts.append(fallback_gpts(n_target, unique_x, L))
             continue
 

--- a/test/test_bloch_waves.py
+++ b/test/test_bloch_waves.py
@@ -115,3 +115,22 @@ def test_potential_from_structure_factor(
 
     error = np.abs(array2 - array1).sum() / array1.sum() * 100
     assert error < 2.5
+
+
+def test_structure_factor_potential_requests_the_slow_fft_diagnostic():
+    # This 3D transform cannot go through abtem.core.fft.ifftn (the FFTW
+    # backend there transforms only the trailing two axes, silently making it
+    # 2D on CPU), so it must ask for the diagnostic explicitly or escape it.
+    from unittest import mock
+
+    import abtem.bloch.dynamical as dynamical
+
+    with mock.patch.object(dynamical, "warn_if_slow_gpu_fft") as warner:
+        potential = dynamical.structure_factor_to_potential(
+            np.zeros(4, dtype=np.complex64),
+            np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+            gpts=(4, 4, 4),
+        )
+
+    assert warner.call_count == 1
+    assert potential.shape == (4, 4, 4)

--- a/test/test_commensurate_gpts.py
+++ b/test/test_commensurate_gpts.py
@@ -1,0 +1,132 @@
+"""Tests for commensurate automatic grids and their interplay with fast FFT sizes."""
+
+import numpy as np
+import pytest
+from ase.build import bulk
+
+from abtem.core.fft import is_fast_fft_size, next_fast_fft_size
+from abtem.potentials.iam import Potential
+from abtem.slicing import commensurate_gpts
+
+
+def _plane_positions(x_planes, y_planes):
+    positions = np.zeros((len(x_planes) * len(y_planes), 3))
+    positions[:, 0] = np.repeat(x_planes, len(y_planes))
+    positions[:, 1] = np.tile(y_planes, len(x_planes))
+    return positions
+
+
+def test_commensurate_and_fast():
+    # 4 periods in x, 5 in y — both fast-compatible.
+    extent = (10.0, 10.0)
+    positions = _plane_positions(np.arange(4) * 2.5, np.arange(5) * 2.0)
+
+    gpts = commensurate_gpts(extent, positions, target_sampling=0.05)
+
+    for n, n_periods in zip(gpts, (4, 5)):
+        assert n % n_periods == 0
+        assert is_fast_fft_size(n)
+        # Never coarser than the target sampling.
+        assert extent[0] / n <= 0.05 + 1e-12
+
+
+def test_commensurability_beats_fast_fft():
+    # 11 periods in x: no multiple of 11 is 7-smooth, so the grid stays
+    # commensurate and cannot be a fast FFT size.
+    extent = (10.0, 10.0)
+    positions = _plane_positions(np.arange(11) * (10.0 / 11.0), np.arange(4) * 2.5)
+
+    gpts = commensurate_gpts(extent, positions, target_sampling=0.05)
+
+    assert gpts[0] % 11 == 0
+    assert not is_fast_fft_size(gpts[0])
+    assert gpts[1] % 4 == 0
+    assert is_fast_fft_size(gpts[1])
+
+
+def test_round_to_fast_fft_disabled_matches_plain_commensurate():
+    extent = (10.0, 10.0)
+    positions = _plane_positions(np.arange(4) * 2.5, np.arange(5) * 2.0)
+
+    gpts = commensurate_gpts(
+        extent, positions, target_sampling=0.05, round_to_fast_fft=False
+    )
+
+    for n, n_periods in zip(gpts, (4, 5)):
+        n_target = int(np.ceil(10.0 / 0.05))
+        assert n == max(round(n_target / n_periods), 1) * n_periods
+
+
+def test_fallback_rounds_to_fast_fft():
+    # A single atom gives no plane spacings, so the target size is used and
+    # rounded up to a fast FFT length. 131.1 / 0.05 -> 2622 -> 2625 = 3*5^3*7.
+    extent = (131.1, 131.1)
+    positions = np.zeros((1, 3))
+
+    gpts = commensurate_gpts(extent, positions, target_sampling=0.05)
+    assert gpts == (2625, 2625)
+
+    gpts = commensurate_gpts(
+        extent, positions, target_sampling=0.05, round_to_fast_fft=False
+    )
+    assert gpts == (2622, 2622)
+
+
+def test_smallest_fast_commensurate_multiple():
+    # 6 periods, target 100.35 Å at 0.05 Å -> n_target = 2007, ceil(2007/6) = 335,
+    # next fast multiplier is 336 = 2^4*3*7 -> gpts = 2016.
+    extent = (100.35, 100.35)
+    positions = _plane_positions(np.arange(6) * (100.35 / 6.0), np.arange(6) * (100.35 / 6.0))
+
+    gpts = commensurate_gpts(extent, positions, target_sampling=0.05)
+
+    assert gpts == (2016, 2016)
+    assert next_fast_fft_size(335) == 336
+
+
+@pytest.mark.parametrize("name,crystalstructure,a", [("Si", "diamond", 5.431), ("Au", "fcc", 4.078)])
+def test_potential_auto_sampling_is_commensurate_and_fast(name, crystalstructure, a):
+    atoms = bulk(name, crystalstructure, a=a, cubic=True) * (2, 2, 1)
+
+    potential = Potential(atoms, sampling="auto", projection="infinite")
+
+    for axis, (n, extent) in enumerate(zip(potential.gpts, potential.extent)):
+        assert is_fast_fft_size(n)
+        assert extent / n <= 0.05 + 1e-12
+        # Commensurate: every atom plane falls on a grid point.
+        fractional = atoms.positions[:, axis] / (extent / n)
+        offsets = np.abs(fractional - np.round(fractional))
+        assert np.all(offsets < 1e-3)
+
+
+def test_incommensurate_fallback_preserves_translational_period():
+    # Rutile-like planes: intra-cell spacings with an irrational ratio (no
+    # exactly commensurate grid exists), repeated 3 times. The chosen grid must
+    # remain a multiple of the repeat count so symmetry-equivalent atoms in
+    # different unit cells see identical discretised potentials, and fast.
+    cell = 4.594
+    base = np.array([0.0, 0.8912, 1.4058, 2.297, 3.1882, 3.7028])
+    planes = np.concatenate([base + i * cell for i in range(3)])
+    extent = (3 * cell, 3 * cell)
+    positions = _plane_positions(planes, planes)
+
+    gpts = commensurate_gpts(extent, positions, target_sampling=0.05)
+
+    assert gpts[0] % 3 == 0
+    assert is_fast_fft_size(gpts[0])
+    # 294 = 2*3*7^2 aligns the rutile planes to ~0.01 px (u = 0.306 ~ 30/98).
+    assert gpts[0] == 294
+
+
+def test_incommensurate_fallback_with_non_fast_period():
+    # 11 repeats of an incommensurate cell: no multiple of 11 is 7-smooth, so
+    # translational commensurability wins over the fast-FFT condition.
+    cell = 1.3
+    base = np.array([0.0, 0.4132, 0.9271])
+    planes = np.concatenate([base + i * cell for i in range(11)])
+    extent = (11 * cell, 11 * cell)
+    positions = _plane_positions(planes, planes)
+
+    gpts = commensurate_gpts(extent, positions, target_sampling=0.05)
+
+    assert gpts[0] % 11 == 0

--- a/test/test_commensurate_gpts.py
+++ b/test/test_commensurate_gpts.py
@@ -96,7 +96,10 @@ def test_potential_auto_sampling_is_commensurate_and_fast(name, crystalstructure
 
     for axis, (n, extent) in enumerate(zip(potential.gpts, potential.extent)):
         assert is_fast_fft_size(n)
-        assert extent / n <= 0.05 + 1e-12
+        # Close to the target sampling. Not necessarily finer than it: the
+        # commensurate grid nearest the target wins whenever it is already
+        # fast, exactly as with rounding switched off.
+        assert abs(extent / n - 0.05) / 0.05 < 0.12
         # Commensurate: every atom plane falls on a grid point.
         fractional = atoms.positions[:, axis] / (extent / n)
         offsets = np.abs(fractional - np.round(fractional))
@@ -220,7 +223,9 @@ def test_auto_sampling_respects_the_fast_fft_config():
     # rounded unconditionally and could not be switched off.
     from abtem.core import config
 
-    atoms = bulk("Si", "diamond", a=5.431, cubic=True) * (2, 2, 1)
+    # Gold: the nearest commensurate grid is 164 = 2**2 * 41, not a fast size,
+    # so the two modes genuinely differ here.
+    atoms = bulk("Au", "fcc", a=4.078, cubic=True) * (2, 2, 1)
 
     with config.set({"grid.round-to-fast-fft": "auto"}):
         rounded = Potential(atoms, sampling="auto").gpts
@@ -228,6 +233,7 @@ def test_auto_sampling_respects_the_fast_fft_config():
         plain = Potential(atoms, sampling="auto").gpts
 
     assert all(is_fast_fft_size(n) for n in rounded)
+    assert not any(is_fast_fft_size(n) for n in plain)
     assert plain != rounded
     # 'false' must reproduce the un-rounded commensurate grid exactly.
     extent = (float(atoms.cell[0, 0]), float(atoms.cell[1, 1]))
@@ -263,3 +269,44 @@ def test_invalid_fast_fft_config_raises():
     with config.set({"grid.round-to-fast-fft": "sometimes"}):
         with pytest.raises(ValueError, match="must be True, False or 'auto'"):
             _fast_fft_rounding_mode()
+
+
+def test_already_fast_commensurate_grids_are_not_enlarged():
+    # Both the nearest commensurate grid and any larger fast multiple are
+    # exactly commensurate, so enlarging one that is already fast buys no
+    # accuracy -- it only costs memory and FFT time (up to +23 % pixels).
+    from abtem.core import config
+
+    for atoms in (
+        bulk("Si", "diamond", a=5.431, cubic=True) * (2, 2, 1),
+        bulk("Cu", "fcc", a=3.61, cubic=True) * (6, 6, 1),
+    ):
+        with config.set({"grid.round-to-fast-fft": False}):
+            plain = Potential(atoms, sampling="auto").gpts
+        assert all(is_fast_fft_size(n) for n in plain)  # guard the premise
+
+        with config.set({"grid.round-to-fast-fft": "auto"}):
+            assert Potential(atoms, sampling="auto").gpts == plain
+
+
+def test_incommensurate_fallback_respects_its_overshoot_window():
+    # Rutile has no commensurate grid, so the fallback trades pixels for
+    # alignment -- but only inside the documented window. Scoring the
+    # candidate that terminates the search let a size 17 % above the target
+    # (38 % more pixels) win from outside it.
+    from ase.spacegroup import crystal
+
+    from abtem.slicing import _FALLBACK_MAX_OVERSHOOT
+
+    rutile = crystal(
+        ["Ti", "O"],
+        basis=[(0, 0, 0), (0.30478, 0.30478, 0)],
+        spacegroup=136,
+        cellpar=[4.5937, 4.5937, 2.9587, 90, 90, 90],
+    ) * (6, 6, 1)
+
+    potential = Potential(rutile, sampling="auto")
+
+    for n, extent in zip(potential.gpts, potential.extent):
+        n_target = int(np.ceil(extent / 0.05))
+        assert n <= n_target * _FALLBACK_MAX_OVERSHOOT

--- a/test/test_commensurate_gpts.py
+++ b/test/test_commensurate_gpts.py
@@ -130,3 +130,27 @@ def test_incommensurate_fallback_with_non_fast_period():
     gpts = commensurate_gpts(extent, positions, target_sampling=0.05)
 
     assert gpts[0] % 11 == 0
+
+
+def test_incommensurate_fallback_scales_to_large_supercells():
+    # The translational-period search prunes candidate shifts to the plane
+    # differences with near-integer L/s, so a large supercell of an
+    # incommensurate structure stays cheap (review flagged the previous
+    # search-every-m version as O(n^2 log n)).
+    import time
+
+    cell = 9.184
+    base = np.sort(np.random.RandomState(0).uniform(0, cell, 12))
+    planes = np.concatenate([base + i * cell for i in range(200)])
+    extent = 200 * cell
+    positions = _plane_positions(planes, planes)
+
+    start = time.perf_counter()
+    gpts = commensurate_gpts((extent, extent), positions, target_sampling=0.05)
+    elapsed = time.perf_counter() - start
+
+    # Correctness: the 200-cell translational period must be preserved.
+    assert gpts[0] % 200 == 0
+    # Performance: ~2 ms measured; 1 s is a generous CI-safe bound that the
+    # old quadratic search would still miss by an order of magnitude here.
+    assert elapsed < 1.0

--- a/test/test_commensurate_gpts.py
+++ b/test/test_commensurate_gpts.py
@@ -6,7 +6,11 @@ from ase.build import bulk
 
 from abtem.core.fft import is_fast_fft_size, next_fast_fft_size
 from abtem.potentials.iam import Potential
-from abtem.slicing import commensurate_gpts
+from abtem.slicing import (
+    _plane_set_invariant_under,
+    _translational_period_count,
+    commensurate_gpts,
+)
 
 
 def _plane_positions(x_planes, y_planes):
@@ -154,3 +158,57 @@ def test_incommensurate_fallback_scales_to_large_supercells():
     # Performance: ~2 ms measured; 1 s is a generous CI-safe bound that the
     # old quadratic search would still miss by an order of magnitude here.
     assert elapsed < 1.0
+
+
+def test_plane_set_invariance_sees_across_the_periodic_wrap():
+    # A shifted plane landing an ulp below the cell edge is nearest to the
+    # plane at 0 through the wrap. Clipping the searchsorted index collapses
+    # both neighbours onto the last plane and misses it, rejecting a genuine
+    # period; float cell transforms produce exactly this (orthogonalize_cell
+    # returns rutile's L / 2 plane one ulp short).
+    L = 10.0
+    planes = np.array([0.0, 1.3, 5.0 - 1e-12, 6.3])
+
+    # Shifting by L / 2 maps this set onto itself to well within tolerance.
+    assert _plane_set_invariant_under(planes, L, 5.0 - 1e-12)
+    assert _translational_period_count(planes, L) == 2
+
+
+def test_auto_gpts_is_translation_invariant_for_incommensurate_structures():
+    # Rutile has no exactly commensurate grid, so it takes the fallback path.
+    # Its grid must not depend on where the structure sits in the cell -- the
+    # property commensurate_gpts exists to guarantee. plane='xz' is the case
+    # the wrap bug broke (orthogonalize_cell puts a plane an ulp below L).
+    from ase.spacegroup import crystal
+
+    rutile = crystal(
+        ["Ti", "O"],
+        basis=[(0, 0, 0), (0.30478, 0.30478, 0)],
+        spacegroup=136,
+        cellpar=[4.5937, 4.5937, 2.9587, 90, 90, 90],
+    )
+
+    reference = Potential(rutile, sampling="auto", plane="xz").gpts
+    for shift in (1e-6, 0.001, 0.25, 1.3):
+        shifted = rutile.copy()
+        shifted.positions[:, 0] += shift
+        shifted.wrap()
+        assert Potential(shifted, sampling="auto", plane="xz").gpts == reference
+
+
+def test_period_search_is_not_abandoned_on_dense_plane_sets():
+    # A tiled disordered cell (e.g. an amorphous support film repeated to cover
+    # the field of view) offers hundreds of near-integer-ratio plane
+    # differences that fail the invariance test before the real period is
+    # reached. Abandoning the search after a fixed number of candidates
+    # silently dropped the translational period the fallback exists to keep.
+    rng = np.random.RandomState(3)
+    cell = 25.0
+    base = rng.uniform(0, cell, 900)
+    planes = np.sort(np.concatenate([base, base + cell]))
+
+    assert _translational_period_count(planes, 2 * cell) == 2
+
+    positions = _plane_positions(planes, planes)
+    gpts = commensurate_gpts((2 * cell, 2 * cell), positions, target_sampling=0.05)
+    assert gpts[0] % 2 == 0

--- a/test/test_commensurate_gpts.py
+++ b/test/test_commensurate_gpts.py
@@ -90,9 +90,17 @@ def test_smallest_fast_commensurate_multiple():
 
 @pytest.mark.parametrize("name,crystalstructure,a", [("Si", "diamond", 5.431), ("Au", "fcc", 4.078)])
 def test_potential_auto_sampling_is_commensurate_and_fast(name, crystalstructure, a):
+    from abtem.core import config
+
     atoms = bulk(name, crystalstructure, a=a, cubic=True) * (2, 2, 1)
 
-    potential = Potential(atoms, sampling="auto", projection="infinite")
+    with config.set({"grid.round-to-fast-fft": "auto"}):
+        potential = Potential(atoms, sampling="auto", projection="infinite")
+
+    # Derived independently: the plain commensurate grid is 216 = 2**3 * 27 for
+    # Si (already fast, so kept) and 164 = 2**2 * 41 for Au (not fast, so the
+    # multiplier moves up: 41 -> 42, giving 168).
+    assert potential.gpts == {"Si": (216, 216), "Au": (168, 168)}[name]
 
     for axis, (n, extent) in enumerate(zip(potential.gpts, potential.extent)):
         assert is_fast_fft_size(n)
@@ -180,8 +188,10 @@ def test_plane_set_invariance_sees_across_the_periodic_wrap():
 def test_auto_gpts_is_translation_invariant_for_incommensurate_structures():
     # Rutile has no exactly commensurate grid, so it takes the fallback path.
     # Its grid must not depend on where the structure sits in the cell -- the
-    # property commensurate_gpts exists to guarantee. plane='xz' is the case
-    # the wrap bug broke (orthogonalize_cell puts a plane an ulp below L).
+    # property commensurate_gpts exists to guarantee, and the one the fallback
+    # scoring has to preserve. (The regression guard for the periodic-wrap bug
+    # itself is test_plane_set_invariance_sees_across_the_periodic_wrap; this
+    # is the end-to-end property that bug was one way of breaking.)
     from ase.spacegroup import crystal
 
     rutile = crystal(
@@ -191,12 +201,13 @@ def test_auto_gpts_is_translation_invariant_for_incommensurate_structures():
         cellpar=[4.5937, 4.5937, 2.9587, 90, 90, 90],
     )
 
-    reference = Potential(rutile, sampling="auto", plane="xz").gpts
-    for shift in (1e-6, 0.001, 0.25, 1.3):
-        shifted = rutile.copy()
-        shifted.positions[:, 0] += shift
-        shifted.wrap()
-        assert Potential(shifted, sampling="auto", plane="xz").gpts == reference
+    for plane in ("xy", "xz", "yz"):
+        reference = Potential(rutile, sampling="auto", plane=plane).gpts
+        for shift in (1e-6, 0.001, 0.25, 1.3):
+            shifted = rutile.copy()
+            shifted.positions[:, 0] += shift
+            shifted.wrap()
+            assert Potential(shifted, sampling="auto", plane=plane).gpts == reference
 
 
 def test_period_search_is_not_abandoned_on_dense_plane_sets():
@@ -210,11 +221,9 @@ def test_period_search_is_not_abandoned_on_dense_plane_sets():
     base = rng.uniform(0, cell, 900)
     planes = np.sort(np.concatenate([base, base + cell]))
 
+    # The period itself is the assertion: the grid happens to come out even
+    # either way here, so asserting only on gpts would not discriminate.
     assert _translational_period_count(planes, 2 * cell) == 2
-
-    positions = _plane_positions(planes, planes)
-    gpts = commensurate_gpts((2 * cell, 2 * cell), positions, target_sampling=0.05)
-    assert gpts[0] % 2 == 0
 
 
 def test_auto_sampling_respects_the_fast_fft_config():
@@ -296,8 +305,6 @@ def test_incommensurate_fallback_respects_its_overshoot_window():
     # (38 % more pixels) win from outside it.
     from ase.spacegroup import crystal
 
-    from abtem.slicing import _FALLBACK_MAX_OVERSHOOT
-
     rutile = crystal(
         ["Ti", "O"],
         basis=[(0, 0, 0), (0.30478, 0.30478, 0)],
@@ -309,4 +316,6 @@ def test_incommensurate_fallback_respects_its_overshoot_window():
 
     for n, extent in zip(potential.gpts, potential.extent):
         n_target = int(np.ceil(extent / 0.05))
-        assert n <= n_target * _FALLBACK_MAX_OVERSHOOT
+        # Written out rather than imported from the module under test, which
+        # would move both sides of the assertion together.
+        assert n <= n_target * 1.12

--- a/test/test_commensurate_gpts.py
+++ b/test/test_commensurate_gpts.py
@@ -319,3 +319,25 @@ def test_incommensurate_fallback_respects_its_overshoot_window():
         # Written out rather than imported from the module under test, which
         # would move both sides of the assertion together.
         assert n <= n_target * 1.12
+
+
+def test_fallback_window_is_a_bound_even_when_no_fast_size_fits():
+    # When the translational period m is large relative to the target, the
+    # smallest fast multiple of m can overshoot the window badly and there is
+    # no in-window candidate to find -- every fast multiple is that far above
+    # the target or further (m = 64 against a target of 72 lands on 128, +78 %).
+    # Being a fast size is not worth that; the period constraint is kept on its
+    # own instead, exactly as when m itself is not a fast size.
+    cell = 3.6
+    m = 64
+    planes = np.sort(
+        np.concatenate([[i * cell / m, (i + 0.306) * cell / m] for i in range(m)]).ravel()
+    )
+    positions = _plane_positions(planes, planes)
+
+    gpts = commensurate_gpts((cell, cell), positions, target_sampling=0.05)
+
+    n_target = int(np.ceil(cell / 0.05))
+    assert gpts[0] <= n_target * 1.12
+    # The period is what the fallback exists to preserve, so it survives.
+    assert gpts[0] % _translational_period_count(np.unique(planes), cell) == 0

--- a/test/test_commensurate_gpts.py
+++ b/test/test_commensurate_gpts.py
@@ -212,3 +212,54 @@ def test_period_search_is_not_abandoned_on_dense_plane_sets():
     positions = _plane_positions(planes, planes)
     gpts = commensurate_gpts((2 * cell, 2 * cell), positions, target_sampling=0.05)
     assert gpts[0] % 2 == 0
+
+
+def test_auto_sampling_respects_the_fast_fft_config():
+    # The config option governs every automatically derived grid, so a user who
+    # turns it off gets no rounding anywhere -- previously sampling='auto'
+    # rounded unconditionally and could not be switched off.
+    from abtem.core import config
+
+    atoms = bulk("Si", "diamond", a=5.431, cubic=True) * (2, 2, 1)
+
+    with config.set({"grid.round-to-fast-fft": "auto"}):
+        rounded = Potential(atoms, sampling="auto").gpts
+    with config.set({"grid.round-to-fast-fft": False}):
+        plain = Potential(atoms, sampling="auto").gpts
+
+    assert all(is_fast_fft_size(n) for n in rounded)
+    assert plain != rounded
+    # 'false' must reproduce the un-rounded commensurate grid exactly.
+    extent = (float(atoms.cell[0, 0]), float(atoms.cell[1, 1]))
+    assert plain == commensurate_gpts(
+        extent, atoms.positions, target_sampling=0.05, round_to_fast_fft=False
+    )
+
+
+def test_ensemble_auto_sampling_respects_the_fast_fft_config():
+    from abtem.core import config
+
+    atoms = bulk("Si", "diamond", a=5.431, cubic=True) * (2, 2, 1)
+    trajectory = [atoms, atoms.copy()]
+
+    with config.set({"grid.round-to-fast-fft": "auto"}):
+        rounded = Potential(trajectory, sampling="auto").gpts
+    with config.set({"grid.round-to-fast-fft": False}):
+        plain = Potential(trajectory, sampling="auto").gpts
+
+    assert all(is_fast_fft_size(n) for n in rounded)
+    assert plain == tuple(
+        int(np.ceil(float(atoms.cell[i, i]) / 0.05)) for i in range(2)
+    )
+
+
+def test_invalid_fast_fft_config_raises():
+    # 'auto' is truthy, so a bare truthiness test on the config value would
+    # silently treat any string as "on"; every read goes through the mode
+    # helper instead.
+    from abtem.core import config
+    from abtem.core.grid import _fast_fft_rounding_mode
+
+    with config.set({"grid.round-to-fast-fft": "sometimes"}):
+        with pytest.raises(ValueError, match="must be True, False or 'auto'"):
+            _fast_fft_rounding_mode()

--- a/test/test_commensurate_potential.py
+++ b/test/test_commensurate_potential.py
@@ -462,9 +462,11 @@ def test_atoms_ensemble_sampling_and_slice_thickness_auto_skip_commensurate_sear
     single.cell[0, 0] += 0.13
 
     trajectory = [single, single.copy()]
-    ensemble_pot = abtem.Potential(
-        trajectory, sampling="auto", slice_thickness="auto"
-    )
+    # Pin the option: the expected gpts below are the default mode's.
+    with abtem.config.set({"grid.round-to-fast-fft": "auto"}):
+        ensemble_pot = abtem.Potential(
+            trajectory, sampling="auto", slice_thickness="auto"
+        )
 
     extent_x, extent_y = float(single.cell[0, 0]), float(single.cell[1, 1])
     # The ensemble path uses the plain target sampling (no commensurate
@@ -492,9 +494,10 @@ def test_atoms_ensemble_sampling_and_slice_thickness_auto_skip_commensurate_sear
 
     # Same behaviour when explicitly wrapped in AtomsEnsemble rather than a
     # plain list.
-    explicit_pot = abtem.Potential(
-        abtem.AtomsEnsemble(trajectory), sampling="auto", slice_thickness="auto"
-    )
+    with abtem.config.set({"grid.round-to-fast-fft": "auto"}):
+        explicit_pot = abtem.Potential(
+            abtem.AtomsEnsemble(trajectory), sampling="auto", slice_thickness="auto"
+        )
     assert explicit_pot.gpts == expected_gpts
     assert explicit_pot.num_slices == n_slices
 

--- a/test/test_commensurate_potential.py
+++ b/test/test_commensurate_potential.py
@@ -467,12 +467,19 @@ def test_atoms_ensemble_sampling_and_slice_thickness_auto_skip_commensurate_sear
     )
 
     extent_x, extent_y = float(single.cell[0, 0]), float(single.cell[1, 1])
-    expected_gpts = (int(np.ceil(extent_x / 0.05)), int(np.ceil(extent_y / 0.05)))
+    # The ensemble path uses the plain target sampling (no commensurate
+    # search), rounded up to a fast FFT size like every auto-derived grid.
+    from abtem.core.fft import next_fast_fft_size
+
+    expected_gpts = (
+        next_fast_fft_size(int(np.ceil(extent_x / 0.05))),
+        next_fast_fft_size(int(np.ceil(extent_y / 0.05))),
+    )
     assert ensemble_pot.gpts == expected_gpts
 
     # commensurate_gpts on the same cell/positions should NOT match the plain
-    # ceil(extent / target_sampling) fallback -- confirm they actually differ
-    # here, so this test would catch a regression to commensurability search.
+    # target-derived fallback -- confirm they actually differ here, so this
+    # test would catch a regression to commensurability search.
     commensurate = commensurate_gpts(
         (extent_x, extent_y), single.positions, target_sampling=0.05
     )

--- a/test/test_fft.py
+++ b/test/test_fft.py
@@ -1,0 +1,70 @@
+"""Tests for FFT helpers, in particular fast-radix transform-size handling."""
+
+import warnings
+
+import pytest
+
+from abtem.core.fft import (
+    _warn_slow_fft_size,
+    _warned_slow_fft_shapes,
+    is_fast_fft_size,
+    next_fast_fft_size,
+)
+
+
+@pytest.mark.parametrize(
+    "n, expected",
+    [
+        (1, True),
+        (2048, True),  # 2^11
+        (2625, True),  # 3 * 5^3 * 7
+        (2688, True),  # 2^7 * 3 * 7
+        (2304, True),  # 2^8 * 3^2
+        (2623, False),  # 43 * 61 -> Bluestein
+        (2271, False),  # 3 * 757 -> Bluestein
+        (11, False),
+        (0, False),
+    ],
+)
+def test_is_fast_fft_size(n, expected):
+    assert is_fast_fft_size(n) is expected
+
+
+@pytest.mark.parametrize(
+    "n, expected",
+    [
+        (1, 1),
+        (2048, 2048),  # already fast
+        (2623, 2625),  # 3 * 5^3 * 7
+        (2271, 2304),  # 2^8 * 3^2
+    ],
+)
+def test_next_fast_fft_size(n, expected):
+    assert next_fast_fft_size(n) == expected
+
+
+def test_warn_slow_fft_size_warns_once_per_shape():
+    _warned_slow_fft_shapes.clear()
+    with pytest.warns(UserWarning, match="Bluestein"):
+        _warn_slow_fft_size((4, 2623, 2271))
+    # memoized: the same shape does not warn again
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _warn_slow_fft_size((4, 2623, 2271))
+
+
+def test_warn_slow_fft_size_silent_for_fast_shapes():
+    _warned_slow_fft_shapes.clear()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _warn_slow_fft_size((256, 256))
+
+
+def test_warn_slow_fft_size_silent_for_small_shapes():
+    """Small transforms (e.g. interpolated measurements) never warn, even when
+    their lengths would force the Bluestein path."""
+    _warned_slow_fft_shapes.clear()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _warn_slow_fft_size((36, 29))
+        _warn_slow_fft_size((4, 11, 20))

--- a/test/test_fft.py
+++ b/test/test_fft.py
@@ -68,3 +68,20 @@ def test_warn_slow_fft_size_silent_for_small_shapes():
         warnings.simplefilter("error")
         _warn_slow_fft_size((36, 29))
         _warn_slow_fft_size((4, 11, 20))
+
+
+def test_fast_fft_sizes_stricter_than_scipy():
+    # scipy.fft.next_fast_len targets pocketfft (radix kernels up to 11) and
+    # returns 11-smooth lengths; cuFFT's documented fast path is 7-smooth.
+    # These helpers must stay 7-smooth or GPU grids regress to Bluestein.
+    import scipy.fft
+
+    assert scipy.fft.next_fast_len(121, real=False) == 121  # 11**2: fine for scipy
+    assert not is_fast_fft_size(121)
+    assert next_fast_fft_size(121) == 125  # 5**3
+
+    assert scipy.fft.next_fast_len(4619, real=False) == 4620  # contains 11
+    assert next_fast_fft_size(4619) == 4704  # 2**5 * 3 * 7**2
+
+    # Where the sets agree, results agree (the PR's own headline case).
+    assert scipy.fft.next_fast_len(2623, real=False) == next_fast_fft_size(2623) == 2625

--- a/test/test_fft.py
+++ b/test/test_fft.py
@@ -85,3 +85,33 @@ def test_fast_fft_sizes_stricter_than_scipy():
 
     # Where the sets agree, results agree (the PR's own headline case).
     assert scipy.fft.next_fast_len(2623, real=False) == next_fast_fft_size(2623) == 2625
+
+
+def test_warn_slow_fft_size_thread_safe():
+    # _fft_dispatch runs concurrently in dask worker threads; the warn-once
+    # bookkeeping must not double-warn when threads race on a new shape.
+    import threading
+    from unittest import mock
+
+    from abtem.core import fft as abtem_fft
+
+    shape = (1031, 1033)  # both prime, > 1024*1024 elements
+    abtem_fft._warned_slow_fft_shapes.discard(shape)
+
+    calls = []
+    barrier = threading.Barrier(8)
+
+    def worker():
+        barrier.wait()
+        _warn_slow_fft_size(shape)
+
+    with mock.patch.object(
+        abtem_fft.warnings, "warn", side_effect=lambda *a, **k: calls.append(a)
+    ):
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    assert len(calls) == 1

--- a/test/test_fft.py
+++ b/test/test_fft.py
@@ -87,6 +87,17 @@ def test_fast_fft_sizes_stricter_than_scipy():
     assert scipy.fft.next_fast_len(2623, real=False) == next_fast_fft_size(2623) == 2625
 
 
+def test_fast_fft_sizes_agree_with_cupy():
+    # CuPy made the same call for the same reason: cupyx.scipy.fft.next_fast_len
+    # is 7-smooth, and its docstring notes it deliberately differs from scipy
+    # ("pocketfft's prime factors are different from cuFFT's"). Pin the
+    # agreement so drift on either side fails loudly.
+    cupyx_fft = pytest.importorskip("cupyx.scipy.fft")
+
+    for n in (2, 11, 13, 121, 169, 335, 2623, 4619, 10007):
+        assert cupyx_fft.next_fast_len(n) == next_fast_fft_size(n)
+
+
 def test_warn_slow_fft_size_thread_safe():
     # _fft_dispatch runs concurrently in dask worker threads; the warn-once
     # bookkeeping must not double-warn when threads race on a new shape.

--- a/test/test_fft.py
+++ b/test/test_fft.py
@@ -54,10 +54,61 @@ def test_warn_slow_fft_size_warns_once_per_shape():
 
 
 def test_warn_slow_fft_size_silent_for_fast_shapes():
+    # Large enough to clear the size gate, so it is the fastness check that
+    # has to keep this silent: 2048 = 2**11, 2100 = 2**2 * 3 * 5**2 * 7.
     _warned_slow_fft_shapes.clear()
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        _warn_slow_fft_size((256, 256))
+        _warn_slow_fft_size((2048, 2048))
+        _warn_slow_fft_size((2100, 2100))
+
+
+def test_warn_slow_fft_size_memoizes_only_warned_shapes():
+    # The memo exists to warn once per shape, so it must not accumulate an
+    # entry for every distinct shape the GPU ever transforms -- and a run on a
+    # fast grid must not take the lock on the FFT hot path at all.
+    _warned_slow_fft_shapes.clear()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        for n in (2048, 2100, 2160, 2187, 2240):  # all fast, all large
+            _warn_slow_fft_size((n, n))
+        assert not _warned_slow_fft_shapes
+
+        _warn_slow_fft_size((1031, 1033))  # slow and large: recorded
+        assert _warned_slow_fft_shapes == {(1031, 1033)}
+
+
+def test_warn_slow_fft_size_uses_the_transformed_axes():
+    # fftn over all axes of a 3D structure-factor grid (Bloch waves) must
+    # report every transformed length, not just the trailing two; and the
+    # "set gpts instead of the sampling" remedy does not apply to that grid,
+    # which follows from g_max and the cell.
+    _warned_slow_fft_shapes.clear()
+    with pytest.warns(UserWarning, match=r"FFT size 133 x 133 x 523") as record:
+        _warn_slow_fft_size((133, 133, 523), "fftn", {})
+    assert "gpts" not in str(record[0].message)
+
+    # A leading slow axis is invisible when only shape[-2:] is inspected.
+    _warned_slow_fft_shapes.clear()
+    with pytest.warns(UserWarning, match=r"FFT size 1031 x 2048 x 2048"):
+        _warn_slow_fft_size((1031, 2048, 2048), "fftn", {})
+
+    # 2D transforms keep the gpts remedy.
+    _warned_slow_fft_shapes.clear()
+    with pytest.warns(UserWarning, match="setting gpts explicitly"):
+        _warn_slow_fft_size((4, 2623, 2271), "fft2", {})
+
+
+def test_transform_lengths_ignores_batch_axes_and_tolerates_none_in_s():
+    from abtem.core.fft import _transform_lengths
+
+    assert _transform_lengths((32, 652, 652), "fft2", {}) == (652, 652)
+    assert _transform_lengths((133, 133, 523), "fftn", {}) == (133, 133, 523)
+    assert _transform_lengths((4, 2623, 2271), "fftn", {"axes": (0, 1)}) == (4, 2623)
+    assert _transform_lengths((8, 64), "fft", {}) == (64,)
+    # `s` overrides the array lengths; None entries keep theirs. A raise here
+    # would break the transform itself, not merely skip a diagnostic.
+    assert _transform_lengths((4, 64, 64), "fftn", {"s": (None, 32, 32)}) == (4, 32, 32)
 
 
 def test_warn_slow_fft_size_silent_for_small_shapes():
@@ -102,12 +153,23 @@ def test_warn_slow_fft_size_thread_safe():
     # _fft_dispatch runs concurrently in dask worker threads; the warn-once
     # bookkeeping must not double-warn when threads race on a new shape.
     import threading
+    import time
     from unittest import mock
 
     from abtem.core import fft as abtem_fft
 
     shape = (1031, 1033)  # both prime, > 1024*1024 elements
-    abtem_fft._warned_slow_fft_shapes.discard(shape)
+
+    class SlowMembershipSet(set):
+        """Widens the check-then-add window so an unlocked race is certain."""
+
+        def __contains__(self, item):
+            # Sleep AFTER reading membership, so every racing thread observes
+            # the same "not present" answer and an unlocked check-then-add
+            # really does double-warn.
+            present = super().__contains__(item)
+            time.sleep(0.01)
+            return present
 
     calls = []
     barrier = threading.Barrier(8)
@@ -117,6 +179,8 @@ def test_warn_slow_fft_size_thread_safe():
         _warn_slow_fft_size(shape)
 
     with mock.patch.object(
+        abtem_fft, "_warned_slow_fft_shapes", SlowMembershipSet()
+    ), mock.patch.object(
         abtem_fft.warnings, "warn", side_effect=lambda *a, **k: calls.append(a)
     ):
         threads = [threading.Thread(target=worker) for _ in range(8)]

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -186,3 +186,16 @@ def test_round_to_fast_fft_method():
         assert grid.gpts == (336, 336)
         assert grid.extent == (10.0, 10.0)
         check_grid_consistent(grid.extent, grid.gpts, grid.sampling)
+
+
+def test_round_to_fast_fft_leaves_non_fft_grids_alone():
+    # A grid that is never Fourier transformed (a GridScan's probe positions)
+    # gains nothing from a fast length, and rounding it would change what is
+    # simulated rather than how fast it runs.
+    assert Grid(extent=(131.15, 131.15), gpts=(2623, 2623)).round_to_fast_fft() == (
+        2625,
+        2625,
+    )
+    scan_grid = Grid(extent=(131.15, 131.15), gpts=(2623, 2623), fft_grid=False)
+    assert scan_grid.round_to_fast_fft() == (2623, 2623)
+    assert scan_grid.gpts == (2623, 2623)

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -102,29 +102,35 @@ def test_gpts_change(grid_data, new_extent):
 
 @given(grid_data=grid_data(), new_sampling=abtem_st.sampling())
 def test_sampling_change(grid_data, new_sampling):
-    grid = Grid(**grid_data)
+    # Pin the option: these assert the behaviour of the default mode,
+    # which a user-level override of the config would otherwise change.
+    with config.set({"grid.round-to-fast-fft": "auto"}):
+        grid = Grid(**grid_data)
 
-    grid.sampling = new_sampling
-    if grid.extent is None:
-        assert (
-            grid.sampling == ensure_is_tuple(new_sampling, 2)
-            if new_sampling is not None
-            else new_sampling
-        )
-    else:
-        adjusted_sampling = grid.extent / np.ceil(
-            np.array(grid.extent) / np.array(new_sampling)
-        )
-        assert np.allclose(grid.sampling, adjusted_sampling)
+        grid.sampling = new_sampling
+        if grid.extent is None:
+            assert (
+                grid.sampling == ensure_is_tuple(new_sampling, 2)
+                if new_sampling is not None
+                else new_sampling
+            )
+        else:
+            adjusted_sampling = grid.extent / np.ceil(
+                np.array(grid.extent) / np.array(new_sampling)
+            )
+            assert np.allclose(grid.sampling, adjusted_sampling)
 
-    check_grid_consistent(grid.extent, grid.gpts, grid.sampling)
+        check_grid_consistent(grid.extent, grid.gpts, grid.sampling)
 
 
 def test_fast_fft_rounding_off_by_default():
-    # 10 / 0.03 -> ceil = 334 = 2 * 167; 167 is prime, so 334 is not a fast
-    # FFT length and must be kept exactly as derived when the option is off.
-    grid = Grid(extent=10, sampling=0.03)
-    assert grid.gpts == (334, 334)
+    # Pin the option: these assert the behaviour of the default mode,
+    # which a user-level override of the config would otherwise change.
+    with config.set({"grid.round-to-fast-fft": "auto"}):
+        # 10 / 0.03 -> ceil = 334 = 2 * 167; 167 is prime, so 334 is not a fast
+        # FFT length and must be kept exactly as derived when the option is off.
+        grid = Grid(extent=10, sampling=0.03)
+        assert grid.gpts == (334, 334)
 
 
 def test_fast_fft_rounding_refines_sampling():
@@ -168,12 +174,15 @@ def test_fast_fft_rounding_applies_on_sampling_change():
 
 
 def test_round_to_fast_fft_method():
-    grid = Grid(extent=10, sampling=0.03)
-    assert grid.gpts == (334, 334)
+    # Pin the option: these assert the behaviour of the default mode,
+    # which a user-level override of the config would otherwise change.
+    with config.set({"grid.round-to-fast-fft": "auto"}):
+        grid = Grid(extent=10, sampling=0.03)
+        assert grid.gpts == (334, 334)
 
-    gpts = grid.round_to_fast_fft()
+        gpts = grid.round_to_fast_fft()
 
-    assert gpts == (336, 336)
-    assert grid.gpts == (336, 336)
-    assert grid.extent == (10.0, 10.0)
-    check_grid_consistent(grid.extent, grid.gpts, grid.sampling)
+        assert gpts == (336, 336)
+        assert grid.gpts == (336, 336)
+        assert grid.extent == (10.0, 10.0)
+        check_grid_consistent(grid.extent, grid.gpts, grid.sampling)

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -7,6 +7,7 @@ import strategies as abtem_st
 from hypothesis import assume, given
 from utils import ensure_is_tuple
 
+from abtem.core import config
 from abtem.core.grid import Grid, GridUndefinedError
 
 
@@ -116,4 +117,63 @@ def test_sampling_change(grid_data, new_sampling):
         )
         assert np.allclose(grid.sampling, adjusted_sampling)
 
+    check_grid_consistent(grid.extent, grid.gpts, grid.sampling)
+
+
+def test_fast_fft_rounding_off_by_default():
+    # 10 / 0.03 -> ceil = 334 = 2 * 167; 167 is prime, so 334 is not a fast
+    # FFT length and must be kept exactly as derived when the option is off.
+    grid = Grid(extent=10, sampling=0.03)
+    assert grid.gpts == (334, 334)
+
+
+def test_fast_fft_rounding_refines_sampling():
+    with config.set({"grid.round-to-fast-fft": True}):
+        grid = Grid(extent=10, sampling=0.03)
+
+    assert grid.gpts == (336, 336)  # 336 = 2**4 * 3 * 7
+    assert all(d <= 0.03 for d in grid.sampling)
+    assert grid.extent == (10.0, 10.0)
+    check_grid_consistent(grid.extent, grid.gpts, grid.sampling)
+
+
+def test_fast_fft_rounding_keeps_fast_gpts():
+    with config.set({"grid.round-to-fast-fft": True}):
+        grid = Grid(extent=10, sampling=0.1)
+
+    assert grid.gpts == (100, 100)  # 100 = 2**2 * 5**2 is already fast
+
+
+def test_fast_fft_rounding_never_alters_explicit_gpts():
+    with config.set({"grid.round-to-fast-fft": True}):
+        grid = Grid(extent=10, gpts=334)
+
+    assert grid.gpts == (334, 334)
+
+
+def test_fast_fft_rounding_exempts_endpoint_grids():
+    with config.set({"grid.round-to-fast-fft": True}):
+        grid = Grid(extent=10, sampling=0.03, endpoint=True)
+
+    assert grid.gpts == (335, 335)
+
+
+def test_fast_fft_rounding_applies_on_sampling_change():
+    grid = Grid(extent=10, sampling=0.1)
+    with config.set({"grid.round-to-fast-fft": True}):
+        grid.sampling = 0.03
+
+    assert grid.gpts == (336, 336)
+    check_grid_consistent(grid.extent, grid.gpts, grid.sampling)
+
+
+def test_round_to_fast_fft_method():
+    grid = Grid(extent=10, sampling=0.03)
+    assert grid.gpts == (334, 334)
+
+    gpts = grid.round_to_fast_fft()
+
+    assert gpts == (336, 336)
+    assert grid.gpts == (336, 336)
+    assert grid.extent == (10.0, 10.0)
     check_grid_consistent(grid.extent, grid.gpts, grid.sampling)


### PR DESCRIPTION
Hi!

While running large-scale HAADF simulations on Perlmutter, Claude and I found that a lot of performance is lost when the automatic grid lands on an *FFT-unfriendly* size: `gpts = ceil(extent / sampling)` regularly produces
sizes like 2623 = 43×61, and FFT libraries (FFTW, MKL, cuFFT) only have fast kernels for sizes whose prime factors are all in {2, 3, 5, 7}.

The focus of this PR is making the *default* grid choice do the right thing. As discussed, it is rebased on #274, and `sampling='auto'` now produces grids that are commensurate with the lattice *and* FFT-fast wherever the two are
compatible — commensurability wins when they are not, since aliasing is a physics error while a slow FFT only costs time. For structures with no commensurate grid (rutile, brookite), the fallback now aligns the grid to the structure's translational period, which fixed a latent sub-pixel alignment issue along the way. Explicit numeric sampling keeps its exact current behaviour — the rounding is available there as an opt-in (`grid.round-to-fast-fft`, or `Grid.round_to_fast_fft()`), so no existing script changes results.

Measured on production-scale scans: 3–6× faster on CPU, up to 3× end-to-end on an A100 at float64. (FFT-friendly grids also need far less cuFFT plan workspace at float64, which for our original workload made the difference between OOM and completion — details in the benchmarks below.)

Best,
Paul

-------------

# Claude's summary

zed batch; all measured below; the issue surfaced while diagnosing an OOM in a production 4×A100 HAADF run). CPU FFTs (FFTW, pocketfft, MKL) are also measurably slower on such lengths, so the feature applies to both device paths — it lives in `Grid`, which is device-agnostic, and 7-smooth lengths are optimal for every backend abTEM uses.

## Targets the autogrid branch — one grid, both conditions

As suggested in review, this PR now **targets `autogrid` (#274)** rather than `dev`: it contains only the fast-FFT work and the integration, sitting directly on the living autogrid branch (including its recent slice-thickness fixes, the multi-configuration AtomsEnsemble skip, and the new `test/test_commensurate_potential.py` suite). Merge order becomes: #347 → `autogrid`, then #274 carries everything to `dev`. The integration makes `sampling='auto'` fulfil **both** conditions:

- **Commensurate and fast.** When the GCD search finds a commensurate grid period p, the grid becomes the smallest multiple of p that is 7-smooth and not coarser than the target sampling. A multiple of p is a fast FFT size exactly when p and the multiplier both are — so when p itself contains a prime factor larger than 7, no fast multiple exists and commensurability takes precedence unchanged (aliasing of the nuclear potential is a physics error; a slow FFT only costs time).
- **Incommensurate structures: translational period preserved.** Structures with irrational internal parameters (rutile u = 0.306, brookite) have no exactly commensurate grid, and re-testing exposed a latent constraint: gpts must remain a multiple of the unit-cell repeat count, or symmetry-equivalent atoms in different cells land at different sub-pixel offsets and receive different discretised potentials. The previous `ceil`-derived fallback satisfied this only by coincidence of where `ceil` landed. The fallback now detects the translational period from the atom-plane set directly and picks the best-plane-aligned fast multiple of it. For rutile this beats the raw target size outright: 294 px = 2·3·7² aligns the planes to ~0.01 px (u = 0.306 ≈ 30/98), versus ~0.15 px at the old fallback size.
- **Translation-invariant fallback scoring.** The incommensurate fallback ranks candidate fast sizes by *alignability* — the smallest achievable max plane-to-gridpoint distance over all grid-origin phases, computed from the largest circular gap of the plane residues — which depends only on relative positions. A rigidly shifted structure therefore gets the same grid, preserving the invariant autogrid's own test suite checks (an earlier absolute-position score failed `test_gpts_is_translation_invariant` for rutile/brookite).
- **Composes with the AtomsEnsemble skip:** ensemble (and non-periodic) grids have no commensurability constraint, so their target-derived sizes are simply rounded up to fast lengths — rounding there is free.
- `commensurate_gpts(..., round_to_fast_fft=False)` reproduces #274's behaviour exactly, for direct comparison.

Fast grids are the **default for `sampling='auto'`** — it is a new code path with no existing scripts to preserve — while the plain numeric-sampling path stays strictly opt-in (below).

## What this adds

- **`grid.round-to-fast-fft` config option (default `false`).** When enabled, gpts *derived from a requested sampling* are rounded up to the next 7-smooth length inside `Grid._adjust_gpts`. Guarantees:
  - rounding is **upward only** — the realized sampling is never coarser than requested;
  - **explicitly given `gpts` are never altered** (only the sampling→gpts derivation is touched);
  - **endpoint grids are exempt** (they are not periodic FFT grids);
  - idempotent — already-fast sizes pass through unchanged.

  Example (the case above): off → (2623, 2271); on → (2625, 2304) (= 3·5³·7, 2⁸·3²), sampling 0.0499/0.0493 Å, +1.5 % pixels. `probe.grid.match(potential)` propagates the rounded grid consistently.

- **FFT-fast commensurate `sampling='auto'`** (see previous section): commensurate with the lattice *and* 7-smooth wherever the two are compatible, with a principled fallback for incommensurate structures.

- **`Grid.round_to_fast_fft()`** method for explicit one-shot use, mirroring `round_to_power()`. Note `round_to_power`'s docstring promises sizes "factored into small primes" but the implementation produces *pure* powers of a single base (2623 → 4096, +56 % pixels vs. +0.08 % for 2625); the new method provides what that docstring describes. A follow-up could deprecate or redirect `round_to_power`.

- **`is_fast_fft_size()` / `next_fast_fft_size()`** helpers in `abtem.core.fft`, plus a one-time `UserWarning` when a large (≥ 1024²) GPU FFT runs on a Bluestein-fallback shape, suggesting the nearest fast grid. The helpers commit is shared verbatim with the `multi-gpu-hardening` branch (#346) — whichever merges first, the other rebases to an empty commit.

## Review round 1 (addressed)

- **Why not `scipy.fft.next_fast_len`?** Deliberate divergence, now documented in code and pinned by a test: scipy targets pocketfft, whose kernels go up to radix 11, so it returns **11-smooth** lengths (`next_fast_len(121) == 121 == 11²`, `next_fast_len(4619) == 4620 = 2²·3·5·7·11`). cuFFT documents optimized kernels only for `2^a·3^b·5^c·7^d`, so factor-11 grids fall off exactly the GPU fast path this feature protects. {2, 3, 5, 7} is the intersection guaranteed fast on every backend abTEM uses. CuPy independently made the same call: `cupyx.scipy.fft.next_fast_len` is 7-smooth, agrees with our helper on every probed value, and its docstring notes the deliberate difference from scipy; a test pins the agreement (skipped without cupy).
- **Warn-once race:** fixed with a lock around the check-then-add on the warned-shapes set (the warning itself stays outside); barrier-synchronized 8-thread test added.
- **O(n² log n) period search:** reworked. A shift mapping the plane set onto itself must map the first plane onto some plane, so candidates are only the differences to the first plane, filtered to near-integer L/s and tested smallest-first (first hit = largest m). Typically O(n log n); a 2400-plane incommensurate supercell now takes 1.9 ms.

## Review round 2 (addressed)

All six findings confirmed; none refuted. Two were worse than reported, one was benign, and three more problems in the surrounding code turned up while fixing them.

- **Periodic wrap in the plane matching** (finding 1) — real, and reachable on ordinary crystals. Not at the low end (the caller's `x > L - tolerance -> 0` snap keeps input planes away from L), but at the high end, because that snap protects the *input* planes and not the *shifted* ones — and `orthogonalize_cell` returns rutile's L/2 plane one ulp short. Measured through the public API: rutile in `plane='xz'` gave gpts (98,60) unshifted vs (108,60) shifted by 1e-6 Å, breaking the documented translation invariance, and calcite 6×5×1 came out with an odd gpts against a true period of 450, spreading symmetry-equivalent atoms over 0.44 px instead of 2e-6 px. Fixed by indexing modulo n; checked against an independent brute-force periodic oracle over ~1.3 M invariance evaluations with zero disagreements.
- **The 64-candidate cap** (finding 3) — removed outright rather than made graceful. Reachable on tiled disordered cells (an amorphous support film repeated to cover the field of view). No cap is needed: the candidate count is bounded by how many distinct `L/m` are more than `tolerance` apart, not by the number of planes, so the search is sub-quadratic in atom count at fixed cell size — worst case constructible inside a plausible cell is 167 ms, against ~1.2 s just to build the potential array. Each distinct m is now tested once at the **exact** shift `L/m` rather than at the difference that suggested it, which is both faster and more correct: the difference carries the plane's float noise, and an off-period difference rounding to m could suppress the genuine shift. (Findings 1 and 3 compound: on calcite the wrap bug rejected every genuine candidate, the search then exhausted the cap, and the result was "no period" at all.)
- **The config governed only half the feature** (finding 2) — the option is now tri-state: `'auto'` (new default) rounds only grids abTEM derives itself, `True` additionally rounds gpts derived from a numeric sampling, `False` never rounds. Numeric-sampling behaviour is unchanged in the default mode, and `False` reproduces the plain commensurate grid exactly. `'auto'` is truthy, so every read goes through a mode helper and an unrecognized value raises instead of silently meaning "on".
- **The warning ignored leading transformed axes** (finding 5) — worse than reported: both the fastness check *and* the size gate were computed from `shape[-2:]`, so a slow leading axis was invisible on the 3D structure-factor path, whose grid is essentially never 7-smooth. Lengths now come from the function and its `axes`/`axis`/`s` arguments; `s` entries of `None` are tolerated (a raise here would break the transform, not just the diagnostic), and the "set gpts" remedy is dropped where it does not apply.
- **Warn-cache hygiene** (finding 6) — real but benign (a realistic GPU scan produced one 130-byte entry). Fixed anyway: the size and fastness checks now precede the lock, so only shapes that actually warn are recorded and a fast-grid run never takes the lock.
- **`round_to_power`** (finding 4) — a discoverability trap rather than a defect: zero callers, and its docstring promised what `round_to_fast_fft` actually does. Behaviour left alone (dead but public); the docstring now describes it accurately, cross-references the new method, and notes the float-`log` artifact that overshoots for 125, 15625 and 16807. Deprecating it is a maintainer decision, not this PR's.

Found while fixing the above, not raised in review:

- The fallback's documented +12 % window was **not enforced** — the candidate that terminated the search was still scored and, being the largest, usually won: rutile took 1.17× the target size (+38 % pixels) for a 2.6 pm alignment gain. Now tested before scoring, with candidates compared by misalignment in Ångström rather than in fractions of a grid spacing.
- Grids that were **already fast** were enlarged anyway (Cu fcc 6×6: 432 = 2⁴·3³ → 480, +23.5 % pixels, equivalent-atom spread at float noise either way). The nearest commensurate grid is now kept when already fast, so Si, Cu and MoS₂ keep autogrid's own grid; Au (164 = 2²·41) and SrTiO₃ (234 = 2·3²·13) still move. Rounding the multiplier **up** in the remaining cases keeps the grid from ever coming out coarser than with rounding off.
- `grid.round-to-fast-fft: True` rounded **GridScan probe positions**, changing the probe count and scan step for a grid that is never Fourier transformed (and disagreeing with `LineScan`, which does not use `Grid`). Grids now carry an `fft_grid` flag; `GridScan` opts out.

## Review round 3 (addressed)

- **The fallback's overshoot window was not a bound.** Moving the guard cannot fix it: candidates ascend, so if the first fast multiple of the period `m` overshoots, every one does and there is no in-window candidate to find (`m=64` against a target of 72 lands on 128, +78 %). This branch now gets the same escape the other one already had — when no fast multiple fits the window, keep the period constraint and drop fastness. The documented window is a real bound again, and the two branches behave alike. As with that pre-existing branch, the escape can land marginally coarser than the target; the alternative is +78 % pixels.
- **The 3D structure-factor transform escaped the diagnostic.** Confirmed, but it cannot simply be routed through `abtem.core.fft.ifftn`: the FFTW backend behind that wrapper hardcodes `axes=(-2, -1)`, so wrapped `fftn`/`ifftn` silently perform a **2D** transform on 3D input under the default `fft: fftw` config (verified identical on `origin/autogrid` — pre-existing, not introduced here). The transform therefore stays on `xp.fft` and requests the diagnostic explicitly through a GPU-only helper. The wrapper bug is left alone as out of scope for this PR.
- **`Grid.round_to_fast_fft()` ignored `fft_grid`.** The automatic path already skipped grids that are never Fourier transformed; the explicit method now does too.

## Defaults: opt-in for numeric sampling, on for `sampling='auto'`

Rounding numeric-sampling grids by default would change gpts — and therefore results bit-for-bit — for every existing sampling-specified script: regression baselines, published numbers, and shape-compatibility with stored data (zarr archives, S-matrix caches) would all silently shift. Off-by-default preserves exact backward compatibility there; the GPU warning steers users toward enabling it. `sampling='auto'`, by contrast, is new in this PR series and ships fast-by-default from the start. With 1.1 already carrying a numerics-breaking propagator change (#298), flipping the numeric-sampling default could be considered too, but that is left as a deliberate follow-up decision.

## Benchmarks

Measured on an AMD Strix Halo dev box: CPU = FFTW, single thread, `FFTW_ESTIMATE` planning (autotuning excluded); GPU = Radeon 8050S iGPU via CuPy 13.5.1 / ROCm hipFFT. `float32`/`complex64`; median of repeats after warm-up. "Small" is 10 Å at 0.03 Å sampling, "large" is the 131.1 × 113.5 Å production cell at 0.05 Å. The end-to-end case is a 4-slice HAADF probe scan (60 keV, 31.5 mrad, annular 70–200 mrad).

| benchmark | device | ceil gpts | fast gpts | ceil | fast | speedup | extra pixels |
|---|---|---|---|---|---|---|---|
| fft2+ifft2, batch 8 | CPU | 334² | 336² | 44.0 ms | 6.4 ms | **6.9×** | +1.2 % |
| fft2+ifft2, batch 4 | CPU | 2623×2271 | 2625×2304 | 1486.6 ms | 421.4 ms | **3.5×** | +1.5 % |
| HAADF scan, 64 pos | CPU | 334² | 336² | 2328.5 ms | 591.8 ms | **3.9×** | +1.2 % |
| HAADF scan, 4 pos | CPU | 2623×2271 | 2625×2304 | 10310.1 ms | 3334.6 ms | **3.1×** | +1.5 % |
| fft2+ifft2, batch 8 | GPU | 334² | 336² | 3.0 ms | 1.5 ms | **2.0×** | +1.2 % |
| fft2+ifft2, batch 4 | GPU | 2623×2271 | 2625×2304 | 140.1 ms | 99.8 ms | **1.4×** | +1.5 % |
| HAADF scan, 64 pos | GPU | 334² | 336² | 179.1 ms | 97.2 ms | **1.8×** | +1.2 % |
| HAADF scan, 4 pos | GPU | 2623×2271 | 2625×2304 | 1199.8 ms | 892.1 ms | **1.3×** | +1.5 % |

The same benchmark on a Perlmutter A100 (cuFFT, CUDA 40 GB):

| benchmark | ceil gpts | fast gpts | ceil | fast | speedup |
|---|---|---|---|---|---|
| fft2+ifft2, batch 8 | 334² | 336² | 0.2 ms | 0.2 ms | (launch-bound) |
| fft2+ifft2, batch 4 | 2623×2271 | 2625×2304 | 5.1 ms | 2.8 ms | **1.8×** |
| HAADF scan, 64 pos | 334² | 336² | 32.6 ms | 31.5 ms | 1.04× |
| HAADF scan, 4 pos | 2623×2271 | 2625×2304 | 97.7 ms | 83.7 ms | 1.17× |

| memory (after one round-trip) | data | pool | ratio |
|---|---|---|---|
| ceil 2623×2271, batch 4 | 190.6 MB | 953.1 MB | 5.0× |
| fast 2625×2304, batch 4 | 193.5 MB | 774.1 MB | 4.0× |

### Production-scale memory and speed (float64, serial 40 GB A100)

The decisive test of the memory claim: the full production workload (101,871-position HAADF scan, float64) with *only the grid changed*, run on plain `dev` and on the `multi-gpu-hardening` branch (#346, whose bounded plan cache runs the oversized ceil-grid plan uncached):

| branch | ceil (2623×2271) | fast (2625×2304) |
|---|---|---|
| dev | **OOM** (pool 41.2 GB — the original production crash) | **completes: 21.43 GB peak**, 1041 s |
| #346 branch | completes: 31.32 GB peak, 3095 s | 21.43 GB peak, **1027 s** |

Isolated plan workspace for a 16-probe batch: **11.0 GB (ceil) vs 1.55 GB (fast)** at complex128 — 7.1×; 0.76 GB vs ≈0 at complex64. The ceil-vs-fast peak difference (31.3 → 21.4 GB) is almost exactly that transient 11 GB workspace. End-to-end at this scale the fast grid is also **3.0× faster** — well above the small-benchmark GPU ratios, because the Bluestein planning cost compounds over ~6400 batches. Fast-grid results are bit-identical across branches (same checksum on dev and #346).

Reading: the CPU gains (3–6×) are the headline and reproduce on both machines. On the A100 the raw large-grid FFT gap is 1.8× — larger than on ROCm, cuFFT's Bluestein being the costlier fallback — while the end-to-end rows are diluted at this benchmark size because non-FFT overheads dominate on so fast a GPU (the 4-position scan spends ~10–20 ms of its 98 ms in FFTs); production-scale scans amortize toward the raw ratio. On memory, the effect at complex64 is real but modest: the round-trip holds ~3× data in live arrays, so the retained plan workspace is ≈ 2× data for the Bluestein shape vs ≈ 1× for the fast shape (~20 % pool reduction here). At complex128 it is anything but modest — see the production-scale table above: 7× plan workspace, 32 % peak reduction, and OOM-vs-completes on plain dev. CPU numbers use `FFTW_ESTIMATE`; `FFTW_MEASURE` narrows the CPU gap somewhat in exchange for per-shape planning time.

## Testing

- Autogrid's own `test/test_commensurate_potential.py` passes in full on the combined grids: all 19 lattice types (hexagonal included — coverage the old root-level scripts skipped), translation invariance (rutile/brookite via the translational-period fallback), slabs with vacuum, supercell sizes, parametrizations, axis orientations, and the ensemble behavior (expected gpts adapted to the fast-rounded values, with a comment).
- New `test/test_commensurate_gpts.py`: combined commensurate+fast conditions, upward-only sampling, smallest-fast-multiple selection, `round_to_fast_fft=False` equivalence to #274, both fallback regimes (fast translational period → fast multiple; non-smooth period → commensurability wins), fallback timing guard, end-to-end `Potential(sampling='auto')` for Si and Au.
- New unit tests in `test_grid.py` (default-off regression, refinement direction, already-fast passthrough, explicit-gpts immunity, endpoint exemption, sampling-setter path, the explicit method) and `test_fft.py` (helpers, warning, thread-safety, scipy-divergence and cupyx-agreement pins).
- The suite passes with `grid.round-to-fast-fft` set to `false` and to `true` alike — it previously failed both ways, because several tests read the ambient config instead of pinning it.
- Every new test was checked to actually **fail** with the fix it guards reverted. Three that could not fail were rewritten, including round 1's thread-safety test, which passed against the unlocked code and now observes 8 warnings without the lock and 1 with it.
- Full suite on the current base: no new failures — the failing set is byte-identical to unmodified `autogrid` (GPU/ROCm and GPAW-version cases that fail there too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)