### PR TITLE
Stop deep-copying (and re-uploading to GPU) the projection integrator per ensemble member

### DIFF
--- a/abtem/potentials/iam.py
+++ b/abtem/potentials/iam.py
@@ -1073,7 +1073,19 @@ class _FieldBuilderFromAtoms(_FieldBuilder):
 
     def _from_partitioned_args(self, *args, **kwargs):
         frozen_phonons_partial = self.frozen_phonons._from_partitioned_args()
-        kwargs = self._copy_kwargs(exclude=("atoms", "sampling"))
+        # integrator is excluded from the deep-copied kwargs and passed through
+        # by reference: generate_blocks()/ensemble_blocks() reconstruct a fresh
+        # Potential per ensemble member, and integrators (e.g.
+        # QuadratureProjectionIntegrals) lazily cache per-symbol projection
+        # tables and, on GPU, device-resident arrays specifically so repeated
+        # calls across many slices don't re-upload them (see the PR #309
+        # discussion in integrals.py). Deep-copying the integrator per member
+        # silently defeats that cache for every single ensemble member -- on
+        # GPU this means a real device-to-device copy of the cached arrays for
+        # every member, for no benefit, since the copy is used once and
+        # discarded.
+        kwargs = self._copy_kwargs(exclude=("atoms", "sampling", "integrator"))
+        kwargs["integrator"] = self.integrator
 
         return partial(
             self._from_partitioned_args_func,

--- a/test/test_potentials.py
+++ b/test/test_potentials.py
@@ -863,3 +863,59 @@ def test_potential_array_slicing_maps_exit_planes():
     split = waves.multislice(potential[:9]).multislice(potential[9:])
 
     assert np.allclose(whole.array, split.array)
+
+
+class TestIntegratorSharedAcrossEnsemble:
+    """generate_blocks()/ensemble_blocks() reconstruct a fresh Potential per
+    ensemble member. The integrator must be passed through by reference, not
+    deep-copied, or every member silently rebuilds (and, on GPU, re-uploads)
+    the per-symbol projection tables and disk caches that QuadratureProjection-
+    Integrals/ScatteringFactorProjectionIntegrals exist specifically to avoid
+    recomputing across repeated calls."""
+
+    def test_integrator_identity_preserved_across_members(self):
+        import abtem
+
+        atoms = Atoms("Si2", positions=[[0, 0, 0], [1, 1, 1]], cell=[4, 4, 4], pbc=True)
+        fp = abtem.FrozenPhonons(atoms, num_configs=4, sigmas=0.05, seed=1)
+        potential = Potential(fp, sampling=0.2, slice_thickness=1.0, projection="finite")
+
+        original_integrator = potential.integrator
+        # Populate the cache the way a real build would, so a deep copy has
+        # actual cached state to (wrongly) duplicate.
+        original_integrator.get_integral_table("Si", potential.sampling)
+
+        seen_integrator_ids = set()
+        seen_table_ids = set()
+        n_members = 0
+        for _, _, block in potential.generate_blocks():
+            block = block.item()
+            n_members += 1
+            seen_integrator_ids.add(id(block.integrator))
+            seen_table_ids.add(id(block.integrator.tables))
+
+        assert n_members == 4
+        assert seen_integrator_ids == {id(original_integrator)}
+        assert seen_table_ids == {id(original_integrator.tables)}
+
+    @pytest.mark.parametrize("projection", ["finite", "infinite"])
+    def test_shared_integrator_does_not_change_results(self, projection):
+        import abtem
+
+        atoms = Atoms("Si2", positions=[[0, 0, 0], [1, 1, 1]], cell=[4, 4, 4], pbc=True)
+        fp = abtem.FrozenPhonons(atoms, num_configs=4, sigmas=0.05, seed=1)
+        potential = Potential(
+            fp, sampling=0.2, slice_thickness=1.0, projection=projection
+        )
+
+        waves = abtem.PlaneWave(energy=100e3)
+        exit_waves = waves.multislice(potential, lazy=False)
+
+        # Rebuilding member-by-member via the (shared-integrator) path used
+        # by generate_blocks() must match the direct build for every member.
+        for index, _, block in potential.generate_blocks():
+            block = block.item()
+            direct = abtem.PlaneWave(energy=100e3).multislice(block, lazy=False)
+            np.testing.assert_allclose(
+                exit_waves.array[index], direct.array[0], atol=1e-10
+            )


### PR DESCRIPTION
## Summary

Found while chasing poor GPU utilization on an energy-resolved frozen-phonon multislice ensemble (see #349 for the related, separate finding about the multislice loop not being vectorized across ensemble members). This one is a genuine bug, not an architecture limitation.

`_FieldBuilderFromAtoms._from_partitioned_args()` — the method `generate_blocks()`/`ensemble_blocks()` use to reconstruct a `Potential` for each ensemble member — built its constructor kwargs via `self._copy_kwargs(...)`, which `copy.deepcopy`s every kwarg, including `integrator`.

`QuadratureProjectionIntegrals`/`ScatteringFactorProjectionIntegrals` lazily cache per-symbol projection tables and, on GPU, device-resident disk arrays (`_device_arrays`) — specifically to avoid rebuilding/re-uploading them repeatedly (see the existing comment in `integrals.py` referencing the PR #309 discussion: re-uploading the disk array "every slice measurably dominated GPU build time"). Deep-copying the integrator on every ensemble-member reconstruction silently rebuilds that entire cache from scratch, once per member, then throws it away when that member's potential object goes out of scope.

On GPU this isn't just wasted CPU time: `copy.deepcopy` on a CuPy array performs a real device-to-device memory copy. For an ensemble of N members, that's N redundant table/disk cache rebuilds and N redundant GPU array copies, none of which does anything useful — it directly explained user-observed GPU utilization during "just computing the potential" that wasn't attributable to any actual multislice math.

## Verification

Confirmed empirically before fixing: building a 4-member `FrozenPhonons` `Potential` and walking `generate_blocks()` showed 4 distinct `integrator` object ids (none matching the original, cache-populated instance) and 4 distinct `_tables` dict ids.

After the fix, all 4 members share the same `integrator` instance and `_tables` dict.

Numerical results are unaffected — checked a multi-config, multi-species (SiC) multislice run before/after: identical checksums to displayed precision.

## What changed

- `integrator` is now excluded from `_copy_kwargs()`'s deep-copied set in `_from_partitioned_args()` and passed through explicitly by reference, so the same integrator instance (and its lazily-populated caches) is reused across every ensemble member reconstructed from the same `Potential`.
- Two new regression tests in `test/test_potentials.py` (`TestIntegratorSharedAcrossEnsemble`): one asserts identity is preserved across `generate_blocks()`, one asserts results are unchanged for both `projection="finite"` and `projection="infinite"`.

## Test plan
- [x] New regression tests pass (`test_integrator_identity_preserved_across_members`, `test_shared_integrator_does_not_change_results[finite|infinite]`)
- [x] Full `test/test_potentials.py` passes
- [x] Full suite passes (`-n auto`): no regressions
- [x] Numerical results verified unchanged before/after the fix (checksum match on multi-config, multi-species multislice)
- [x] Real GPU utilization/timing improvement verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
