### PR TITLE
Fix exploded spectrum panel layout, silent single-config zeros, and add crop()

### DIFF
--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -6001,7 +6001,14 @@ class MomentumResolvedSpectrum(BaseMeasurements):
             nrows = (n + ncols - 1) // ncols
             if figsize is None:
                 figsize = (4 * ncols, 3.5 * nrows)
-            fig, axes_arr = plt.subplots(nrows, ncols, figsize=figsize, squeeze=False)
+            fig, axes_arr = plt.subplots(
+                nrows,
+                ncols,
+                figsize=figsize,
+                squeeze=False,
+                sharex=True,
+                sharey=True,
+            )
             axes_flat = axes_arr.flatten()
 
             # Shared colour scale across panels so the single colorbar applies to
@@ -6030,11 +6037,28 @@ class MomentumResolvedSpectrum(BaseMeasurements):
                     a.set_title(panel_title)
             for k in range(len(indices), len(axes_flat)):
                 axes_flat[k].set_visible(False)
+
+            # Hide the x/y tick labels and axis labels of interior panels
+            # (kept only on the bottom row / left column), since sharex/sharey
+            # above already makes them redundant on every other panel.
+            for a in axes_flat[: len(indices)]:
+                a.label_outer()
+
+            # tight_layout() must run before fig.colorbar(): colorbar()
+            # shrinks the given panel axes via their gridspec to make room for
+            # the new colorbar axes, and a tight_layout() call afterwards
+            # would re-layout every axes from scratch -- including the
+            # colorbar axes, which it has no special handling for -- and can
+            # end up overlapping it with the last panel instead of leaving it
+            # in its own strip.
+            fig.tight_layout()
             if cbar and im is not None:
                 fig.colorbar(
-                    im, ax=axes_flat[: len(indices)].tolist(), label=cbar_label
+                    im,
+                    ax=axes_flat[: len(indices)].tolist(),
+                    label=cbar_label,
+                    pad=0.015,
                 )
-            fig.tight_layout()
             return fig, axes_arr
 
         # Single panel — collapse any ensemble axes to their first element.

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -6193,6 +6193,14 @@ def phonon_loss_diffraction_patterns(
     ``FrozenPhononsAxis`` is collapsed.  Apply an offset ``AnnularDetector``
     or ``SlitDetector`` to integrate over desired q points.
 
+    Note that ``I_tds`` is the variance of the diffracted amplitude across
+    frozen-phonon configurations: with a single configuration per energy,
+    ``I_incoherent`` and ``I_coherent`` are identical by construction and
+    ``I_tds`` is exactly zero everywhere, not a numerical artifact. At least
+    2 configurations per energy are required for ``component="tds"``/``"all"``
+    (this is enforced with a ``ValueError``); in practice many more are
+    needed for good statistics.
+
     Parameters
     ----------
     exit_waves : Waves
@@ -6261,6 +6269,18 @@ def phonon_loss_diffraction_patterns(
 
     # --- number of frozen-phonon configurations ---
     N = exit_waves.shape[fp_axis_idx]
+
+    if N < 2 and component in ("tds", "all"):
+        raise ValueError(
+            f"component={component!r} requires at least 2 frozen-phonon "
+            f"configurations per energy, got N={N}. TDS/phonon-loss is "
+            "I_incoherent - I_coherent, the variance of the diffracted "
+            "amplitude across configurations -- for a single configuration "
+            "I_incoherent and I_coherent are identical by construction, so "
+            "the result is exactly zero everywhere, not a numerical fluke. "
+            "Build the EnergyResolvedAtomsEnsemble with more than one "
+            "configuration per energy to get a non-trivial signal."
+        )
 
     dp_kwargs = dict(max_angle=max_angle, parity=parity, fftshift=True)
 

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -5789,6 +5789,25 @@ class IndexedDiffractionPatterns(BaseMeasurements):
         )
 
 
+def _axis_range_mask(
+    values: np.ndarray, value_range: Optional[tuple[float, float]], param_name: str
+) -> np.ndarray:
+    if value_range is None:
+        return np.ones(len(values), dtype=bool)
+
+    lo, hi = value_range
+    if lo > hi:
+        raise ValueError(f"{param_name}={value_range}: min must not exceed max")
+
+    mask = (values >= lo) & (values <= hi)
+    if not mask.any():
+        raise ValueError(
+            f"{param_name}={value_range} selects no data -- values span "
+            f"[{values.min()}, {values.max()}]"
+        )
+    return mask
+
+
 class MomentumResolvedSpectrum(BaseMeasurements):
     """
     Momentum-resolved energy-loss spectrum S(q, E).
@@ -5796,6 +5815,11 @@ class MomentumResolvedSpectrum(BaseMeasurements):
     Stores a 2D intensity array whose last two dimensions correspond to
     scattering-vector bins (q) and energy bins (E). Additional leading
     dimensions are ensemble axes.
+
+    Use :meth:`crop` to restrict the q/energy-loss range before plotting
+    with :meth:`show` -- besides zooming in, this also rescales the
+    colour scale (and, for an exploded grid, every panel's shared colour
+    scale) to the cropped region instead of the full data.
 
     Parameters
     ----------
@@ -5878,6 +5902,44 @@ class MomentumResolvedSpectrum(BaseMeasurements):
             ensemble_axes_metadata=axes_metadata[:-2] or None,
             metadata=metadata,
         )
+
+    def crop(
+        self,
+        q_range: Optional[tuple[float, float]] = None,
+        e_range: Optional[tuple[float, float]] = None,
+    ) -> "MomentumResolvedSpectrum":
+        """
+        Crop the spectrum to a q and/or energy-loss range.
+
+        Parameters
+        ----------
+        q_range : tuple of float, optional
+            Inclusive ``(min, max)`` scattering-vector range [mrad] to keep.
+            If None (default), the full q range is kept.
+        e_range : tuple of float, optional
+            Inclusive ``(min, max)`` energy-loss range [eV] to keep -- note
+            this is in eV (the unit ``e_values`` is stored in) regardless of
+            the ``e_units`` display option of :meth:`show`. If None
+            (default), the full energy range is kept.
+
+        Returns
+        -------
+        cropped : MomentumResolvedSpectrum
+            The cropped spectrum.
+        """
+        q = np.array(self._q_values)
+        e = np.array(self._e_values)
+
+        q_mask = _axis_range_mask(q, q_range, "q_range")
+        e_mask = _axis_range_mask(e, e_range, "e_range")
+
+        array = self.array[..., q_mask, :][..., :, e_mask]
+
+        kwargs = self._copy_kwargs(exclude=("array", "q_values", "e_values"))
+        kwargs["array"] = array
+        kwargs["q_values"] = q[q_mask]
+        kwargs["e_values"] = e[e_mask]
+        return self.__class__(**kwargs)
 
     def show(
         self,

--- a/test/test_phonon_loss.py
+++ b/test/test_phonon_loss.py
@@ -54,6 +54,32 @@ def test_invalid_component_raises():
         phonon_loss_diffraction_patterns(waves, component="bogus")
 
 
+@pytest.mark.parametrize("component", ["tds", "all"])
+def test_single_config_tds_raises_instead_of_returning_zeros(component):
+    """With one frozen-phonon configuration, I_incoherent == I_coherent by
+    construction, so I_tds is identically zero everywhere -- not a bug, but
+    silently returning an all-zero array looks exactly like one. This must
+    raise instead."""
+    waves = _make_exit_waves([0.02, 0.05, 0.10], n_configs=1)
+    with pytest.raises(ValueError, match="at least 2 frozen-phonon"):
+        phonon_loss_diffraction_patterns(waves, component=component)
+
+
+@pytest.mark.parametrize("component", ["coherent", "incoherent"])
+def test_single_config_non_tds_components_still_work(component):
+    """coherent/incoherent are well-defined (if trivial) for a single
+    configuration and must not be blocked by the N>=2 check."""
+    waves = _make_exit_waves([0.02, 0.05, 0.10], n_configs=1)
+    dp = phonon_loss_diffraction_patterns(waves, component=component)
+    assert not np.allclose(dp.array, 0.0)
+
+
+def test_two_configs_tds_does_not_raise():
+    waves = _make_exit_waves([0.02, 0.05, 0.10], n_configs=2)
+    dp = phonon_loss_diffraction_patterns(waves, component="tds")
+    assert dp.array.shape[0] == 3
+
+
 class TestThermalWeighting:
     def test_signed_axis_and_zero_bin_passthrough(self):
         e_values = [0.0, 0.02, 0.05, 0.10]

--- a/test/test_spectral_detectors.py
+++ b/test/test_spectral_detectors.py
@@ -408,6 +408,76 @@ def test_show_warns_on_ensemble_collapse():
         spec.show()
 
 
+# ---- MomentumResolvedSpectrum.crop() -----------------------------------------
+
+
+def _make_simple_spectrum(seed=0):
+    rng = np.random.default_rng(seed)
+    q_values = np.linspace(0, 10, 6)
+    e_values = np.linspace(-0.1, 0.1, 5)
+    array = rng.random((len(q_values), len(e_values)))
+    return (
+        MomentumResolvedSpectrum(array, q_values=q_values, e_values=e_values),
+        array,
+    )
+
+
+def test_crop_selects_correct_sub_range():
+    spec, array = _make_simple_spectrum()
+
+    cropped = spec.crop(q_range=(2, 8), e_range=(-0.06, 0.06))
+
+    assert cropped.q_values == tuple(spec.q_values[1:5])
+    assert cropped.e_values == tuple(spec.e_values[1:4])
+    np.testing.assert_allclose(cropped.array, array[1:5, 1:4])
+
+
+def test_crop_none_keeps_full_range():
+    spec, array = _make_simple_spectrum()
+    cropped = spec.crop()
+    assert cropped.q_values == spec.q_values
+    assert cropped.e_values == spec.e_values
+    np.testing.assert_allclose(cropped.array, array)
+
+
+def test_crop_only_q_range():
+    spec, array = _make_simple_spectrum()
+    cropped = spec.crop(q_range=(2, 8))
+    assert cropped.q_values == tuple(spec.q_values[1:5])
+    assert cropped.e_values == spec.e_values
+    np.testing.assert_allclose(cropped.array, array[1:5, :])
+
+
+def test_crop_preserves_ensemble_axes():
+    spec, array = _make_multiaxis_spectrum()
+    cropped = spec.crop(q_range=(0, 5))
+    assert cropped.ensemble_shape == spec.ensemble_shape
+    assert cropped.ensemble_axes_metadata == spec.ensemble_axes_metadata
+    np.testing.assert_allclose(cropped.array, array[..., :3, :])
+
+
+def test_crop_empty_range_raises():
+    spec, _ = _make_simple_spectrum()
+    with pytest.raises(ValueError, match="selects no data"):
+        spec.crop(q_range=(100, 200))
+
+
+def test_crop_reversed_range_raises():
+    spec, _ = _make_simple_spectrum()
+    with pytest.raises(ValueError, match="min must not exceed max"):
+        spec.crop(q_range=(8, 2))
+
+
+def test_cropped_spectrum_shows_without_error():
+    import matplotlib
+
+    matplotlib.use("Agg")
+    spec, _ = _make_simple_spectrum()
+    cropped = spec.crop(q_range=(2, 8), e_range=(-0.06, 0.06))
+    fig, ax = cropped.show()
+    assert ax.get_xlim()[1] < spec.q_values[-1]
+
+
 # ---- momentum_resolved_spectrum with a lazy (dask-backed) input -------------
 
 

--- a/test/test_spectral_detectors.py
+++ b/test/test_spectral_detectors.py
@@ -338,6 +338,65 @@ def test_show_explode_true_matches_full_range():
     assert axes_true.shape == axes_all.shape
 
 
+@pytest.mark.parametrize("n_panels, ncols", [(4, 4), (6, 4)])
+def test_show_explode_shares_axes_and_places_colorbar_beside_panels(
+    n_panels, ncols
+):
+    """An exploded grid must not repeat the y-axis label/tick labels on every
+    panel (only the leftmost column of each row), and the colorbar must land
+    in its own strip beside the panels rather than overlapping the last one
+    (regression: tight_layout() called after fig.colorbar() previously
+    fought over the colorbar axes' position -- see the "This figure includes
+    Axes that are not compatible with tight_layout" warning that used to
+    fire here)."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+
+    rng = np.random.default_rng(0)
+    q_values = np.linspace(0, 10, 5)
+    e_values = np.linspace(-0.1, 0.1, 6)
+    array = rng.random((n_panels, 5, 6))
+    spec = MomentumResolvedSpectrum(
+        array,
+        q_values=q_values,
+        e_values=e_values,
+        ensemble_axes_metadata=[
+            OrdinalAxis(label="axis0", values=tuple(range(n_panels)))
+        ],
+    )
+
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        fig, axes = spec.show(explode=True)
+
+    axes_flat = axes.flatten()[:n_panels]
+    nrows = len(axes.flatten()) // ncols
+
+    for k, a in enumerate(axes_flat):
+        row, col = divmod(k, ncols)
+        is_left_column = col == 0
+        assert bool(a.yaxis.get_label().get_text()) == is_left_column
+
+    # The colorbar axes (last Axes added to the figure that isn't one of the
+    # panels) must not overlap any panel's bounding box.
+    fig.canvas.draw()
+    panel_bboxes = [a.get_window_extent() for a in axes_flat]
+    cbar_axes = [a for a in fig.axes if a not in list(axes.flatten())]
+    assert len(cbar_axes) == 1
+    cbar_bbox = cbar_axes[0].get_window_extent()
+    for bbox in panel_bboxes:
+        assert not bbox.overlaps(cbar_bbox)
+
+    # The colorbar should sit close to the rightmost panel, not stranded with
+    # a large empty gap.
+    rightmost_panel_bbox = panel_bboxes[ncols - 1 if ncols <= n_panels else n_panels - 1]
+    gap = cbar_bbox.x0 - rightmost_panel_bbox.x1
+    assert gap < 0.25 * rightmost_panel_bbox.width
+
+
 def test_show_warns_on_ensemble_collapse():
     """A non-exploded show() on an object with ensemble axes must warn that
     only member (0, ..., 0) is shown."""


### PR DESCRIPTION
## Summary

Three changes on this branch, all in phonon-loss/spectral measurement code based on production testing.

### 1. Exploded panel grid layout (`MomentumResolvedSpectrum.show(explode=...)`)

- **Y-axis label/tick labels repeated on every panel.** The grid was built with plain `plt.subplots(nrows, ncols, ...)` — no `sharex`/`sharey` — so each panel independently drew its own "Energy loss [meV]" label and full tick labels, even panels that aren't in the first column.
- **Colorbar overlapping the last panel** (or, depending on figure size, stranded with a large gap from it). `fig.colorbar(im, ax=<list of panel axes>)` resizes those axes' gridspec to make room for the new colorbar axes — but the code then called `fig.tight_layout()` *after* that, which re-lays out every Axes in the figure from scratch with no special handling for a colorbar axes. Matplotlib actually already warns about this ("This figure includes Axes that are not compatible with tight_layout"), but the existing test suite was filtering that warning out (`@pytest.mark.filterwarnings("ignore:This figure includes Axes")`) rather than treating it as the layout bug it's flagging.

Screenshot showed exactly this: 4 exploded panels each fully-labeled on the y-axis, and the colorbar drawn over the last panel.

**Fix:**
- Pass `sharex=True, sharey=True` to `plt.subplots()`, then call `ax.label_outer()` on each panel so only the bottom row keeps x tick labels/label and only the left column keeps y tick labels/label.
- Reorder so `fig.tight_layout()` runs *before* `fig.colorbar(...)`, not after — the colorbar's own gridspec-based resize is sufficient and doesn't get undone by a later `tight_layout()` call.
- Added `pad=0.015` to `fig.colorbar()` so it sits close to the last panel instead of leaving a large empty gap (the default `pad` was tuned for a single axes, not the multi-axes `ax=[...]` case).

Verified against the actual "This figure includes Axes that are not compatible with tight_layout" warning: it fired before the fix (confirmed with a direct repro) and is gone after.

### 2. Single frozen-phonon configuration silently gives an all-zero TDS pattern (`phonon_loss_diffraction_patterns`)

`I_tds = I_incoherent - I_coherent` is the variance of the diffracted amplitude across frozen-phonon configurations. With exactly one configuration per energy, `I_incoherent` and `I_coherent` reduce to the same single `|FT(psi)|²` term by construction, so `I_tds` is exactly zero everywhere — not a numerical fluke, a guaranteed consequence of the formula. That produced a `DiffractionPatterns` object that was silently all zeros, indistinguishable from an actual bug from the caller's side.

**Fix:** `component="tds"`/`"all"` now raise a `ValueError` when there are fewer than 2 frozen-phonon configurations per energy, explaining why and pointing at the fix (build the ensemble with more than one configuration per energy). `component="coherent"`/`"incoherent"` are unaffected — they remain well-defined (if trivial) for a single configuration. Also documented in the function's docstring.

### 3. `MomentumResolvedSpectrum.crop()` — focus visualizations on a region

New method to crop a spectrum to a q/energy-loss sub-range, mirroring the existing `.crop()` convention on `Images`, `DiffractionPatterns`, and `IndexedDiffractionPatterns`: returns a new, smaller measurement object rather than a `show()`-time view/xlim hack. Unlike those, `MomentumResolvedSpectrum`'s q/e axes are explicit non-uniform values rather than a pixel grid, so `crop()` takes inclusive `(min, max)` ranges — `q_range` in mrad, `e_range` in eV (the unit `e_values` is stored in, independent of `show()`'s `e_units` display option).

Cropping before `.show()` also rescales the (auto) colour scale to just the cropped region — including per-panel in an exploded grid, since each panel's `vmin`/`vmax` is computed from whatever data `show()` is actually given.

```python
spectrum.crop(q_range=(0, 40), e_range=(0, 0.05)).show(explode=True)
```

## Test plan
- [x] New `test_show_explode_shares_axes_and_places_colorbar_beside_panels` (`test/test_spectral_detectors.py`), parametrized over a single-row (4 panels) and multi-row (6 panels, 2×4) grid: asserts only the left-column panels keep a y-axis label, the colorbar axes doesn't overlap any panel's bounding box, and the gap between the last panel and the colorbar stays small.
- [x] New tests in `test/test_phonon_loss.py`: single-config `tds`/`all` raise with a clear message; single-config `coherent`/`incoherent` still work; 2-config `tds` does not raise.
- [x] New tests in `test/test_spectral_detectors.py` for `crop()`: correct q/e sub-range selection, `None` keeps full range, q-only crop, ensemble axes preserved, empty-selection and reversed-range raise clear errors, cropped spectrum still plots.
- [x] Visual check: reproduced the reported panel-layout bug from a synthetic 4-panel `MomentumResolvedSpectrum` (matches the screenshot exactly), confirmed resolved for both a single-row and a 2-row grid.
- [x] Full test suite passes after each commit on this branch: 1121 / 1126 / 1133 passed, 805 skipped, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
