### PR TITLE
Fix transition_potential_scan crash for chunked scans without explicit sites

### DIFF
--- a/abtem/waves.py
+++ b/abtem/waves.py
@@ -44,7 +44,10 @@ from abtem.core.utils import (
     tuple_range,
 )
 from abtem.detectors import BaseDetector, FlexibleAnnularDetector
-from abtem.inelastic.core_loss import BaseTransitionPotential
+from abtem.inelastic.core_loss import (
+    BaseTransitionPotential,
+    _extract_scattering_sites,
+)
 from abtem.measurements import (
     BaseMeasurements,
     DiffractionPatterns,
@@ -1476,6 +1479,12 @@ class Waves(BaseWaves, ArrayObject):
             transition_potentials = [transition_potentials]
 
         potential = validate_potential(potential, self)
+
+        # Resolve sites from the potential's atoms before it is potentially
+        # pre-built into a bare PotentialArray below, which carries no atoms
+        # and would otherwise make site extraction fail (abTEM issue #340).
+        sites = _extract_scattering_sites(potential, sites)
+
         potential = _prebuild_reused_potential(potential, self)
 
         measurements: list[Waves | BaseMeasurements] = []

--- a/test/test_ionization.py
+++ b/test/test_ionization.py
@@ -214,6 +214,58 @@ def test_transition_potential_scan_accepts_grid_scan(si_atoms, device):
 
 
 @pytest.mark.parametrize("device", ["cpu", gpu])
+def test_transition_potential_scan_auto_sites_survive_potential_prebuild(
+    si_atoms, device
+):
+    """Regression test for a bug where ``_prebuild_reused_potential`` (added for
+    issue #339/#340) replaced the ``Potential`` with a bare ``PotentialArray``
+    before auto-extracted ``sites`` were resolved from it. ``PotentialArray``
+    carries no atoms, so ``_extract_scattering_sites`` raised ``ValueError``
+    for any multi-chunk lazy scan (e.g. ``max_batch`` small enough to split the
+    scan into more than one dask block) that didn't pass ``sites=`` explicitly.
+
+    Also asserts the auto-extracted-sites result is bit-identical to both an
+    unchunked scan and an explicit ``sites=`` scan, since the fix must resolve
+    sites from the *original* potential rather than change what site set is
+    used.
+    """
+    potential = _make_si_potential(si_atoms, device)
+    tp = _make_si_transition_potential(potential, device)
+    probe = _make_probe(potential, device)
+    detector = abtem.FlexibleAnnularDetector()
+    scan = abtem.GridScan(
+        start=(0, 0), end=(1, 1), fractional=True,
+        potential=potential, endpoint=False, sampling=2.0,
+    )
+
+    unchunked = probe.transition_potential_scan(
+        potential=potential, transition_potentials=tp, scan=scan,
+        detectors=detector, double_channel=False, lazy=False,
+    ).compute()
+
+    chunked_auto_sites = probe.transition_potential_scan(
+        potential=potential, transition_potentials=tp, scan=scan,
+        detectors=detector, double_channel=False, max_batch=1, lazy=True,
+    ).compute()
+
+    chunked_explicit_sites = probe.transition_potential_scan(
+        potential=potential, transition_potentials=tp, scan=scan,
+        detectors=detector, sites=si_atoms, double_channel=False,
+        max_batch=1, lazy=True,
+    ).compute()
+
+    if device == "gpu":
+        chunked_auto_sites = chunked_auto_sites.to_cpu()
+        chunked_explicit_sites = chunked_explicit_sites.to_cpu()
+        unchunked = unchunked.to_cpu()
+
+    np.testing.assert_array_equal(chunked_auto_sites.array, unchunked.array)
+    np.testing.assert_array_equal(
+        chunked_auto_sites.array, chunked_explicit_sites.array
+    )
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
 def test_transition_potential_scan_crystal_potential_matches_manual_tile(device):
     """Auto-extracted sites from a CrystalPotential must produce the same
     result as a regular Potential built from a manually-tiled supercell.


### PR DESCRIPTION
## Summary

`Probe.transition_potential_scan` / `Waves.transition_potential_multislice` raised a bare `ValueError` for any scan chunked into more than one dask block (e.g. via `max_batch`) when `sites=` wasn't passed explicitly.

Root cause: `_prebuild_reused_potential` (added in #340) replaces a lazy `Potential` with a bare, already-built `PotentialArray` whenever the scan spans more than one chunk and the potential fits the chunk-size budget — a legitimate optimization to avoid rebuilding the potential per chunk. But `PotentialArray` carries no atoms, and `_extract_scattering_sites`'s auto-extraction only knows how to pull atoms from `Potential`/`FrozenPhonons`-wrapped potentials/`CrystalPotential`, so it raised:

```
ValueError: Could not derive scattering sites from the potential (PotentialArray). Pass `sites=` explicitly...
```

## Fix

Resolve `sites` from the potential *before* `_prebuild_reused_potential` can replace it with a bare array — exactly what `_extract_scattering_sites` would have done with the unbuilt potential. This preserves the #340 optimization; the resolved `sites` (an `Atoms`/`SliceIndexedAtoms`) is passed straight through, so `_extract_scattering_sites` downstream is a no-op regardless of what `potential` ends up being.

Verified the auto-extracted-sites result is bit-identical (`max abs diff: 0.0`) to both an unchunked scan and an explicit `sites=` scan.

## Test plan
- [x] New regression test `test_transition_potential_scan_auto_sites_survive_potential_prebuild`, parametrized over cpu/gpu, asserting bit-identical output across unchunked / auto-sites-chunked / explicit-sites-chunked scans
- [x] Confirmed the new test fails with the exact reported error when the fix is reverted, and passes with it applied
- [x] Full `test/test_ionization.py` suite passes (23 passed, 20 skipped — GPU-only)
- [x] Broader regression sweep: `test_waves.py`, `test_scan.py`, `test_potential_chunking.py`, `test_simulate.py`, `test_energy_ensemble.py` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
