### PR TITLE
Fix inter-panel colorbar span and tick-label collision in AxesGrid

### DIFF
--- a/abtem/visualize/axes_grid.py
+++ b/abtem/visualize/axes_grid.py
@@ -14,20 +14,29 @@ from abtem.core.utils import flatten_list_of_lists, interleave
 
 
 class _SyncedCbarLocator:
-    """Locator that keeps a colorbar aligned with a reference axes."""
+    """Locator that keeps a colorbar aligned with the union of a set of
+    reference axes, so a colorbar spans the full height (``sync_axis="y"``)
+    or width (``sync_axis="x"``) of every panel it is meant to cover -- e.g.
+    a single shared colorbar spanning every row of a multi-row exploded
+    grid, or a per-panel colorbar matching just its own panel.
+    """
 
-    def __init__(self, original_locator, ref_ax, sync_axis="y"):
+    def __init__(self, original_locator, ref_axes, sync_axis="y"):
         self._original = original_locator
-        self._ref_ax = ref_ax
+        self._ref_axes = ref_axes
         self._sync_axis = sync_axis
 
     def __call__(self, axes, renderer):
         pos = self._original(axes, renderer)
-        ref = self._ref_ax.get_position(original=False)
+        positions = [ax.get_position(original=False) for ax in self._ref_axes]
         if self._sync_axis == "y":
-            return Bbox.from_bounds(pos.x0, ref.y0, pos.width, ref.height)
+            y0 = min(p.y0 for p in positions)
+            y1 = max(p.y1 for p in positions)
+            return Bbox.from_bounds(pos.x0, y0, pos.width, y1 - y0)
         else:
-            return Bbox.from_bounds(ref.x0, pos.y0, ref.width, pos.height)
+            x0 = min(p.x0 for p in positions)
+            x1 = max(p.x1 for p in positions)
+            return Bbox.from_bounds(x0, pos.y0, x1 - x0, pos.height)
 
 
 def _cbar_orientation(cbar_loc):
@@ -107,7 +116,10 @@ class AxesGrid:
 
         self._sizes = {
             "cbar_spacing": Size.Fixed(1.1),
-            "padding": Size.Fixed(0.1),
+            # Wide enough to fit a ~3-4 character tick label (e.g. the
+            # "-100"/"100" pair at a shared panel boundary) without the
+            # two neighbouring panels' edge labels visually colliding.
+            "padding": Size.Fixed(0.25),
             "cbar_shift": Size.Fixed(0.0),
             "cbar_width": Size.Fixed(0.15),
             "left": Size.Fixed(0.0),
@@ -318,16 +330,29 @@ class AxesGrid:
         return line_types
 
     def _connect_cbar_sync(self):
-        ref_ax = self._axes.ravel()[0]
         sync_axis = "y" if self._cbar_loc == "right" else "x"
-        for cax in self._caxes.ravel():
+
+        def sync(cax, ref_axes):
             if cax is None or cax == 0:
-                continue
+                return
             original_locator = cax.get_axes_locator()
             if original_locator is not None:
                 cax.set_axes_locator(
-                    _SyncedCbarLocator(original_locator, ref_ax, sync_axis)
+                    _SyncedCbarLocator(original_locator, ref_axes, sync_axis)
                 )
+
+        if self._cbar_mode == "each":
+            # Each panel has its own colorbar(s): match only that panel.
+            for col in range(self._ncols):
+                for row in range(self._nrows):
+                    ref_axes = [self._axes[col, row]]
+                    for cax in self._caxes[col, row].ravel():
+                        sync(cax, ref_axes)
+        else:
+            # One shared colorbar: span every panel it is shared across.
+            ref_axes = list(self._axes.ravel())
+            for cax in self._caxes.ravel():
+                sync(cax, ref_axes)
 
     def set_sizes(self, **kwargs):
         for key, value in kwargs.items():

--- a/test/test_axes_grid.py
+++ b/test/test_axes_grid.py
@@ -1,0 +1,116 @@
+"""Tests for AxesGrid layout: colorbar span and inter-panel tick spacing.
+
+Both bugs were found while auditing exploded-grid plots of energy-ensemble
+diffraction patterns, but are general AxesGrid issues reproducible on any
+multi-panel measurement (e.g. a plain defocus series), not specific to
+energy ensembles.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import pytest
+
+import abtem
+
+
+@pytest.fixture
+def two_by_two_diffraction_patterns():
+    """A 2x2 exploded grid (defocus x spherical aberration), cheap to build."""
+    abtem.config.set({"diagnostics.progress_bar": False})
+    probe = abtem.Probe(
+        gpts=32,
+        extent=10,
+        energy=100e3,
+        semiangle_cutoff=20,
+        defocus=[0, 50],
+        C30=[0, 1e6],
+    )
+    return probe.build().compute().diffraction_patterns(max_angle=40)
+
+
+def test_shared_colorbar_spans_every_row(two_by_two_diffraction_patterns):
+    """Regression test: _connect_cbar_sync used to anchor the shared colorbar
+    (cbar_mode="single") to a single reference panel (self._axes.ravel()[0])
+    regardless of grid shape, so on a multi-row grid it only matched the
+    height of one row instead of spanning the whole grid.
+    """
+    dp = two_by_two_diffraction_patterns
+    plt.close("all")
+    visualization = dp.show(explode=True, cbar=True, common_color_scale=True)
+    axes = visualization.axes
+    fig = visualization.get_figure()
+    fig.canvas.draw()
+
+    all_axes_bboxes = [ax.get_position(original=False) for ax in axes._axes.ravel()]
+    grid_y0 = min(bbox.y0 for bbox in all_axes_bboxes)
+    grid_y1 = max(bbox.y1 for bbox in all_axes_bboxes)
+
+    cbar_bbox = axes._caxes.ravel()[0].get_position(original=False)
+    assert cbar_bbox.y0 == pytest.approx(grid_y0, abs=1e-6)
+    assert cbar_bbox.y1 == pytest.approx(grid_y1, abs=1e-6)
+
+
+def test_each_colorbar_matches_its_own_panel(two_by_two_diffraction_patterns):
+    """Regression test: with cbar_mode="each", _connect_cbar_sync anchored
+    every colorbar to self._axes.ravel()[0] regardless of which panel it
+    actually belonged to, so every row but the reference row's got a
+    colorbar positioned at the wrong (reference row's) height -- silently
+    overlapping that row's own correctly-placed colorbar rather than being
+    visibly absent.
+    """
+    dp = two_by_two_diffraction_patterns
+    plt.close("all")
+    visualization = dp.show(explode=True, cbar=True)  # cbar_mode="each"
+    axes = visualization.axes
+    fig = visualization.get_figure()
+    fig.canvas.draw()
+
+    for col in range(axes._ncols):
+        for row in range(axes._nrows):
+            own_ax_bbox = axes._axes[col, row].get_position(original=False)
+            for cax in axes._caxes[col, row].ravel():
+                if cax is None or cax == 0:
+                    continue
+                cbar_bbox = cax.get_position(original=False)
+                assert cbar_bbox.y0 == pytest.approx(own_ax_bbox.y0, abs=1e-6)
+                assert cbar_bbox.y1 == pytest.approx(own_ax_bbox.y1, abs=1e-6)
+
+
+def test_abutting_panels_have_nonzero_gap(two_by_two_diffraction_patterns):
+    """Regression test: with a single shared colorbar removing the usual
+    per-panel gap, adjacent panels used to abut with zero space between
+    them, so each panel's boundary-facing tick label (e.g. "100" and its
+    neighbour's "-100") visually collided. AxesGrid's "padding" spacer
+    must be wide enough to fit a several-character tick label.
+    """
+    dp = two_by_two_diffraction_patterns
+    plt.close("all")
+    visualization = dp.show(
+        explode=True, units="mrad", cbar=True, common_color_scale=True
+    )
+    axes = visualization.axes
+    fig = visualization.get_figure()
+    fig.canvas.draw()
+
+    bboxes = axes._axes.ravel()
+    positions = [ax.get_position(original=False) for ax in bboxes]
+
+    # Any two panels at the same row (same y-range) that are horizontally
+    # adjacent must have a visible gap between them.
+    fig_width_inches = fig.get_size_inches()[0]
+    min_gap_inches = 0.15  # comfortably less than the fixed 0.25" padding
+
+    for i, pos_i in enumerate(positions):
+        for j, pos_j in enumerate(positions):
+            if i >= j:
+                continue
+            same_row = abs(pos_i.y0 - pos_j.y0) < 1e-6
+            if not same_row:
+                continue
+            gap = (
+                (pos_j.x0 - pos_i.x1) if pos_j.x0 >= pos_i.x1 else (pos_i.x0 - pos_j.x1)
+            )
+            assert gap * fig_width_inches > min_gap_inches


### PR DESCRIPTION
## Summary

Two independent layout bugs in exploded-grid plots (`explode=True`), affecting any measurement type and any ensemble axis. Found while auditing energy-ensemble diffraction pattern plots, but both are reproducible on a plain, non-energy defocus series — general `AxesGrid` issues, not specific to energy ensembles.

### 1. Colorbars didn't span multi-row grids

`_connect_cbar_sync` always anchored every colorbar's position to a single reference panel (`self._axes.ravel()[0]`), regardless of the actual grid shape:

- `cbar_mode="single"` (`common_color_scale=True`): the one shared colorbar matched only that single reference panel's height, not the whole grid's — cropped to one row on a multi-row grid.
- `cbar_mode="each"`: every panel's own colorbar got repositioned to the *reference* panel's height too, so colorbars for every row but the reference row silently landed on top of the reference row's — they weren't missing, they were invisibly stacked underneath it.

Fixed by having `_SyncedCbarLocator` sync to the union of a *list* of reference axes instead of one, and `_connect_cbar_sync` pass the whole grid for a shared colorbar, or just the owning panel for a per-panel one.

### 2. Adjacent panels could abut with zero gap

Whenever a single shared colorbar removes the usual per-panel spacing (`common_color_scale=True`), panels ended up directly touching, so each panel's boundary-facing tick label visually collided with its neighbour's (e.g. `"100"` running into `"-100"`). `AxesGrid` already had a dedicated `"padding"` spacer between panels — just too thin (`0.1"`) to fit a several-character tick label. Widened to `0.25"`.

## Test plan

- [x] New `test/test_axes_grid.py`: colorbar span for both `cbar_mode="single"` and `cbar_mode="each"` on a 2×2 grid, plus a non-zero-gap check between same-row panels
- [x] Confirmed all three fail with the exact reported symptoms when the fix is reverted, and pass with it applied
- [x] Verified visually across 1×3, 2×2, and 2×3 grids in both `cbar_mode` settings
- [x] `test/test_spectral_detectors.py` (the only other test touching `.show()`) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
