### PR TITLE
Read abtem.yaml config as UTF-8 on Windows

### DIFF
--- a/abtem/core/config.py
+++ b/abtem/core/config.py
@@ -255,7 +255,7 @@ def check_deprecations(key: str, deprecations: dict = deprecations) -> str:
 def _initialize() -> None:
     fn = os.path.join(os.path.dirname(__file__), "abtem.yaml")
 
-    with open(fn) as f:
+    with open(fn, encoding="utf-8") as f:
         _defaults = yaml.safe_load(f)
 
     update_defaults(_defaults)


### PR DESCRIPTION
## Summary

`abtem/core/config.py` loads the bundled `abtem.yaml` with `open(fn)` and no explicit encoding. On Windows with a non-UTF-8 system locale (e.g. Chinese/GBK), Python's default text encoding is `gbk`, so reading the UTF-8 `abtem.yaml` raises:

```
UnicodeDecodeError: 'gbk' codec can't decode byte 0x94 in position 1025: illegal multibyte sequence
```

This makes `import abtem` fail at startup on such systems.

## Fix

Open the config file with an explicit UTF-8 encoding:

```python
with open(fn, encoding="utf-8") as f:
```

## Verification

Confirmed locally that `import abtem` succeeds afterwards:

```
venv\Scripts\python.exe -c "import abtem; print(abtem.__version__, abtem.__file__)"
# 1.1.0 F:\papers\backscatter\abTEM\abtem\__init__.py
```

<details><summary>Before / after</summary>

Before the fix, on a Windows GBK-locale machine, `import abtem` crashes. After the fix it imports cleanly.

</details>