### PR TITLE
Fix Probe.energy/PlaneWave.energy leaking internal EnergyEnsemble wrapper

### DIFF
--- a/abtem/waves.py
+++ b/abtem/waves.py
@@ -1763,7 +1763,15 @@ class WavesBuilder(BaseWaves, Ensemble, CopyMixin, EqualityMixin):
 
     @property
     def _ensembles(self):
-        return {name: getattr(self, name) for name in self._ensemble_names}
+        # "energy" is special-cased to read the private EnergyEnsemble wrapper
+        # directly: the public `.energy` property (defined by subclasses)
+        # unwraps it to a plain float/BaseDistribution for external
+        # consumers, but the ensemble machinery here needs the wrapper
+        # itself (it has `.ensemble_shape`, `.ensemble_axes_metadata`, etc.).
+        return {
+            name: self._energy if name == "energy" else getattr(self, name)
+            for name in self._ensemble_names
+        }
 
     @property
     def _ensemble_shapes(self):
@@ -2018,7 +2026,7 @@ class PlaneWave(WavesBuilder):
 
     @property
     def energy(self):
-        return self._energy
+        return self._energy.energy
 
     @energy.setter
     def energy(self, value):
@@ -2311,7 +2319,7 @@ class Probe(WavesBuilder):
 
     @property
     def energy(self):
-        return self._energy
+        return self._energy.energy
 
     @energy.setter
     def energy(self, value):

--- a/test/test_energy_ensemble.py
+++ b/test/test_energy_ensemble.py
@@ -158,6 +158,56 @@ class TestProbeEnergyEnsemble:
         assert tuple(energy_axes[0].values) == (40e3, 60e3, 80e3)
 
 
+class TestWavesBuilderEnergyProperty:
+    """Regression tests: PlaneWave.energy / Probe.energy must return the
+    unwrapped value (float or BaseDistribution), not the internal
+    EnergyEnsemble wrapper -- and detector.show() must accept a WavesBuilder
+    directly (not just a built Waves object)."""
+
+    def test_probe_energy_is_plain_float(self):
+        probe = Probe(energy=100e3, gpts=32, sampling=0.1, semiangle_cutoff=30)
+        assert probe.energy == 100e3
+        assert isinstance(probe.energy, float)
+
+    def test_plane_wave_energy_is_plain_float(self):
+        pw = PlaneWave(energy=100e3, gpts=32, sampling=0.1)
+        assert pw.energy == 100e3
+        assert isinstance(pw.energy, float)
+
+    def test_probe_energy_ensemble_is_distribution(self):
+        from abtem.distributions import BaseDistribution
+
+        probe = Probe(energy=ENERGIES, gpts=32, sampling=0.1, semiangle_cutoff=30)
+        assert isinstance(probe.energy, BaseDistribution)
+
+    def test_annular_detector_show_unbuilt_probe(self):
+        """AnnularDetector.show() must accept a Probe directly, without build()."""
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        probe = Probe(
+            energy=80e3, semiangle_cutoff=20, sampling=0.1, extent=10
+        )
+        abtem.AnnularDetector(inner=40, outer=80).show(probe)
+        plt.close("all")
+
+    def test_segmented_detector_show_unbuilt_plane_wave(self):
+        """SegmentedDetector.show() must accept a PlaneWave directly, without build()."""
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        from abtem.detectors import SegmentedDetector
+
+        pw = PlaneWave(energy=80e3, sampling=0.1, extent=10)
+        SegmentedDetector(
+            nbins_radial=2, nbins_azimuthal=4, inner=10, outer=80
+        ).show(pw)
+        plt.close("all")
+
+
 class TestWavesEnergyEnsemble:
     def test_list_energy(self):
         arr = np.ones((3, 32, 32), dtype=complex)


### PR DESCRIPTION
## Summary

Probe.energy and PlaneWave.energy returned self._energy directly -- the internal EnergyEnsemble wrapper object -- instead of unwrapping it to a plain float (scalar case) or BaseDistribution (ensemble case). This is a regression from the PR #257 energy-ensemble refactor.

This breaks any code path that calls .energy on a Probe/PlaneWave and expects a plain value, most visibly SomeDetector.show(probe) for any probe/plane wave (not just energy-ensemble ones), since _energy_from_waves() in abtem/detectors.py reads waves.energy and feeds it into energy2wavelength, which then fails comparing an EnergyEnsemble object against a number:

```python
probe = abtem.Probe(energy=80e3, semiangle_cutoff=20, sampling=0.1, extent=10)
abtem.AnnularDetector(inner=40, outer=80).show(probe)
# TypeError: <= not supported between instances of EnergyEnsemble and int
```

Most docs notebooks build the waves first (probe.build()) before showing them, and Waves.energy resolves correctly (it goes through Accelerator.energy, not this wrapper) -- so the bug only fires when a WavesBuilder subclass itself (Probe/PlaneWave), not a built Waves object, is passed directly to show().

## Root cause and fix

Naively unwrapping the getter (return self._energy.energy) alone breaks WavesBuilder._ensembles, which does {name: getattr(self, name) for name in self._ensemble_names} -- "energy" is one of the ensemble_names, so the internal ensemble machinery also goes through the public .energy property and needs the wrapper object (with its .ensemble_shape, .ensemble_axes_metadata, etc.), not the unwrapped value.

This PR:
- Unwraps Probe.energy / PlaneWave.energy to self._energy.energy, matching what the setter already does internally.
- Updates WavesBuilder._ensembles to read self._energy directly for the "energy" name instead of going through the (now-unwrapped) public property, since only the internal ensemble machinery needs the wrapper itself.

This is the same pattern already used elsewhere in the codebase (WavesBuilder._valid_energy, Accelerator.check_match/match) to bypass .energy for consumers that need a scalar rather than a possibly-wrapped value.

## Test plan

- [x] Added regression tests in test/test_energy_ensemble.py (TestWavesBuilderEnergyProperty): Probe.energy/PlaneWave.energy return plain float/BaseDistribution, and AnnularDetector.show(probe) / SegmentedDetector.show(plane_wave) work on unbuilt scalar-energy waves (the exact case that was broken).
- [x] pytest test/test_energy_ensemble.py -n auto -- 59 passed, 7 skipped (slow-marked)
- [x] pytest test/test_detect.py test/test_waves.py test/test_ctf.py test/test_axes_grid.py test/test_tilt.py test/test_scan.py -n auto -- 238 passed
- [x] pytest test/test_multislice_input.py test/test_simulate.py test/test_prism_upsample.py test/test_realspace_multislice.py test/test_measure.py test/test_distributions.py test/test_potentials.py -n auto -- 313 passed

Generated with Claude Code