### PR TITLE
Fix MomentumResolvedSpectrum.show() crash from stale plt.subplots axes-sharing read

### DIFF
--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -6067,15 +6067,21 @@ class MomentumResolvedSpectrum(BaseMeasurements):
             nrows = (n + ncols - 1) // ncols
             if figsize is None:
                 figsize = (4 * ncols, 3.5 * nrows)
+            # Axes are linked explicitly below rather than via plt.subplots'
+            # own sharex=True/sharey=True: that path reads back the object
+            # array slot it just allocated (matplotlib/gridspec.py's
+            # `axarr[0, 0]`) before every axes is created, and on some numpy
+            # builds that slot is not reliably None on first read.
             fig, axes_arr = plt.subplots(
                 nrows,
                 ncols,
                 figsize=figsize,
                 squeeze=False,
-                sharex=True,
-                sharey=True,
             )
             axes_flat = axes_arr.flatten()
+            for ax in axes_flat[1:]:
+                ax.sharex(axes_flat[0])
+                ax.sharey(axes_flat[0])
 
             # Shared colour scale across panels so the single colorbar applies to
             # every panel (otherwise the norm autoscales to the first panel only).


### PR DESCRIPTION
## Summary
- `MomentumResolvedSpectrum.show(explode=...)` called `plt.subplots(..., sharex=True, sharey=True)`, which internally reads back the object-array slot it just allocated (matplotlib's `gridspec.py` `axarr[0, 0]`) while still constructing the grid.
- On at least one real machine (Linux, Python 3.13.9, confirmed on both numpy 2.3.5 and 2.5.2), that slot was not reliably `None` on first read under certain process allocation-history conditions, causing `TypeError: 'other' must be an instance of matplotlib.axes._base._AxesBase, not a float` deep inside matplotlib's `Axes.sharex()`.
- Root cause traces to numpy's own object-array allocator, not to abTEM's code or a specific numpy version — reproducible only with a specific combination of imports present in the process (not reproducible as a fresh/minimal script), and not fixed by upgrading numpy.
- Fix: build the panel grid unshared (`plt.subplots(nrows, ncols, figsize=figsize, squeeze=False)`), then link every axis to the first explicitly via `.sharex()` / `.sharey()`. This avoids ever reading that object-array slot during axes construction, sidestepping the crash regardless of root cause.

## Test plan
- [x] `pytest test/test_spectral_detectors.py -q` passes locally (36 passed)
- [x] Confirmed by the reporter: the fix resolves the crash on the machine where it was reproducible (previously failing deterministically on both numpy 2.3.5 and 2.5.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)