### PR TITLE
Fix TestBlochWavesEnergyEnsemble class-scoped fixtures for pytest 9

### DIFF
--- a/test/test_energy_ensemble.py
+++ b/test/test_energy_ensemble.py
@@ -407,7 +407,8 @@ class TestBlochWavesEnergyEnsemble:
     shaped, stacked results without requiring manual loops."""
 
     @pytest.fixture(scope="class")
-    def bw_multi(self):
+    @classmethod
+    def bw_multi(cls):
         """Shared BlochWaves object with multiple energies (expensive to create)."""
         atoms = _srtio3_atoms()
         return BlochWaves(
@@ -415,22 +416,26 @@ class TestBlochWavesEnergyEnsemble:
         )
 
     @pytest.fixture(scope="class")
-    def dp_single(self, bw_multi):
+    @classmethod
+    def dp_single(cls, bw_multi):
         """Cached single-thickness diffraction patterns (used by multiple tests)."""
         return bw_multi.calculate_diffraction_patterns(BLOCH_THICKNESS[0]).compute()
 
     @pytest.fixture(scope="class")
-    def dp_multi(self, bw_multi):
+    @classmethod
+    def dp_multi(cls, bw_multi):
         """Cached multi-thickness diffraction patterns."""
         return bw_multi.calculate_diffraction_patterns(BLOCH_THICKNESS).compute()
 
     @pytest.fixture(scope="class")
-    def ew_single(self, bw_multi):
+    @classmethod
+    def ew_single(cls, bw_multi):
         """Cached single-thickness exit waves."""
         return bw_multi.calculate_exit_waves(BLOCH_THICKNESS[0]).compute()
 
     @pytest.fixture(scope="class")
-    def ew_multi(self, bw_multi):
+    @classmethod
+    def ew_multi(cls, bw_multi):
         """Cached multi-thickness exit waves."""
         return bw_multi.calculate_exit_waves(BLOCH_THICKNESS).compute()
 


### PR DESCRIPTION
## Summary
- `TestBlochWavesEnergyEnsemble` (in `test/test_energy_ensemble.py`, only exercised with `--runslow`) defines its class-scoped fixtures (`bw_multi`, `dp_single`, `dp_multi`, `ew_single`, `ew_multi`) as plain instance methods taking `self`.
- pytest 9 deprecates this pattern (`PytestRemovedIn10Warning: Class-scoped fixture defined as instance method is deprecated`), and once that warning fires during the first test's fixture setup, it leaves `FixtureDef._finalizers` in an inconsistent state for the rest of the class — turning one warning into cascading `AssertionError: assert not self._finalizers` setup errors for every other test in the class.
- Fix: define these fixtures as `@classmethod`, per pytest's own migration guidance, since none of them use instance state.

## Test plan
- [x] `pytest --runslow test/test_energy_ensemble.py -q` — 66 passed (previously 60 passed, 6 errors)
- [x] Confirmed by the reporter on the machine where the errors were originally observed

🤖 Generated with [Claude Code](https://claude.com/claude-code)