### PR TITLE
Fix oversized single-chunk zarr writes and the corrupted-file it leaves behind

### DIFF
--- a/abtem/array.py
+++ b/abtem/array.py
@@ -222,6 +222,37 @@ def multi_output_blockwise(
     return outputs
 
 
+# Codecs (Blosc/zlib) reject a single buffer over 2**31 - 1 bytes. Writing a
+# whole array as one zarr chunk -- as this module used to always do -- hits
+# that limit for any reasonably large array, especially at float64. Stay well
+# under it (also a more sensible chunk size for parallel IO in general) by
+# halving the largest axis of the chunk shape until it fits the budget.
+_MAX_ZARR_CHUNK_BYTES = 512 * 1024**2
+
+
+def _safe_zarr_chunks(
+    shape: tuple[int, ...], itemsize: int, max_bytes: Optional[int] = None
+) -> tuple[int, ...]:
+    if max_bytes is None:
+        # Read fresh rather than as a default-argument value, so overriding
+        # the module-level budget (e.g. in tests) takes effect.
+        max_bytes = _MAX_ZARR_CHUNK_BYTES
+
+    chunks = list(shape)
+
+    def nbytes() -> int:
+        n = itemsize
+        for c in chunks:
+            n *= c
+        return n
+
+    while nbytes() > max_bytes and any(c > 1 for c in chunks):
+        i = max(range(len(chunks)), key=lambda j: chunks[j])
+        chunks[i] = max(1, chunks[i] // 2)
+
+    return tuple(chunks)
+
+
 class ComputableList(list):
     """A list with methods for conveniently computing its items."""
 
@@ -368,11 +399,26 @@ class ComputableList(list):
                             root.create_array(
                                 name=f"array{i}",
                                 data=computed_array,
-                                chunks=computed_array.shape,
+                                chunks=_safe_zarr_chunks(
+                                    computed_array.shape,
+                                    computed_array.dtype.itemsize,
+                                ),
                                 overwrite=True,
                                 compressors=compressors,
                             )
-                    finally:
+                    except BaseException:
+                        # A failed write (e.g. a chunk still over a codec's
+                        # buffer limit) can leave a .zip with valid-looking
+                        # metadata (shape/dtype/chunks) but no actual chunk
+                        # data -- silently readable later as all zeros
+                        # (zarr's fill_value for a declared-but-missing
+                        # chunk) instead of raising again. Don't leave that
+                        # behind.
+                        store.close()
+                        if os.path.exists(url):
+                            os.remove(url)
+                        raise
+                    else:
                         store.close()
 
                 return url
@@ -389,6 +435,13 @@ class ComputableList(list):
 
                 root = zarr.open(url, mode="w")
 
+                def _close():
+                    store = getattr(root, "store", None)
+                    if store is not None:
+                        close_fn = getattr(store, "close", None)
+                        if callable(close_fn):
+                            close_fn()
+
                 try:
                     for metadata_dict in metadata_list:
                         for key, value in metadata_dict.items():
@@ -398,15 +451,22 @@ class ComputableList(list):
                         root.create_array(
                             name=f"array{i}",
                             data=computed_array,
-                            chunks=computed_array.shape,
+                            chunks=_safe_zarr_chunks(
+                                computed_array.shape,
+                                computed_array.dtype.itemsize,
+                            ),
                             overwrite=True,
                         )
-                finally:
-                    store = getattr(root, "store", None)
-                    if store is not None:
-                        close_fn = getattr(store, "close", None)
-                        if callable(close_fn):
-                            close_fn()
+                except BaseException:
+                    # See the matching comment in write_to_zipstore: don't
+                    # leave a partially-written store with valid-looking
+                    # metadata but missing/incomplete chunk data.
+                    _close()
+                    if os.path.exists(url):
+                        shutil.rmtree(url)
+                    raise
+                else:
+                    _close()
 
                 return url
 

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -1,3 +1,4 @@
+import os
 from numbers import Number
 
 import hypothesis.extra.numpy as numpy_st
@@ -270,6 +271,107 @@ def test_from_zarr_legacy_format(data, has_array, url):
 
     has_array_from_zarr = from_zarr(url).compute()
     assert has_array_from_zarr == has_array
+
+
+# ---- large-array zarr chunking (regression: whole-array single chunk hit a
+# codec's 2**31-1 byte buffer limit, and a write that failed partway left a
+# store with valid-looking metadata but silently-all-zero data) -------------
+
+
+def test_safe_zarr_chunks_stays_under_budget():
+    from abtem.array import _safe_zarr_chunks
+
+    shape = (1025, 512, 512)
+    chunks = _safe_zarr_chunks(shape, itemsize=8, max_bytes=10_000_000)
+
+    nbytes = 8
+    for c in chunks:
+        nbytes *= c
+    assert nbytes <= 10_000_000
+    assert all(0 < c <= s for c, s in zip(chunks, shape))
+
+
+def test_safe_zarr_chunks_no_op_when_already_small():
+    from abtem.array import _safe_zarr_chunks
+
+    shape = (4, 8, 8)
+    assert _safe_zarr_chunks(shape, itemsize=8) == shape
+
+
+def _make_dp(n_energy, gpts, seed=0):
+    import dask.array as da
+    import numpy as np
+
+    import abtem
+    from abtem.measurements import DiffractionPatterns
+
+    rng = np.random.default_rng(seed)
+    array = rng.random((n_energy, gpts, gpts))
+    lazy_array = da.from_array(array, chunks=(1, gpts, gpts))
+    dp = DiffractionPatterns.from_array_and_metadata(
+        lazy_array,
+        axes_metadata=[
+            OrdinalAxis(label="energy", values=tuple(range(n_energy))),
+            abtem.core.axes.ReciprocalSpaceAxis(sampling=0.1, label="x", units="1/A"),
+            abtem.core.axes.ReciprocalSpaceAxis(sampling=0.1, label="y", units="1/A"),
+        ],
+    )
+    return dp, array
+
+
+@pytest.mark.parametrize("suffix", ["", ".zip"])
+def test_to_zarr_writes_multiple_chunks_not_one_giant_chunk(tmp_path, monkeypatch, suffix):
+    """A single whole-array zarr chunk hits a codec's 2**31-1 byte buffer
+    limit for any reasonably large array (regression: this used to always
+    happen via chunks=computed_array.shape). Force a tiny budget so a small
+    test array reproduces the same "must be split" condition, and check the
+    written array is actually split -- and still round-trips correctly."""
+    import numpy as np
+    import zarr
+
+    import abtem.array as abtem_array_module
+
+    monkeypatch.setattr(abtem_array_module, "_MAX_ZARR_CHUNK_BYTES", 10_000)
+
+    dp, array = _make_dp(n_energy=8, gpts=16)
+    url = str(tmp_path / f"dp{suffix}")
+    dp.to_zarr(url)
+
+    if suffix == ".zip":
+        store = zarr.storage.ZipStore(url, mode="r")
+        root = zarr.open(store=store, mode="r")
+    else:
+        root = zarr.open(url, mode="r")
+
+    zarr_array = root["array0"]
+    assert zarr_array.chunks != zarr_array.shape
+
+    if suffix == ".zip":
+        store.close()
+
+    loaded = abtem_array_module.from_zarr(url).compute()
+    np.testing.assert_allclose(loaded.array, array)
+
+
+@pytest.mark.parametrize("suffix", ["", ".zip"])
+def test_to_zarr_cleans_up_on_failed_write(tmp_path, monkeypatch, suffix):
+    """A write that fails partway (e.g. a chunk still over a codec's buffer
+    limit) must not leave behind a store with valid-looking metadata but
+    missing chunk data -- previously silently readable back as all zeros
+    (zarr's fill_value for a declared-but-never-written chunk)."""
+    import zarr
+
+    def _raising_create_array(self, *args, **kwargs):
+        raise ValueError("Codec does not support buffers of > 2147483647 bytes")
+
+    monkeypatch.setattr(zarr.Group, "create_array", _raising_create_array)
+
+    dp, _ = _make_dp(n_energy=4, gpts=8)
+    url = str(tmp_path / f"dp{suffix}")
+    with pytest.raises(ValueError, match="Codec does not support buffers"):
+        dp.to_zarr(url)
+
+    assert not os.path.exists(url)
 
 
 @given(data=st.data())


### PR DESCRIPTION
## Summary

Two related bugs reported by @TomaSusi when saving large `phonon_loss_diffraction_patterns` data at float64 precision with zip compression:

1. `ValueError: Codec does not support buffers of > 2147483647 bytes` — Blosc/zlib reject a single compression buffer over 2**31 - 1 bytes.
2. Separately: after saving to `.zarr.zip`, the lazily-loaded result didn't match the directly-computed one — the loaded data was all zeros.

## Root cause

`ComputableList.to_zarr` always wrote each array as **one single zarr chunk**, regardless of size:

```python
root.create_array(name=f"array{i}", data=computed_array, chunks=computed_array.shape, ...)
```

For any reasonably large array — especially at float64 — that single chunk exceeds the codec's 2 GiB buffer limit, reproducing bug #1 exactly (confirmed with a 2 GiB synthetic array).

Worse, that failure happens *inside* `create_array()`, **after** the zarr group's metadata (shape/dtype/chunks) has already been written. The store's `finally: store.close()` still runs, finalizing a `.zip`/directory store that opens fine and reports the correct shape/dtype, but has no actual chunk data. Reading it back doesn't raise — it silently returns zarr's `fill_value` (0), which is exactly bug #2. I reproduced this directly: a failed 2 GiB write left behind a 44 KB file that `from_zarr()` opens successfully and computes to all zeros.

These aren't two independent bugs — #2 is what a partially-failed #1 leaves behind.

## Fix

- New `_safe_zarr_chunks()` picks a chunk shape that stays under a 512 MiB budget (well under the codec limit, and a more sensible chunk size for parallel IO in general) by halving the largest axis until it fits, instead of always using the whole-array shape. Applied to both the zip-store and directory-store write paths.
- On any exception during the write, the partially-written file/directory is now removed before re-raising, so a failed save never leaves behind an artifact that looks valid but silently returns wrong data.

Verified the 2 GiB case now saves and loads back with **zero difference** from the original array (previously: hard failure, and a corrupted file if the exception were ever swallowed).

## Test plan
- [x] `_safe_zarr_chunks` unit tests (stays under budget, no-op when already small)
- [x] New round-trip tests (directory and zip store) that force a tiny chunk budget and confirm the written array is actually split into multiple zarr chunks, and still round-trips correctly
- [x] New cleanup tests (directory and zip store) confirming a failed write doesn't leave a file/directory behind
- [x] Manual repro: a 2 GiB float64 array, which previously hit the exact reported `ValueError` and left a corrupted-but-openable `.zarr.zip`, now saves and round-trips with 0.0 max absolute difference
- [x] Full test suite: 1321 passed, 830 skipped, 0 failures (3 deselected -- pre-existing, unrelated hangs in `test_multigpu_logic.py` spinning up real multi-process dask clusters that never complete in this sandbox; tracked separately, not caused by or related to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
