### PR TITLE
Share diffraction-pattern FFT across detectors in one detection pass

### DIFF
--- a/abtem/core/fft.py
+++ b/abtem/core/fft.py
@@ -1,5 +1,6 @@
 """Module for handling Fourier transforms and convolution in abTEM."""
 
+import contextlib
 import math
 import threading
 import warnings
@@ -552,6 +553,84 @@ def ifft2(x: U, overwrite_x: bool = False, **kwargs) -> U:
     Using the FFT library specified in the configuration.
     """
     return _fft_dispatch(x, func_name="ifft2", overwrite_x=overwrite_x, **kwargs)
+
+
+# --- Shared diffraction-pattern FFT ----------------------------------------
+#
+# Several radial detectors (AnnularDetector, FlexibleAnnularDetector,
+# SegmentedDetector, PixelatedDetector, ...) each derive their measurement
+# from ``Waves.diffraction_patterns``, which starts with a 2D FFT of the wave
+# function array. When several such detectors are evaluated against the same
+# array in one detection pass (once per detector, per site batch, per slice
+# in e.g. ``transition_potential_multislice_and_detect``), that FFT would
+# otherwise be recomputed once per detector even though the input and
+# normalization are identical every time. ``share_diffraction_pattern_fft``
+# below lets a caller precompute that FFT once and attach it directly to the
+# specific ``Waves`` object it was computed from, for the duration of a
+# ``with`` block; the (cheap) crop / intensity / fftshift that turns it into
+# a specific detector's diffraction pattern still runs once per call.
+#
+# Deliberately NOT a cache keyed by array identity: several in-place
+# multislice steps (e.g. propagating a wave with ``overwrite_x=True``)
+# legitimately reuse the exact same array object across multislice depths
+# while overwriting its contents, so identity alone cannot tell "the same
+# data" apart from "the same object, now holding different data." Attaching
+# the precomputed value as a plain attribute on one specific ``Waves``
+# instance sidesteps that: there is nothing to key or invalidate, because a
+# read only ever consults *that* object's own attribute, and the attribute
+# only exists for the lifetime of the ``with`` block that put it there.
+#
+#   * No global or thread-local state: the shared value lives on the Waves
+#     object itself, so a dask worker thread naturally only ever sees the
+#     ``waves``/``scattered_waves`` object local to its own call stack.
+#   * A caller not using ``share_diffraction_pattern_fft`` (any standalone
+#     ``detector.detect(waves)``, or any code path that hasn't opted in)
+#     never sees a ``_shared_diffraction_pattern_fft`` attribute at all, so
+#     it is unconditionally identical to the pre-sharing behavior.
+#   * The one rule callers must follow: do not mutate ``waves.array`` (e.g.
+#     run a multislice step) between entering and exiting the block. A
+#     mistake here can only affect reads of *that* object within *that*
+#     block -- there is no shared slot it could leak into for some later,
+#     unrelated array to read.
+
+
+@contextlib.contextmanager
+def share_diffraction_pattern_fft(waves, normalize: bool, compute):
+    """Attach ``compute()`` to ``waves`` as its shared diffraction-pattern FFT
+    for the duration of this block, so several detectors evaluated against
+    this exact, not-yet-mutated ``waves`` object can each reuse it via
+    ``get_shared_diffraction_pattern_fft`` instead of recomputing their own.
+    See the module comment above for the full rationale.
+
+    Do not mutate ``waves.array`` (e.g. run a multislice step) while this
+    block is active. Safe to nest on the same ``waves`` object: an outer
+    block's value (if any) is saved and restored around a nested one,
+    rather than a nested block's exit deleting an outer block's value.
+    """
+    previous = getattr(waves, "_shared_diffraction_pattern_fft", None)
+    waves._shared_diffraction_pattern_fft = (normalize, compute())
+    try:
+        yield
+    finally:
+        if previous is None:
+            del waves._shared_diffraction_pattern_fft
+        else:
+            waves._shared_diffraction_pattern_fft = previous
+
+
+def get_shared_diffraction_pattern_fft(waves, normalize: bool, compute):
+    """Return ``compute()``, reusing the value attached to ``waves`` by an
+    enclosing ``share_diffraction_pattern_fft(waves, normalize, ...)`` if one
+    is active and its ``normalize`` matches; otherwise calls ``compute()``
+    directly. See the module comment above ``share_diffraction_pattern_fft``.
+    """
+    shared = getattr(waves, "_shared_diffraction_pattern_fft", None)
+    if shared is not None:
+        shared_normalize, shared_fft = shared
+        if shared_normalize == normalize:
+            return shared_fft
+
+    return compute()
 
 
 @overload

--- a/abtem/inelastic/core_loss.py
+++ b/abtem/inelastic/core_loss.py
@@ -1546,16 +1546,19 @@ def prism_transition_potential_scan(
             + list(scan_axes_metadata),
         )
 
-        for det_idx, detector in enumerate(detectors):
-            m = detector.detect(position_waves)
-            m = m.sum((0,))
-            if isinstance(exit_idx, int):
-                idx = () if n_exit == 1 else (exit_idx,)
-                measurements[det_idx].array[idx] += m.array
-            else:
-                measurements[det_idx].array[exit_idx] += (
-                    m.array[(None,) * len(exit_idx)]
-                )
+        # All detectors here see the same, not-yet-mutated ``position_waves``
+        # -- share one diffraction-pattern FFT across them.
+        with position_waves._share_diffraction_pattern_fft():
+            for det_idx, detector in enumerate(detectors):
+                m = detector.detect(position_waves)
+                m = m.sum((0,))
+                if isinstance(exit_idx, int):
+                    idx = () if n_exit == 1 else (exit_idx,)
+                    measurements[det_idx].array[idx] += m.array
+                else:
+                    measurements[det_idx].array[exit_idx] += (
+                        m.array[(None,) * len(exit_idx)]
+                    )
 
     def _scatter_at_site(atom):
         site_xy = np.array(
@@ -1935,17 +1938,22 @@ def prism_transition_potential_scan_beam_basis(
                 OrdinalAxis(values=tuple(range(int(mask.sum())))),
             ],
         )
-        for det_idx, detector in enumerate(detectors):
-            m = detector.detect(wave)
-            m = m.sum((0,))
-            full_partial = xp.zeros(
-                (n_positions,) + m.array.shape[1:], dtype=m.array.dtype
-            )
-            full_partial[mask] = m.array
-            full_partial = copy_to_device(full_partial, measurements[det_idx].array)
-            measurements[det_idx].array += full_partial.reshape(
-                scan_shape + m.array.shape[1:]
-            )
+        # All detectors here see the same, not-yet-mutated ``wave`` -- share
+        # one diffraction-pattern FFT across them.
+        with wave._share_diffraction_pattern_fft():
+            for det_idx, detector in enumerate(detectors):
+                m = detector.detect(wave)
+                m = m.sum((0,))
+                full_partial = xp.zeros(
+                    (n_positions,) + m.array.shape[1:], dtype=m.array.dtype
+                )
+                full_partial[mask] = m.array
+                full_partial = copy_to_device(
+                    full_partial, measurements[det_idx].array
+                )
+                measurements[det_idx].array += full_partial.reshape(
+                    scan_shape + m.array.shape[1:]
+                )
 
     # --- Main loop ---
     for slice_index, transmission in enumerate(transmissions):

--- a/abtem/multislice.py
+++ b/abtem/multislice.py
@@ -492,13 +492,16 @@ def _update_measurements(
 ) -> None:
     assert len(detectors) == len(measurements)
 
-    for i, detector in enumerate(detectors):
-        new_measurement = detector.detect(waves)
+    # All detectors here see the same, not-yet-mutated ``waves`` -- share one
+    # diffraction-pattern FFT across them (see Waves._share_diffraction_pattern_fft).
+    with waves._share_diffraction_pattern_fft():
+        for i, detector in enumerate(detectors):
+            new_measurement = detector.detect(waves)
 
-        if additive:
-            measurements[i].array[measurement_index] += new_measurement.array
-        else:
-            measurements[i].array[measurement_index] = new_measurement.array
+            if additive:
+                measurements[i].array[measurement_index] += new_measurement.array
+            else:
+                measurements[i].array[measurement_index] = new_measurement.array
     return
 
 
@@ -797,10 +800,11 @@ def multislice_and_detect(
 
     # Handle final output if not using intermediate measurements
     if measurements is None:
-        measurements = [
-            detector.detect(waves)[(None,) * len(potential.ensemble_shape)]
-            for detector in detectors
-        ]
+        with waves._share_diffraction_pattern_fft():
+            measurements = [
+                detector.detect(waves)[(None,) * len(potential.ensemble_shape)]
+                for detector in detectors
+            ]
 
     elif return_backscattered:
         _back_propagate_backscattered_waves(
@@ -939,10 +943,18 @@ def transition_potential_multislice_and_detect(
                 potential_index, exit_plane_index, potential
             )
 
-            for i, detector in enumerate(detectors):
-                new_measurement = detector.detect(waves)
-                new_measurement = new_measurement.sum((0,))
-                measurements[i].array[measurement_index] += new_measurement.array
+            # All detectors here see the same, not-yet-mutated ``waves`` at
+            # this exit plane -- share one diffraction-pattern FFT across
+            # them (see Waves._share_diffraction_pattern_fft). The block is
+            # re-entered fresh each call, so a later call at a *different*
+            # slice_index/depth (waves whose ``.array`` some in-place
+            # multislice steps reuse across depths) never sees a value
+            # computed for an earlier one.
+            with waves._share_diffraction_pattern_fft():
+                for i, detector in enumerate(detectors):
+                    new_measurement = detector.detect(waves)
+                    new_measurement = new_measurement.sum((0,))
+                    measurements[i].array[measurement_index] += new_measurement.array
 
     waves = waves.ensure_real_space()
 
@@ -1151,13 +1163,19 @@ def transition_potential_multislice_and_detect(
                         )
                         measurement_plane_indices = (exit_planes,)
 
-                    for i, detector in enumerate(detectors):
-                        new_measurement = detector.detect(scattered_waves).sum((0,))
-                        measurements[i].array[measurement_plane_indices] += (
-                            new_measurement.array[
-                                (None,) * len(measurement_plane_indices)
-                            ]
-                        )
+                    # All detectors here see the same, not-yet-mutated
+                    # ``scattered_waves`` -- share one diffraction-pattern
+                    # FFT across them (see Waves._share_diffraction_pattern_fft).
+                    with scattered_waves._share_diffraction_pattern_fft():
+                        for i, detector in enumerate(detectors):
+                            new_measurement = detector.detect(scattered_waves).sum(
+                                (0,)
+                            )
+                            measurements[i].array[measurement_plane_indices] += (
+                                new_measurement.array[
+                                    (None,) * len(measurement_plane_indices)
+                                ]
+                            )
 
     tqdm_pbar.close_if_exists()
 

--- a/abtem/prism/s_matrix.py
+++ b/abtem/prism/s_matrix.py
@@ -1182,8 +1182,11 @@ class SMatrixArray(BaseSMatrix, ArrayObject):
 
                 pbar.update_if_exists(len(sub_scan))
 
-                for detector, measurement in zip(detectors, measurements):
-                    measurement.array[indices] = detector.detect(waves).array
+                # All detectors here see the same, not-yet-mutated ``waves``
+                # -- share one diffraction-pattern FFT across them.
+                with waves._share_diffraction_pattern_fft():
+                    for detector, measurement in zip(detectors, measurements):
+                        measurement.array[indices] = detector.detect(waves).array
 
         pbar.close_if_exists()
 
@@ -2386,8 +2389,12 @@ class CompressedSMatrixArray(BaseSMatrix, CopyMixin, EqualityMixin):
 
                     pbar.update_if_exists((stop - start) * scan_shape[1])
 
-                    for detector, measurement in zip(detectors, measurements):
-                        measurement.array[indices] = detector.detect(waves).array
+                    # All detectors here see the same, not-yet-mutated
+                    # ``waves`` -- share one diffraction-pattern FFT across
+                    # them.
+                    with waves._share_diffraction_pattern_fft():
+                        for detector, measurement in zip(detectors, measurements):
+                            measurement.array[indices] = detector.detect(waves).array
 
                 del interpolated, plane_wave
 
@@ -2684,8 +2691,11 @@ class CompressedSMatrixArray(BaseSMatrix, CopyMixin, EqualityMixin):
 
         pbar.update_if_exists(n_reduced)
 
-        for detector, measurement in zip(detectors, measurements):
-            measurement.array[indices] = detector.detect(waves).array
+        # All detectors here see the same, not-yet-mutated ``waves`` --
+        # share one diffraction-pattern FFT across them.
+        with waves._share_diffraction_pattern_fft():
+            for detector, measurement in zip(detectors, measurements):
+                measurement.array[indices] = detector.detect(waves).array
 
     def _batch_reduce_to_measurements(
         self,

--- a/abtem/waves.py
+++ b/abtem/waves.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import itertools
 import warnings
 from abc import abstractmethod
@@ -34,7 +35,14 @@ from abtem.core.chunks import estimate_potential_chunk_size, validate_chunks
 from abtem.core.complex import abs2
 from abtem.core.energy import Accelerator, HasAcceleratorMixin
 from abtem.core.ensemble import Ensemble, _wrap_with_array, unpack_blockwise_args
-from abtem.core.fft import fft2, fft_crop, fft_interpolate, ifft2
+from abtem.core.fft import (
+    fft2,
+    fft_crop,
+    fft_interpolate,
+    get_shared_diffraction_pattern_fft,
+    ifft2,
+    share_diffraction_pattern_fft,
+)
 from abtem.core.grid import Grid, HasGrid2DMixin, polar_spatial_frequencies
 from abtem.core.utils import (
     CopyMixin,
@@ -1234,14 +1242,29 @@ class Waves(BaseWaves, ArrayObject):
         return self.__class__(**kwargs)
 
     @staticmethod
-    def _diffraction_pattern(array, new_gpts, return_complex, fftshift, normalize):
-        xp = get_array_module(array)
-
+    def _diffraction_pattern_fft(array, normalize):
+        """Compute the (un-cropped) FFT that all diffraction-pattern flavours
+        (full/cutoff/valid crop, real or complex, block-direct or not) are
+        derived from. Factored out of ``_diffraction_pattern`` so it can be
+        shared (and cached) across several downstream cropping calls that
+        differ only in ``new_gpts``/``return_complex``/``fftshift``.
+        """
         if normalize:
             array = array / float(np.prod(array.shape[-2:]))
 
-        array = fft2(array, overwrite_x=False)
+        return fft2(array, overwrite_x=False)
 
+    @staticmethod
+    def _diffraction_pattern_from_fft(fft_array, new_gpts, return_complex, fftshift):
+        """Crop/intensity/shift an already-computed FFT (see
+        ``_diffraction_pattern_fft``) into the requested diffraction pattern.
+        This part is comparatively cheap, so sharing the FFT above across
+        multiple detectors is what makes a second (or third) radial
+        detector nearly free.
+        """
+        xp = get_array_module(fft_array)
+
+        array = fft_array
         if array.shape[-2:] != new_gpts:
             array = fft_crop(array, new_shape=array.shape[:-2] + new_gpts)
 
@@ -1252,6 +1275,51 @@ class Waves(BaseWaves, ArrayObject):
             return xp.fft.fftshift(array, axes=(-1, -2))
 
         return array
+
+    @staticmethod
+    def _diffraction_pattern(array, new_gpts, return_complex, fftshift, normalize):
+        fft_array = Waves._diffraction_pattern_fft(array, normalize)
+        return Waves._diffraction_pattern_from_fft(
+            fft_array, new_gpts=new_gpts, return_complex=return_complex, fftshift=fftshift
+        )
+
+    @staticmethod
+    def _diffraction_pattern_should_normalize(metadata, renormalize=True):
+        """Whether ``diffraction_patterns`` should renormalize the intensity
+        for the given ``metadata`` (see its ``renormalize`` parameter).
+        Factored out so callers sharing a diffraction-pattern FFT across
+        several detectors (see ``abtem.core.fft.share_diffraction_pattern_fft``)
+        can compute the same boolean the shared FFT must be keyed on.
+        """
+        if renormalize and "normalization" in metadata:
+            if metadata["normalization"] == "values":
+                return True
+            elif metadata["normalization"] != "reciprocal_space":
+                raise RuntimeError(
+                    f"normalization {metadata['normalization']} not recognized"
+                )
+        return False
+
+    @contextlib.contextmanager
+    def _share_diffraction_pattern_fft(self, renormalize: bool = True):
+        """Precompute this waves object's diffraction-pattern FFT once and
+        share it with every ``detector.detect(self)`` call made inside this
+        block, instead of each detector computing its own (see
+        ``abtem.core.fft.share_diffraction_pattern_fft``).
+
+        Wrap exactly a loop over several detectors that are known, by
+        construction, to see this exact, not-yet-mutated waves object --
+        e.g. one pass over several detectors at a fixed multislice depth.
+        Do not mutate ``self.array`` (e.g. run a multislice step) while this
+        block is active.
+        """
+        normalize = self._diffraction_pattern_should_normalize(
+            self.metadata, renormalize
+        )
+        with share_diffraction_pattern_fft(
+            self, normalize, lambda: self._diffraction_pattern_fft(self.array, normalize)
+        ):
+            yield
 
     def diffraction_patterns(
         self,
@@ -1319,14 +1387,7 @@ class Waves(BaseWaves, ArrayObject):
         metadata["label"] = "intensity"
         metadata["units"] = "arb. unit"
 
-        normalize = False
-        if renormalize and "normalization" in metadata:
-            if metadata["normalization"] == "values":
-                normalize = True
-            elif metadata["normalization"] != "reciprocal_space":
-                raise RuntimeError(
-                    f"normalization {metadata['normalization']} not recognized"
-                )
+        normalize = self._diffraction_pattern_should_normalize(metadata, renormalize)
 
         if self.is_lazy:
             dtype = get_dtype(complex=return_complex)
@@ -1342,12 +1403,21 @@ class Waves(BaseWaves, ArrayObject):
                 meta=xp.array((), dtype=dtype),
             )
         else:
-            pattern = self._diffraction_pattern(
-                self.array,
+            # Reuse the FFT precomputed for this exact ``self`` by an
+            # enclosing ``share_diffraction_pattern_fft(self, ...)`` (see
+            # abtem.core.fft), if one is active -- e.g. another detector
+            # evaluated against the same waves in the same detection pass.
+            # Only the FFT is shared; cropping/intensity/shift below still
+            # runs per call, so this is bit-for-bit identical to calling
+            # ``_diffraction_pattern`` directly.
+            fft_array = get_shared_diffraction_pattern_fft(
+                self, normalize, lambda: self._diffraction_pattern_fft(self.array, normalize)
+            )
+            pattern = self._diffraction_pattern_from_fft(
+                fft_array,
                 new_gpts=new_gpts,
                 return_complex=return_complex,
                 fftshift=fftshift,
-                normalize=normalize,
             )
 
         diffraction_patterns = DiffractionPatterns(

--- a/benchmarks/benchmark_shared_diffraction_pattern.py
+++ b/benchmarks/benchmark_shared_diffraction_pattern.py
@@ -1,0 +1,227 @@
+"""
+Benchmark: marginal cost of running multiple angular (radial) detectors in a
+single transition-potential (core-loss) multislice pass.
+
+Before the shared-FFT cache (see ``Waves._cached_diffraction_pattern_fft`` in
+abtem/waves.py), every radial detector (``AnnularDetector``,
+``FlexibleAnnularDetector``, ``SegmentedDetector``, ``PixelatedDetector``)
+recomputed its own 2D FFT of the wave function array via
+``Waves.diffraction_patterns`` -> ``_diffraction_pattern``, even when several
+such detectors are evaluated against the exact same (eager) array in the same
+detection pass (as happens once per detector, per site batch, per slice in
+``transition_potential_multislice_and_detect``). This benchmark reproduces
+that scenario and reports the wall-clock cost of adding a second (and third)
+``AnnularDetector`` to the pass.
+
+Usage:
+    python benchmarks/benchmark_shared_diffraction_pattern.py
+    python benchmarks/benchmark_shared_diffraction_pattern.py --device gpu
+"""
+
+import argparse
+import os
+import sys
+import time
+
+os.environ.setdefault("TQDM_DISABLE", "1")
+
+_repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+import numpy as np
+from ase.build import bulk
+
+import abtem
+from abtem import AnnularDetector, GridScan, Potential, Probe
+from abtem.core.axes import OrdinalAxis
+from abtem.inelastic.core_loss import TransitionPotentialArray
+from abtem.multislice import transition_potential_multislice_and_detect
+
+try:
+    import cupy as cp
+except ImportError:
+    cp = None
+
+
+def _disable_shared_diffraction_pattern_cache():
+    """Monkeypatch away the shared-FFT optimization so the *same* installed
+    abtem can also produce a true pre-optimization baseline, without needing
+    a separate checkout/branch.
+
+    ``Waves.diffraction_patterns`` calls
+    ``abtem.core.fft.get_shared_diffraction_pattern_fft``, imported into the
+    ``abtem.waves`` module namespace. Replacing that name there (not in
+    ``abtem.core.fft``, which every other module's own already-bound import
+    wouldn't see) makes every diffraction-pattern computation always
+    recompute its FFT, regardless of whether a
+    ``waves._share_diffraction_pattern_fft()`` block is active -- i.e.
+    exactly the behavior before this optimization existed.
+    """
+    import abtem.waves as _waves_mod
+
+    def _always_recompute(waves, normalize, compute):
+        return compute()
+
+    _waves_mod.get_shared_diffraction_pattern_fft = _always_recompute
+
+
+def _make_scene(device, gpts=96, num_slices=3, n_transitions=16):
+    # A small Si cell repeated/sliced to give exactly `num_slices` potential
+    # slices, matching the "3 slices" scenario in the task description.
+    atoms = bulk("Si", cubic=True)
+    slice_thickness = atoms.cell[2, 2] / num_slices
+
+    potential = Potential(
+        atoms,
+        gpts=gpts,
+        slice_thickness=slice_thickness,
+        device=device,
+    )
+    assert potential.num_slices == num_slices, potential.num_slices
+
+    probe = Probe(energy=100e3, semiangle_cutoff=20, device=device)
+    probe.grid.match(potential)
+
+    rng = np.random.default_rng(0)
+    array = (
+        rng.standard_normal((n_transitions, *potential.gpts))
+        + 1j * rng.standard_normal((n_transitions, *potential.gpts))
+    ).astype(np.complex64)
+    if device == "gpu":
+        array = cp.asarray(array)
+
+    transition_potentials = TransitionPotentialArray(
+        Z=14,
+        array=array,
+        energy=100e3,
+        extent=potential.extent,
+        ensemble_axes_metadata=[OrdinalAxis(values=tuple(range(n_transitions)))],
+        metadata={"Z": 14, "n": 1, "l": 0},
+    )
+
+    scan = GridScan(
+        start=(0, 0),
+        end=(1, 1),
+        fractional=True,
+        potential=potential,
+        endpoint=False,
+        gpts=(4, 4),
+    )
+
+    # Eager batch of probe wave functions at all 4x4 scan positions -- this
+    # is exactly the ``waves`` that ``Waves.transition_potential_multislice``
+    # would build internally and hand to
+    # ``transition_potential_multislice_and_detect`` per dask block.
+    waves = probe.build(scan=scan, lazy=False)
+
+    return waves, potential, transition_potentials
+
+
+def _run(waves, potential, transition_potentials, detectors):
+    # Call the low-level driver directly rather than going through
+    # ``Probe.transition_potential_scan``: with more than one detector, the
+    # latter hits a pre-existing, unrelated bug in
+    # ``Waves.transition_potential_multislice`` (it asserts the
+    # per-transition-potential result is a single Waves/BaseMeasurements,
+    # but ``apply_transform`` returns a plain list/ComputableList once there
+    # is more than one detector). That bug is orthogonal to the optimization
+    # under test here -- this driver is precisely the hot loop named in the
+    # task ("transition_potential_multislice_and_detect ... calls
+    # detector.detect(scattered_waves) in a loop over detectors").
+    return transition_potential_multislice_and_detect(
+        waves=waves.copy(),
+        potential=potential,
+        transition_potential=transition_potentials,
+        detectors=detectors,
+        sites=None,
+    )
+
+
+def _time_it(label, fn, n_repeats, n_warmup=1):
+    for _ in range(n_warmup):
+        fn()
+
+    times = []
+    for _ in range(n_repeats):
+        start = time.perf_counter()
+        fn()
+        times.append(time.perf_counter() - start)
+
+    best = min(times)
+    print(f"  {label:45s} best={best:.4f}s  all={['%.4f' % t for t in times]}")
+    return best
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", default="cpu", choices=["cpu", "gpu"])
+    parser.add_argument("--gpts", type=int, default=96)
+    parser.add_argument("--slices", type=int, default=3)
+    parser.add_argument("--transitions", type=int, default=16)
+    parser.add_argument("--repeats", type=int, default=5)
+    args = parser.parse_args()
+
+    if args.device == "gpu" and cp is None:
+        print("cupy not available, skipping GPU benchmark")
+        return
+
+    waves, potential, tp = _make_scene(
+        args.device, gpts=args.gpts, num_slices=args.slices,
+        n_transitions=args.transitions,
+    )
+
+    print(
+        f"device={args.device} gpts={args.gpts} slices={args.slices} "
+        f"scan=4x4 transitions={args.transitions}\n"
+    )
+
+    configs = {
+        "one AnnularDetector": [AnnularDetector(inner=0, outer=20)],
+        "two AnnularDetectors": [
+            AnnularDetector(inner=0, outer=20),
+            AnnularDetector(inner=20, outer=40),
+        ],
+        "three AnnularDetectors": [
+            AnnularDetector(inner=0, outer=20),
+            AnnularDetector(inner=20, outer=40),
+            AnnularDetector(inner=40, outer=60),
+        ],
+    }
+
+    print("-- with shared-FFT cache (current behavior) --")
+    cached = {
+        label: _time_it(label, lambda d=detectors: _run(waves, potential, tp, d), args.repeats)
+        for label, detectors in configs.items()
+    }
+
+    print("\n-- pre-cache baseline (each detector recomputes its own FFT) --")
+    _disable_shared_diffraction_pattern_cache()
+    baseline = {
+        label: _time_it(label, lambda d=detectors: _run(waves, potential, tp, d), args.repeats)
+        for label, detectors in configs.items()
+    }
+
+    labels = list(configs)
+    print()
+    print(f"  {'':24s} {'baseline':>10s} {'cached':>10s} {'speedup':>9s}")
+    for label in labels:
+        b, c = baseline[label], cached[label]
+        print(f"  {label:24s} {b:9.4f}s {c:9.4f}s {b / c:8.2f}x")
+
+    print()
+    b1, b2, b3 = (baseline[l] for l in labels)
+    c1, c2, c3 = (cached[l] for l in labels)
+    print("  marginal cost of an extra detector, relative to 1 detector's own time:")
+    print(
+        f"    baseline : 2nd detector {(b2 - b1) / b1 * 100:+.1f}%   "
+        f"3rd detector {(b3 - b2) / b1 * 100:+.1f}%"
+    )
+    print(
+        f"    cached   : 2nd detector {(c2 - c1) / c1 * 100:+.1f}%   "
+        f"3rd detector {(c3 - c2) / c1 * 100:+.1f}%"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_stem_multi_detector.py
+++ b/benchmarks/benchmark_stem_multi_detector.py
@@ -1,0 +1,295 @@
+"""
+Benchmark: time and memory savings from sharing the diffraction-pattern FFT
+across multiple angular detectors in a *regular* (elastic) STEM multislice
+scan -- as opposed to the transition-potential/core-loss scenario in
+``benchmark_shared_diffraction_pattern.py``.
+
+Mirrors a typical everyday STEM simulation: one ``Potential``, one
+``GridScan``, and a handful of angular detectors evaluated together (e.g. a
+bright-field disk, one or two annular dark-field rings, and a segmented
+detector) via ``Probe.scan(..., detectors=[...])`` ->
+``multislice_and_detect``.
+
+Each configuration is measured in its own subprocess (see
+``benchmark_potential_chunking.py`` for the same pattern) so that one
+config's allocations/caches never leak into the peak-RSS measurement of the
+next.
+
+Usage:
+    python benchmarks/benchmark_stem_multi_detector.py
+    python benchmarks/benchmark_stem_multi_detector.py --device gpu
+    python benchmarks/benchmark_stem_multi_detector.py --gpts 256 --scan 32
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+os.environ.setdefault("TQDM_DISABLE", "1")
+
+_repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+
+CONFIGS = {
+    "one_annular": 1,
+    "two_annular": 2,
+    "three_annular": 3,
+    "bf_adf_segmented": "mixed",
+}
+
+
+def _build_detectors(config, max_angle):
+    """Build detectors with angles scaled to fractions of ``max_angle``
+    (the largest angle the simulation grid can resolve), so the detector
+    ranges stay valid across different ``--gpts``/probe settings.
+    """
+    from abtem import AnnularDetector, SegmentedDetector
+
+    a = max_angle
+
+    if config == 1:
+        return [AnnularDetector(inner=0, outer=0.3 * a)]
+    if config == 2:
+        return [
+            AnnularDetector(inner=0, outer=0.3 * a),
+            AnnularDetector(inner=0.5 * a, outer=0.9 * a),
+        ]
+    if config == 3:
+        return [
+            AnnularDetector(inner=0, outer=0.2 * a),
+            AnnularDetector(inner=0.3 * a, outer=0.6 * a),
+            AnnularDetector(inner=0.6 * a, outer=0.95 * a),
+        ]
+    if config == "mixed":
+        # A realistic everyday combination: bright field, one ADF ring, and
+        # a segmented (e.g. DPC-style) detector, all reading the same
+        # diffraction pattern.
+        return [
+            AnnularDetector(inner=0, outer=0.2 * a),  # BF
+            AnnularDetector(inner=0.5 * a, outer=0.9 * a),  # ADF
+            SegmentedDetector(
+                inner=0.2 * a, outer=0.5 * a, nbins_radial=2, nbins_azimuthal=4
+            ),
+        ]
+    raise ValueError(config)
+
+
+def _disable_shared_diffraction_pattern_cache():
+    """Monkeypatch away the shared-FFT optimization so the same installed
+    abtem also gives a true pre-optimization baseline (see the equivalent
+    helper in ``benchmark_shared_diffraction_pattern.py`` for why this
+    particular monkeypatch point -- ``abtem.waves``'s already-bound
+    ``get_shared_diffraction_pattern_fft`` -- is the one that actually takes
+    effect everywhere ``Waves.diffraction_patterns`` is called from)."""
+    import abtem.waves as _waves_mod
+
+    def _always_recompute(waves, normalize, compute):
+        return compute()
+
+    _waves_mod.get_shared_diffraction_pattern_fft = _always_recompute
+
+
+def _run_subprocess_worker(device, config, gpts, scan_gpts, num_slices, no_cache):
+    import resource
+
+    import numpy as np
+    from ase.build import bulk
+
+    import abtem
+    from abtem import Potential, Probe, GridScan
+
+    if no_cache:
+        _disable_shared_diffraction_pattern_cache()
+
+    atoms = bulk("Au", cubic=True) * (
+        max(1, gpts // 20), max(1, gpts // 20), 1
+    )
+    slice_thickness = atoms.cell[2, 2] / num_slices if num_slices else atoms.cell[2, 2]
+
+    potential = Potential(
+        atoms, gpts=gpts, slice_thickness=slice_thickness, device=device,
+    )
+    probe = Probe(energy=200e3, semiangle_cutoff=25, device=device)
+    probe.grid.match(potential)
+
+    scan = GridScan(
+        start=(0, 0), end=(1, 1), fractional=True, potential=potential,
+        endpoint=False, gpts=(scan_gpts, scan_gpts),
+    )
+
+    max_angle = float(np.floor(min(probe.cutoff_angles)))
+    detectors = _build_detectors(config, max_angle)
+
+    # Warm-up: build FFTW plans / JIT paths outside the timed region.
+    warm_scan = GridScan(
+        start=(0, 0), end=(0.25, 0.25), fractional=True, potential=potential,
+        endpoint=False, gpts=(2, 2),
+    )
+    probe.scan(scan=warm_scan, potential=potential, detectors=detectors, lazy=False)
+
+    start_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+
+    start = time.perf_counter()
+    result = probe.scan(scan=scan, potential=potential, detectors=detectors, lazy=False)
+    if hasattr(result, "compute"):
+        result = result.compute()
+    elapsed = time.perf_counter() - start
+
+    end_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+
+    # ru_maxrss is bytes on macOS/BSD, kilobytes on Linux.
+    rss_unit_bytes = 1 if sys.platform == "darwin" else 1024
+
+    print(
+        json.dumps(
+            {
+                "elapsed_s": elapsed,
+                "peak_rss_mb": end_rss * rss_unit_bytes / (1024 ** 2),
+                "rss_growth_mb": (end_rss - start_rss) * rss_unit_bytes / (1024 ** 2),
+            }
+        )
+    )
+
+
+def _run_one_config(device, config, gpts, scan_gpts, num_slices, no_cache=False):
+    cmd = [
+        sys.executable,
+        __file__,
+        "--subprocess-worker",
+        "--device", device,
+        "--config", str(config),
+        "--gpts", str(gpts),
+        "--scan", str(scan_gpts),
+        "--slices", str(num_slices),
+    ]
+    if no_cache:
+        cmd.append("--no-cache")
+
+    proc = subprocess.run(cmd, capture_output=True, text=True, cwd=_repo_root)
+    if proc.returncode != 0:
+        print(proc.stdout)
+        print(proc.stderr, file=sys.stderr)
+        raise RuntimeError(f"subprocess failed for config={config}")
+
+    # The JSON result is the last line of stdout (tqdm/warning noise, if
+    # any, precedes it).
+    line = proc.stdout.strip().splitlines()[-1]
+    return json.loads(line)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", default="cpu", choices=["cpu", "gpu"])
+    parser.add_argument("--gpts", type=int, default=192)
+    parser.add_argument("--scan", type=int, default=16, help="scan_gpts per side")
+    parser.add_argument("--slices", type=int, default=8)
+    parser.add_argument("--repeats", type=int, default=3)
+
+    # Internal flags used to re-invoke this script as a measurement worker.
+    parser.add_argument("--subprocess-worker", action="store_true")
+    parser.add_argument("--config", default=None)
+    parser.add_argument("--no-cache", action="store_true")
+
+    args = parser.parse_args()
+
+    if args.subprocess_worker:
+        config = args.config
+        if config not in ("mixed",):
+            config = int(config)
+        _run_subprocess_worker(
+            args.device, config, args.gpts, args.scan, args.slices, args.no_cache
+        )
+        return
+
+    if args.device == "gpu":
+        try:
+            import cupy  # noqa: F401
+        except ImportError:
+            print("cupy not available, skipping GPU benchmark")
+            return
+
+    print(
+        f"device={args.device} gpts={args.gpts}x{args.gpts} "
+        f"scan={args.scan}x{args.scan} slices={args.slices}\n"
+    )
+
+    def _measure(no_cache):
+        rows = {}
+        for label, config in CONFIGS.items():
+            timings, rss_growths, peak_rsses = [], [], []
+            for _ in range(args.repeats):
+                r = _run_one_config(
+                    args.device, config, args.gpts, args.scan, args.slices,
+                    no_cache=no_cache,
+                )
+                timings.append(r["elapsed_s"])
+                rss_growths.append(r["rss_growth_mb"])
+                peak_rsses.append(r["peak_rss_mb"])
+            rows[label] = (min(timings), min(rss_growths), max(peak_rsses), timings)
+        return rows
+
+    print("-- pre-cache baseline (each detector recomputes its own FFT) --")
+    baseline = _measure(no_cache=True)
+    for label, (best_t, best_rss, peak_rss, timings) in baseline.items():
+        print(
+            f"  {label:20s} time best={best_t:.4f}s "
+            f"(all={['%.4f' % t for t in timings]})  "
+            f"rss_growth best={best_rss:.1f} MB  peak_rss={peak_rss:.1f} MB"
+        )
+
+    print("\n-- with shared-FFT cache (current behavior) --")
+    cached = _measure(no_cache=False)
+    for label, (best_t, best_rss, peak_rss, timings) in cached.items():
+        print(
+            f"  {label:20s} time best={best_t:.4f}s "
+            f"(all={['%.4f' % t for t in timings]})  "
+            f"rss_growth best={best_rss:.1f} MB  peak_rss={peak_rss:.1f} MB"
+        )
+
+    labels = list(CONFIGS)
+    print()
+    print(f"  {'':20s} {'baseline':>10s} {'cached':>10s} {'speedup':>9s}  "
+          f"{'rss (baseline->cached)':>26s}")
+    for label in labels:
+        bt, brss, _, _ = baseline[label]
+        ct, crss, _, _ = cached[label]
+        print(
+            f"  {label:20s} {bt:9.4f}s {ct:9.4f}s {bt / ct:8.2f}x  "
+            f"{brss:8.1f} -> {crss:6.1f} MB ({crss - brss:+.1f})"
+        )
+
+    print()
+    bt1, _, _, _ = baseline["one_annular"]
+    bt2, _, _, _ = baseline["two_annular"]
+    bt3, _, _, _ = baseline["three_annular"]
+    ct1, _, _, _ = cached["one_annular"]
+    ct2, _, _, _ = cached["two_annular"]
+    ct3, _, _, _ = cached["three_annular"]
+
+    print("  marginal TIME cost of an extra detector, relative to 1 detector's own time:")
+    print(
+        f"    baseline : 2nd detector {(bt2 - bt1) / bt1 * 100:+.1f}%   "
+        f"3rd detector {(bt3 - bt2) / bt1 * 100:+.1f}%"
+    )
+    print(
+        f"    cached   : 2nd detector {(ct2 - ct1) / ct1 * 100:+.1f}%   "
+        f"3rd detector {(ct3 - ct2) / ct1 * 100:+.1f}%"
+    )
+
+    bt_mix, brss_mix, _, _ = baseline["bf_adf_segmented"]
+    ct_mix, crss_mix, _, _ = cached["bf_adf_segmented"]
+    print()
+    print(
+        f"  realistic BF+ADF+segmented pass: "
+        f"{bt_mix:.4f}s -> {ct_mix:.4f}s ({bt_mix / ct_mix:.2f}x), "
+        f"RSS growth {brss_mix:.1f} -> {crss_mix:.1f} MB"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_diffraction_pattern_cache.py
+++ b/test/test_diffraction_pattern_cache.py
@@ -1,0 +1,482 @@
+"""Tests for the shared diffraction-pattern FFT (abtem.core.fft:
+``share_diffraction_pattern_fft`` / ``get_shared_diffraction_pattern_fft``,
+and ``Waves._share_diffraction_pattern_fft``).
+
+Motivation: every radial detector (AnnularDetector, FlexibleAnnularDetector,
+SegmentedDetector, PixelatedDetector) recomputed its own 2D FFT of the wave
+function array via ``Waves.diffraction_patterns``, even when several such
+detectors are evaluated against the exact same array in one detection pass
+(as happens once per detector, per site batch, per slice, in e.g.
+``transition_potential_multislice_and_detect``). These tests check that:
+
+1. The FFT is actually shared/computed only once per detection pass when the
+   optimization applies (the performance goal).
+2. Detector results are unaffected -- bit-identical (to within tiny floating-
+   point accumulation-order noise) to the pre-sharing behaviour -- for
+   AnnularDetector, FlexibleAnnularDetector, SegmentedDetector and
+   PixelatedDetector.
+3. Sharing cannot leak between different Waves objects (there is no global
+   state to leak through -- the precomputed value is a plain attribute on
+   one specific Waves instance), is a no-op outside an explicit
+   ``share_diffraction_pattern_fft``/``_share_diffraction_pattern_fft``
+   block, and -- the subtle case this module exists to guard against --
+   cannot return a stale result when an in-place multislice step reuses the
+   very same array object across depths while overwriting its contents.
+
+All device-parametrised tests use ``["cpu", gpu]`` via ``test/utils.py:gpu``.
+"""
+import ase
+import numpy as np
+import pytest
+
+import abtem
+from abtem import (
+    AnnularDetector,
+    FlexibleAnnularDetector,
+    PixelatedDetector,
+    Potential,
+    Probe,
+    SegmentedDetector,
+)
+from abtem.antialias import AntialiasAperture
+from abtem.core.axes import OrdinalAxis
+from abtem.core.fft import (
+    get_shared_diffraction_pattern_fft,
+    share_diffraction_pattern_fft,
+)
+from abtem.inelastic.core_loss import TransitionPotentialArray
+from abtem.multislice import (
+    FresnelPropagator,
+    conventional_multislice_step,
+    transition_potential_multislice_and_detect,
+)
+
+try:
+    import cupy as cp
+except ImportError:
+    cp = None
+
+from utils import gpu  # noqa: E402  -- pytest.param('gpu', skipif no cupy)
+
+
+class _FakeWaves:
+    """Minimal stand-in for a Waves object in the low-level primitive tests
+    below -- just something ``share_diffraction_pattern_fft`` can attach a
+    plain attribute to (a raw numpy array can't: it has no ``__dict__``)."""
+
+
+# ---------------------------------------------------------------------------
+# Low-level primitive tests (no real Waves objects involved).
+# ---------------------------------------------------------------------------
+
+
+def test_shared_fft_is_a_noop_by_default():
+    """Outside any ``share_diffraction_pattern_fft`` block,
+    ``get_shared_diffraction_pattern_fft`` must call ``compute`` every time
+    -- sharing must never happen implicitly."""
+    waves = _FakeWaves()
+    calls = []
+
+    def compute():
+        calls.append(1)
+        return object()
+
+    get_shared_diffraction_pattern_fft(waves, False, compute)
+    get_shared_diffraction_pattern_fft(waves, False, compute)
+    get_shared_diffraction_pattern_fft(waves, False, compute)
+
+    assert len(calls) == 3
+
+
+def test_share_block_computes_once_and_is_reused():
+    """Inside a ``share_diffraction_pattern_fft`` block, repeated
+    ``get_shared_diffraction_pattern_fft`` calls with the same ``normalize``
+    must reuse the precomputed value (compute called once, for the
+    ``share_diffraction_pattern_fft`` call itself)."""
+    waves = _FakeWaves()
+    calls = []
+
+    def compute():
+        calls.append(1)
+        return "the-fft"
+
+    with share_diffraction_pattern_fft(waves, False, compute):
+        r1 = get_shared_diffraction_pattern_fft(waves, False, lambda: calls.append(1))
+        r2 = get_shared_diffraction_pattern_fft(waves, False, lambda: calls.append(1))
+
+    assert len(calls) == 1
+    assert r1 == "the-fft" and r2 == "the-fft"
+
+
+def test_share_block_does_not_leak_to_a_different_object():
+    """Sharing is attached to one specific object -- a *different* object
+    (even created inside the same block) must never see it."""
+    waves_a = _FakeWaves()
+    waves_b = _FakeWaves()
+    calls = []
+
+    with share_diffraction_pattern_fft(waves_a, False, lambda: "a-value"):
+        result_a = get_shared_diffraction_pattern_fft(
+            waves_a, False, lambda: calls.append("a") or "a-value"
+        )
+        result_b = get_shared_diffraction_pattern_fft(
+            waves_b, False, lambda: calls.append("b") or "b-value"
+        )
+
+    assert result_a == "a-value"
+    assert result_b == "b-value"
+    assert calls == ["b"]  # waves_b always recomputes; waves_a never does
+
+
+def test_share_block_does_not_share_across_different_normalize():
+    """The same object with a different ``normalize`` flag must miss the
+    shared value and recompute."""
+    waves = _FakeWaves()
+    calls = []
+
+    with share_diffraction_pattern_fft(waves, False, lambda: "normalize=False"):
+        get_shared_diffraction_pattern_fft(
+            waves, False, lambda: calls.append(1) or "x"
+        )
+        get_shared_diffraction_pattern_fft(
+            waves, True, lambda: calls.append(1) or "x"
+        )
+
+    assert len(calls) == 1  # only the normalize=True lookup recomputed
+
+
+def test_share_block_clears_on_exit():
+    """The precomputed value must not survive past the block: a lookup after
+    the block closes must always recompute, never returning a value shared
+    by an earlier, now-closed block."""
+    waves = _FakeWaves()
+    calls = []
+
+    def compute():
+        calls.append(1)
+        return "value"
+
+    with share_diffraction_pattern_fft(waves, False, compute):
+        get_shared_diffraction_pattern_fft(waves, False, compute)
+
+    # Outside the block: must recompute.
+    get_shared_diffraction_pattern_fft(waves, False, compute)
+
+    assert len(calls) == 2
+
+
+def test_share_block_reflects_the_object_it_was_set_on_not_a_stale_copy():
+    """The critical safety property: two *separate* blocks on the same
+    object (with a real mutation of the underlying data source in between)
+    must each produce their own value -- there is no shared/global slot for
+    a later block to accidentally see an earlier block's stale entry."""
+    waves = _FakeWaves()
+    source = {"value": 1.0}
+
+    with share_diffraction_pattern_fft(waves, False, lambda: source["value"]):
+        first = get_shared_diffraction_pattern_fft(waves, False, lambda: None)
+
+    # "Mutate" between blocks.
+    source["value"] = 2.0
+
+    with share_diffraction_pattern_fft(waves, False, lambda: source["value"]):
+        second = get_shared_diffraction_pattern_fft(waves, False, lambda: None)
+
+    assert first == 1.0
+    assert second == 2.0
+
+
+def test_nested_share_blocks_restore_outer_value():
+    waves = _FakeWaves()
+
+    with share_diffraction_pattern_fft(waves, False, lambda: "outer"):
+        assert get_shared_diffraction_pattern_fft(waves, False, lambda: None) == "outer"
+        with share_diffraction_pattern_fft(waves, False, lambda: "inner"):
+            assert (
+                get_shared_diffraction_pattern_fft(waves, False, lambda: None)
+                == "inner"
+            )
+        # Back in the outer block: must see the outer value again, not
+        # leftover state from the (now-exited) inner block.
+        assert get_shared_diffraction_pattern_fft(waves, False, lambda: None) == "outer"
+
+    # And after both blocks: back to always recomputing.
+    assert get_shared_diffraction_pattern_fft(waves, False, lambda: "fresh") == "fresh"
+
+
+# ---------------------------------------------------------------------------
+# Detector-level correctness: sharing must not change results.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def si_atoms():
+    return ase.build.bulk("Si", cubic=True)
+
+
+def _make_potential(atoms, device, gpts=48, num_slices=3):
+    slice_thickness = atoms.cell[2, 2] / num_slices
+    return Potential(atoms, gpts=gpts, slice_thickness=slice_thickness, device=device)
+
+
+def _make_transition_potential(potential, device, n_transitions=4, seed=0):
+    rng = np.random.default_rng(seed)
+    array = (
+        rng.standard_normal((n_transitions, *potential.gpts))
+        + 1j * rng.standard_normal((n_transitions, *potential.gpts))
+    ).astype(np.complex64)
+    if device == "gpu":
+        array = cp.asarray(array)
+    return TransitionPotentialArray(
+        Z=14,
+        array=array,
+        energy=100e3,
+        extent=potential.extent,
+        ensemble_axes_metadata=[OrdinalAxis(values=tuple(range(n_transitions)))],
+        metadata={"Z": 14, "n": 1, "l": 0},
+    )
+
+
+def _make_probe_waves(potential, device, scan_gpts=(2, 2)):
+    probe = Probe(energy=100e3, semiangle_cutoff=20, device=device)
+    probe.grid.match(potential)
+    scan = abtem.GridScan(
+        start=(0, 0), end=(1, 1), fractional=True, potential=potential,
+        endpoint=False, gpts=scan_gpts,
+    )
+    return probe.build(scan=scan, lazy=False)
+
+
+ALL_RADIAL_DETECTORS = [
+    lambda: AnnularDetector(inner=0, outer=15),
+    lambda: FlexibleAnnularDetector(step_size=10),
+    lambda: SegmentedDetector(inner=0, outer=30, nbins_radial=3, nbins_azimuthal=4),
+    lambda: PixelatedDetector(),
+]
+DETECTOR_IDS = ["annular", "flexible_annular", "segmented", "pixelated"]
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+@pytest.mark.parametrize("double_channel", [True, False])
+def test_transition_potential_multiple_radial_detectors_match_uncached(
+    si_atoms, device, double_channel
+):
+    """Running all four radial detector types together in one
+    ``transition_potential_multislice_and_detect`` pass (which shares the FFT
+    across them) must give the same result as running each detector alone
+    (which never shares anything), to within tiny floating-point
+    accumulation-order noise.
+    """
+    potential = _make_potential(si_atoms, device)
+    tp = _make_transition_potential(potential, device)
+    waves = _make_probe_waves(potential, device)
+
+    detectors = [factory() for factory in ALL_RADIAL_DETECTORS]
+
+    combined = transition_potential_multislice_and_detect(
+        waves=waves.copy(),
+        potential=potential,
+        transition_potential=tp,
+        detectors=detectors,
+        sites=None,
+        double_channel=double_channel,
+    )
+
+    for name, factory, combined_result in zip(DETECTOR_IDS, ALL_RADIAL_DETECTORS, combined):
+        solo = transition_potential_multislice_and_detect(
+            waves=waves.copy(),
+            potential=potential,
+            transition_potential=tp,
+            detectors=[factory()],
+            sites=None,
+            double_channel=double_channel,
+        )[0]
+
+        combined_array = np.asarray(combined_result.array)
+        solo_array = np.asarray(solo.array)
+        if device == "gpu":
+            combined_array = cp.asnumpy(combined_array)
+            solo_array = cp.asnumpy(solo_array)
+
+        np.testing.assert_allclose(
+            combined_array,
+            solo_array,
+            rtol=1e-4,
+            atol=1e-6,
+            err_msg=f"{name} detector result changed when sharing the FFT",
+        )
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_standalone_detect_calls_never_share(si_atoms, device):
+    """A plain, standalone ``detector.detect(waves)`` (not wrapped in
+    ``waves._share_diffraction_pattern_fft()``) must never see sharing --
+    this is the default, always-safe path used throughout the rest of the
+    codebase and by any user calling ``detect`` directly."""
+    potential = _make_potential(si_atoms, device)
+    probe = Probe(energy=100e3, semiangle_cutoff=20, device=device)
+    probe.grid.match(potential)
+    waves = probe.build(lazy=False)
+
+    calls = []
+    from abtem.waves import Waves
+
+    original = Waves._diffraction_pattern_fft
+
+    def counting(array, normalize):
+        calls.append(1)
+        return original(array, normalize)
+
+    Waves._diffraction_pattern_fft = staticmethod(counting)
+    try:
+        detector = AnnularDetector(inner=0, outer=20)
+        detector.detect(waves)
+        detector.detect(waves)
+        detector.detect(waves)
+    finally:
+        Waves._diffraction_pattern_fft = staticmethod(original)
+
+    assert len(calls) == 3, (
+        "standalone detect() calls on the same waves object must each "
+        "recompute the FFT -- sharing must require an explicit block"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The regression this module exists to prevent: in-place mutation across
+# multislice depths must never be masked by a stale shared value.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_in_place_multislice_reuses_array_identity(si_atoms, device):
+    """Sanity check for the hazard this design guards against:
+    ``FresnelPropagator.propagate(..., in_place=True)`` (used by
+    ``conventional_multislice_step``) legitimately reuses the very same
+    ``waves.array`` Python object across multislice depths while
+    overwriting its contents. If this ever stops being true, the other
+    tests in this module would no longer be exercising the hazard they
+    claim to."""
+    potential = _make_potential(si_atoms, device)
+    probe = Probe(energy=100e3, semiangle_cutoff=20, device=device)
+    probe.grid.match(potential)
+    waves = probe.build(lazy=False)
+
+    propagator = FresnelPropagator()
+    aperture = AntialiasAperture()
+
+    w = waves.copy()
+    array_ids = set()
+    for potential_slice in potential.generate_slices():
+        w = conventional_multislice_step(w, potential_slice, propagator, aperture)
+        array_ids.add(id(w.array))
+
+    assert len(array_ids) == 1
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_unshared_loop_survives_in_place_mutation_across_depths(si_atoms, device):
+    """A bare loop calling ``detector.detect(w)`` once per multislice depth,
+    with no ``_share_diffraction_pattern_fft`` block, must give the same
+    per-depth results as an uncached reference -- even though ``w.array``
+    keeps the same identity across depths (see
+    ``test_in_place_multislice_reuses_array_identity``). This is the
+    scenario that would silently break with a cache keyed on array identity
+    alone.
+    """
+    potential = _make_potential(si_atoms, device, gpts=48, num_slices=3)
+    probe = Probe(energy=100e3, semiangle_cutoff=20, device=device)
+    probe.grid.match(potential)
+    waves = probe.build(lazy=False)
+
+    propagator = FresnelPropagator()
+    aperture = AntialiasAperture()
+    detector = AnnularDetector(inner=0, outer=20)
+
+    def run_pass():
+        w = waves.copy()
+        results = []
+        for potential_slice in potential.generate_slices():
+            w = conventional_multislice_step(w, potential_slice, propagator, aperture)
+            result = detector.detect(w).array
+            if device == "gpu":
+                result = cp.asnumpy(result)
+            results.append(np.array(result, copy=True))
+        return results
+
+    reference = run_pass()
+    repeated = run_pass()
+
+    for depth, (ref, rep) in enumerate(zip(reference, repeated)):
+        np.testing.assert_allclose(
+            ref, rep, rtol=1e-4, atol=1e-6,
+            err_msg=f"depth {depth} result changed between repeated passes",
+        )
+
+    # And the per-depth values must actually differ from each other (the
+    # potential does scatter a little at each slice) -- a stale value from
+    # an earlier depth would collapse these to be identical.
+    assert len(set(round(float(v), 5) for v in reference)) > 1
+
+
+@pytest.mark.parametrize("device", ["cpu", gpu])
+def test_share_per_depth_shares_within_but_not_across_depths(si_atoms, device):
+    """Using ``waves._share_diffraction_pattern_fft()`` per depth (the
+    pattern used by the real multislice call sites) must (a) give the same
+    per-depth, per-detector results as no sharing at all, and (b) actually
+    compute the FFT only once per depth even though two detectors are
+    evaluated there.
+    """
+    potential = _make_potential(si_atoms, device, gpts=48, num_slices=3)
+    probe = Probe(energy=100e3, semiangle_cutoff=20, device=device)
+    probe.grid.match(potential)
+    waves = probe.build(lazy=False)
+
+    propagator = FresnelPropagator()
+    aperture = AntialiasAperture()
+    d1 = AnnularDetector(inner=0, outer=20)
+    d2 = AnnularDetector(inner=20, outer=40)
+
+    from abtem.waves import Waves
+
+    def run_pass(share):
+        original = Waves._diffraction_pattern_fft
+        calls = []
+
+        def counting(array, normalize):
+            calls.append(1)
+            return original(array, normalize)
+
+        Waves._diffraction_pattern_fft = staticmethod(counting)
+        try:
+            w = waves.copy()
+            results = []
+            for potential_slice in potential.generate_slices():
+                w = conventional_multislice_step(w, potential_slice, propagator, aperture)
+                if share:
+                    with w._share_diffraction_pattern_fft():
+                        r1 = d1.detect(w).array
+                        r2 = d2.detect(w).array
+                else:
+                    r1 = d1.detect(w).array
+                    r2 = d2.detect(w).array
+                if device == "gpu":
+                    r1 = cp.asnumpy(r1)
+                    r2 = cp.asnumpy(r2)
+                results.append((np.array(r1, copy=True), np.array(r2, copy=True)))
+        finally:
+            Waves._diffraction_pattern_fft = staticmethod(original)
+        return results, len(calls)
+
+    unshared_results, unshared_calls = run_pass(share=False)
+    shared_results, shared_calls = run_pass(share=True)
+
+    n_slices = potential.num_slices
+    assert unshared_calls == 2 * n_slices  # one FFT per detector per depth
+    assert shared_calls == n_slices  # shared: one FFT per depth
+
+    for depth, ((u1, u2), (s1, s2)) in enumerate(
+        zip(unshared_results, shared_results)
+    ):
+        np.testing.assert_allclose(u1, s1, rtol=1e-4, atol=1e-6)
+        np.testing.assert_allclose(u2, s2, rtol=1e-4, atol=1e-6)


### PR DESCRIPTION
## Problem

Every radial detector (`AnnularDetector`, `FlexibleAnnularDetector`, `SegmentedDetector`, `PixelatedDetector`) recomputes its own diffraction pattern from the same wave functions via `Waves.diffraction_patterns`, so running several angular detectors in one detection pass pays the (relatively expensive) 2D FFT once per detector — multiplied by sites and slices in `transition_potential_multislice_and_detect`, and present in the same shape in `multislice_and_detect` and the PRISM drivers.

## Fix

`Waves._diffraction_pattern` is split into `_diffraction_pattern_fft` (the FFT) and `_diffraction_pattern_from_fft` (the cheap crop/intensity/fftshift). A new `abtem.core.fft.share_diffraction_pattern_fft` / `get_shared_diffraction_pattern_fft` pair lets a caller precompute the FFT once and attach it **directly to the specific `Waves` object** it was computed from, for the duration of a `with` block:

```python
with waves._share_diffraction_pattern_fft():
    for detector in detectors:
        detector.detect(waves)
```

**Design note — why not a cache keyed by array identity:** several in-place multislice steps (`FresnelPropagator.propagate(..., in_place=True)`, used by every `FourierMultislice` step) legitimately reuse the exact same array object across multislice depths while overwriting its contents — confirmed directly (`id(waves.array)` is identical across every slice of a real multislice run). A cache keyed on identity alone would hand back a stale FFT from an earlier depth. Attaching the precomputed value as a plain attribute on one specific `Waves` instance avoids this: a read only ever consults that object's own attribute, which exists only for the lifetime of the `with` block that set it, so a mistake can only affect reads of *that* object within *that* block — there's no shared/global slot for it to leak into. A standalone `detector.detect(waves)` call never sees the attribute, so it's unconditionally identical to the pre-sharing behavior.

Wrapped the multi-detector loops that share one, not-yet-mutated array:
- `multislice.py`: `_update_measurements`, `_update_loss_measurements`, the double-channel detection loop, the final fallback list
- `prism/s_matrix.py`: three detect-into-measurement loops
- `inelastic/core_loss.py`: the two PRISM-EELS beam-basis detection loops

## Correctness

- Bit-equivalence verified (float32/FFTW-plan noise floor only — the same magnitude of noise present between two baseline reruns with sharing disabled) for all four radial detector types, standalone and inside `transition_potential_multislice_and_detect` with `double_channel` True/False.
- `test/test_diffraction_pattern_cache.py` (new, parametrised over `["cpu", gpu]`) covers the sharing primitives, detector-result equivalence, and specifically reproduces the in-place-mutation hazard described above to confirm it's handled correctly with vs. without the shared block. Also covers nesting on the same object, which an earlier iteration of this got wrong (fixed: `share_diffraction_pattern_fft` now saves/restores rather than deletes on exit).
- Full test suite: 1333 passed, 7 pre-existing failures in `test/test_gpaw.py` (unrelated GPAW-version incompatibility on this environment, being tracked separately) — matches unmodified `dev` exactly, zero new failures.

## Benchmarks

Both scripts compute a true pre-sharing baseline **in-process via monkeypatch**, so the same installed abtem reproduces both numbers without a separate checkout:

- `benchmarks/benchmark_shared_diffraction_pattern.py` — transition-potential/core-loss scan (96×96, 3 slices, 4×4 scan, 16 transitions): marginal cost of a 3rd `AnnularDetector` drops substantially (roughly halved to a third, run-to-run) relative to a baseline with sharing disabled.
- `benchmarks/benchmark_stem_multi_detector.py` — regular STEM (192×192, 8 slices, 16×16 scan): a more modest few-percent time improvement; no reliably measurable memory difference at this scale, since the shared diffraction-pattern buffer is tiny relative to total process memory and per-position cost there is dominated by potential/transmission-function work rather than detection.

## Out of scope

`test/test_gpaw.py`'s 7 pre-existing failures (a GPAW-version grid-size incompatibility, unrelated to this change) are being tracked and fixed in a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
