### PR TITLE
Fix 7 pre-existing test_gpaw.py failures against GPAW 26.7.0

### DIFF
--- a/test/test_gpaw.py
+++ b/test/test_gpaw.py
@@ -13,6 +13,76 @@ try:
     from gpaw.utilities.ps2ae import PS2AE
 
     from abtem.potentials.gpaw import GPAWPotential
+
+    # GPAW's own gpaw/utilities/ps2ae.py (add_potential_correction) is
+    # written against the old-style Density API and unconditionally does:
+    #
+    #     dens.Q_aL.redistribute(dens.atom_partition.as_serial())
+    #     ...
+    #     dens.Q_aL.redistribute(dens.atom_partition)
+    #
+    # `calc.density` (a @property) builds a fresh `FakeDensity` compat shim
+    # (gpaw.new.backwards_compatibility.FakeDensity) for GPAW's new PW
+    # backend, and that shim never defines `Q_aL` at all -- only its
+    # renamed replacement `ccc_aL` (see FakeDensity.__init__: `self.ccc_aL =
+    # density.calculate_compensation_charge_coefficients()`). This is a gap
+    # in GPAW's own ps2ae.py/FakeDensity compatibility layer, not an abTEM
+    # bug (abtem/potentials/gpaw.py already has its own Q_aL/ccc_aL
+    # fallback for its own code paths; this shim is only needed because the
+    # tests call GPAW's PS2AE utility directly).
+    #
+    # `.redistribute()` exists to gather each atom's data onto rank 0
+    # before a local calculation and scatter it back afterwards, for MPI
+    # runs where atoms are split across domains/ranks. In a genuinely
+    # serial (single-process) run -- as in these tests -- every atom is
+    # already local to the one and only rank (atom_partition.rank_a is all
+    # zeros, comm.size == 1), so redistributing is provably a no-op: there
+    # is nothing to gather or scatter. The shim below asserts that
+    # invariant explicitly and refuses to silently no-op (raising instead)
+    # if it is ever exercised under real multi-rank parallelism, where
+    # skipping the actual gather would silently corrupt the result.
+    from gpaw.new.backwards_compatibility import FakeDensity
+
+    class _SerialCompensationChargeCoefficientsAsQaL:
+        """Adapts a new-backend `ccc_aL` (AtomArrays) to look like the
+        old-style `Q_aL` (dict-like ArrayDict) that both ps2ae.py and
+        abtem/potentials/gpaw.py (`dict(Q_aL)`) expect, valid only for
+        single-process (serial) GPAW calculations."""
+
+        def __init__(self, ccc_aL):
+            self._ccc_aL = ccc_aL
+
+        def __getitem__(self, a):
+            return self._ccc_aL[a]
+
+        def __getattr__(self, name):
+            # Delegate dict-like access (keys/items/get/values/...) to the
+            # underlying AtomArrays so e.g. `dict(Q_aL)` (used in
+            # abtem/potentials/gpaw.py) keeps working. `redistribute`
+            # below is defined on the class, so it takes precedence over
+            # this fallback rather than being delegated.
+            return getattr(self._ccc_aL, name)
+
+        def redistribute(self, partition):
+            if partition.comm.size != 1:
+                raise NotImplementedError(
+                    "Q_aL/ccc_aL compatibility shim (see test_gpaw.py) only "
+                    "supports serial (single-process) GPAW calculations; "
+                    f"got comm.size={partition.comm.size}. Redistributing "
+                    "compensation charge coefficients across real MPI "
+                    "ranks is not implemented here."
+                )
+            # comm.size == 1 => every atom is already local to the only
+            # rank, so redistributing to any partition on this comm is a
+            # genuine no-op.
+            return self
+
+    if not hasattr(FakeDensity, "Q_aL"):
+        FakeDensity.Q_aL = property(
+            lambda self: _SerialCompensationChargeCoefficientsAsQaL(
+                self.ccc_aL
+            )
+        )
 except ImportError:
     pass
 
@@ -20,7 +90,14 @@ except ImportError:
 @pytest.fixture
 def gpaw_calculator_no_bonding():
     atoms = Atoms("C", positions=[(0, 0, 0)], cell=(5.0,) * 3, pbc=True)
-    atoms.calc = GPAW(mode=PW(500), h=0.2, txt=None, kpts=(3, 3, 3))
+    # h=0.2 makes GPAW's "new" PW-mode backend pick a real-space FFT grid
+    # (50x50x26 for this cell) that its own PWDesc.indices() rejects as
+    # "too small" as soon as get_electrostatic_potential() is called
+    # (gpaw/core/plane_waves.py). This is a GPAW grid-size quirk in the new
+    # backend, not an abTEM bug; a slightly finer h picks a larger, clean
+    # cubic grid (28^3 density / 56^3 fine grid) that avoids it with margin
+    # (confirmed stable for h in [0.15, 0.19], not just barely under 0.2).
+    atoms.calc = GPAW(mode=PW(500), h=0.18, txt=None, kpts=(3, 3, 3))
     atoms.get_potential_energy()
     return atoms.calc
 
@@ -28,7 +105,10 @@ def gpaw_calculator_no_bonding():
 @pytest.fixture
 def gpaw_calculator_bonding():
     atoms = Atoms("C", positions=[(0, 0, 0)], cell=(2.0,) * 3, pbc=True)
-    atoms.calc = GPAW(mode=PW(500), h=0.2, txt=None, kpts=(3, 3, 3))
+    # See gpaw_calculator_no_bonding above: h=0.2 triggers GPAW's new PW
+    # backend "20x20x11 grid too small!" error from get_electrostatic_
+    # potential(); h=0.18 gives a clean 12^3 density / 24^3 fine grid instead.
+    atoms.calc = GPAW(mode=PW(500), h=0.18, txt=None, kpts=(3, 3, 3))
     atoms.get_potential_energy()
     return atoms.calc
 


### PR DESCRIPTION
## Summary

Fixes all 7 pre-existing failures in `test/test_gpaw.py` when run against GPAW 26.7.0, caused by two compatibility gaps between GPAW's new PW-mode backend and its own utilities (not abTEM bugs):

1. **Grid-size bug (5 tests)**: `h=0.2` in the `gpaw_calculator_no_bonding`/`gpaw_calculator_bonding` fixtures made GPAW's new PW backend pick an FFT grid (e.g. `50x50x26`) that its own `PWDesc.indices()` (`gpaw/core/plane_waves.py`) rejects as "too small" as soon as `get_electrostatic_potential()` is called -- either directly (via `PS2AE`) or internally through `abtem.potentials.gpaw.GPAWPotential`. Bumping `h` to `0.18` picks a clean cubic grid instead (28^3/56^3 and 12^3/24^3), confirmed robust across `h in [0.15, 0.19]`, not just barely under the failing threshold.

2. **`ps2ae.py` / `FakeDensity` gap (2 tests)**: GPAW's own `gpaw/utilities/ps2ae.py` (`add_potential_correction`) calls `dens.Q_aL.redistribute(...)`, but the new backend's `FakeDensity` compat shim only exposes the renamed `ccc_aL`, never `Q_aL`, raising `AttributeError`. Added a small, guarded (`hasattr`-checked, so it's inert if GPAW fixes this upstream) compatibility shim in the test module that adapts `ccc_aL` to look like `Q_aL`. Its `.redistribute()` explicitly asserts `comm.size == 1` (verified this holds for these serial single-process fixtures -- `atom_partition.rank_a` is already all-zeros, so redistributing is a genuine no-op) and raises rather than silently mis-behaving if ever hit under real MPI parallelism.

Physics was sanity-checked, not just made to pass: the resulting all-electron potential correction is large and in the physically correct direction (deepens from -239 eV to -17970 eV near the nucleus, recovering the Coulomb singularity the pseudopotential smooths out), and independently agrees with abTEM's IAM potential comparison (594 eV vs 592 eV peak, matching `test_gpaw_vs_iam`'s own tolerance).

## Test plan
- [x] `pytest -n auto test/test_gpaw.py -v` -- 7/7 passed
- [x] `pytest -n auto test/` -- 1327 passed, 0 failed, 821 skipped (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
