### PR TITLE
Fix (2l+1) orbital-degeneracy double-count in core-loss transition potentials

### DIFF
--- a/abtem/inelastic/core_loss.py
+++ b/abtem/inelastic/core_loss.py
@@ -662,7 +662,15 @@ class TransitionPotential(BaseTransitionPotential):
             array[i] = self._calculate_form_factor(bound, excited, k, phi, theta)
 
             if self._orbital_filling_factor:
-                array[i] *= np.sqrt(4 * bound.l + 2)
+                # 4*l+2 is the full subshell's electron count: spin (2) times
+                # orbital degeneracy (2*l+1). The orbital part is already
+                # realised explicitly -- SubshellTransitions.get_transitions
+                # builds one bound state per ml and this array is summed
+                # incoherently over all of them -- so only the spin factor
+                # belongs here. Applying 4*l+2 per ml double-counts the
+                # orbital degeneracy by (2*l+1); invisible for l=0, where
+                # 4*l+2 reduces to the spin-only factor of 2.
+                array[i] *= np.sqrt(2)
 
             array[i] *= relativistic_mass_correction(self.energy) / (
                 2 * np.pi**2 * kn * k**2 * energy2sigma(self.energy)

--- a/test/test_ionization.py
+++ b/test/test_ionization.py
@@ -1058,3 +1058,51 @@ def test_subshell_transitions_real_gpaw_pipeline():
     array = np.asarray(result.array)
     assert np.isfinite(array).all()
     assert np.any(array != 0)
+
+
+@pytest.mark.skipif("gpaw" not in sys.modules, reason="requires gpaw")
+def test_orbital_filling_factor_is_spin_only_not_full_shell_degeneracy():
+    """Regression test for a (2*l+1) orbital-degeneracy double-count.
+
+    ``SubshellTransitions.get_transitions()`` already realises a subshell's
+    orbital degeneracy explicitly: it builds one distinct bound state per
+    ``ml`` in ``range(-l, l+1)`` and ``TransitionPotential.build()`` sums
+    their contributions incoherently. ``orbital_filling_factor`` must
+    therefore contribute only the *remaining* spin degeneracy (2), not the
+    full subshell occupancy ``4*l+2 = spin(2) * orbital(2*l+1)`` -- applying
+    ``4*l+2`` per already-explicit ``ml`` inflates the total by exactly
+    ``(2*l+1)``. This was invisible for every K edge (l=0), where
+    ``4*l+2`` reduces to the spin-only factor of 2, which is exactly why it
+    went undetected: only checked directly against an independent
+    tabulation (Bote & Salvat) does a p- or d-subshell reveal it, at 3x and
+    5x respectively.
+
+    Checked here without any external data: for a single explicit bound
+    ``ml`` state, turning ``orbital_filling_factor`` on must scale the
+    intensity by exactly 2 (spin), regardless of ``l`` -- not by ``4*l+2``.
+    """
+    from abtem.inelastic.core_loss import SubshellTransitions, TransitionPotential
+
+    for Z, n, l in [(14, 1, 0), (14, 2, 1), (22, 3, 2)]:
+        transitions = SubshellTransitions(Z, n, l, epsilon=25.0)
+        one_ml_transitions = [
+            t for t in transitions.get_transitions() if t[0].ml == 0
+        ]
+        assert len(one_ml_transitions) > 0
+
+        kwargs = dict(extent=6.0, gpts=32, energy=100e3, double_channel=False)
+        with_factor = TransitionPotential(
+            Z, one_ml_transitions, orbital_filling_factor=True, **kwargs,
+        ).build()
+        without_factor = TransitionPotential(
+            Z, one_ml_transitions, orbital_filling_factor=False, **kwargs,
+        ).build()
+
+        intensity_with = float((np.abs(with_factor.array) ** 2).sum())
+        intensity_without = float((np.abs(without_factor.array) ** 2).sum())
+
+        assert intensity_with == pytest.approx(2.0 * intensity_without, rel=1e-6), (
+            f"l={l}: orbital_filling_factor should apply spin degeneracy (2x "
+            f"intensity), not the full shell occupancy "
+            f"({4 * l + 2}x intensity, from the old 4*l+2 formula)"
+        )

--- a/test/test_ionization.py
+++ b/test/test_ionization.py
@@ -1061,6 +1061,7 @@ def test_subshell_transitions_real_gpaw_pipeline():
 
 
 @pytest.mark.skipif("gpaw" not in sys.modules, reason="requires gpaw")
+@pytest.mark.filterwarnings("ignore:the cell:RuntimeWarning")
 def test_orbital_filling_factor_is_spin_only_not_full_shell_degeneracy():
     """Regression test for a (2*l+1) orbital-degeneracy double-count.
 


### PR DESCRIPTION
## Bug

`TransitionPotential.build()` multiplies every explicit bound `ml` state's amplitude by `sqrt(4*l+2)` — the full subshell electron count, spin (2) times orbital degeneracy `(2*l+1)`. But `SubshellTransitions.get_transitions()` already realises the orbital degeneracy explicitly: it builds one distinct bound state per `ml` in `range(-l, l+1)` and `TransitionPotential.build()` sums their contributions incoherently. Applying `4*l+2` per already-explicit `ml` therefore double-counts the orbital part by exactly `(2*l+1)`.

This is invisible for every K edge (l=0), where `4*l+2` reduces to the spin-only factor of 2 — exactly why it went undetected through this project's existing L-edge PRISM-EELS test coverage, which checks internal consistency (PRISM vs. multislice, lazy vs. eager) rather than absolute scale.

## How it was found

While independently validating an unrelated EDX reproduction against experiment, one L-edge (Sr L2,3) needed checking against an external absolute-scale tabulation (Bote & Salvat 2008) for the first time in this project's history. It came out 2.5–2.9x too high across `order=1,2,3`, while every K edge checked the same way (Si, C, Cu, Ti, O, Sr) landed in the ordinary 0.83–1.14 range expected from the known PWBA-vs-DWBA gap.

Confirmed the excess is exactly `(2l+1)` — not element- or order-specific — across two elements and three `l` values:

| edge | l | 2l+1 | abTEM/Bote-Salvat | ÷(2l+1) |
|---|---|---|---|---|
| Ti K | 0 | 1 | 0.833 | 0.833 |
| Au L2,3 | 1 | 3 | 2.683 | 0.894 |
| Au M4,5 | 2 | 5 | 4.247 | 0.849 |

After the fix, all three land in the same tight 0.833–0.894 band with no residual `l`-dependence.

## Fix

The filling factor should supply only the spin degeneracy (2) that remains after the outer `ml` loop already accounts for the orbital part. Identical result for `l=0` (`sqrt(4*0+2) == sqrt(2)`), so no K-edge result changes.

**Affects every L-edge or M-edge EELS or EDX simulation built via `SubshellTransitions`** — p-subshells were 3x too large, d-subshells 5x too large. K-edges are unaffected.

## Testing

Added `test_orbital_filling_factor_is_spin_only_not_full_shell_degeneracy`, which isolates a single explicit `ml` transition and checks that toggling `orbital_filling_factor` scales intensity by exactly 2 (not `4*l+2`) for `l=0, 1, 2`. Confirmed it fails against the pre-fix code with the expected `(4*l+2)/2` ratio (3x for l=1, 5x for l=2) before verifying it passes with the fix.

Full suite: 1321 passed, 0 new failures. The 7 failures in `test/test_gpaw.py` are pre-existing on `dev` (a GPAW-version grid-size incompatibility unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
