### PR TITLE
Fix interpolate_line and from_zarr(chunks=auto) corrupting arrays with chunked base axes (follow-up to #363)

### DIFF
--- a/abtem/array.py
+++ b/abtem/array.py
@@ -2308,7 +2308,16 @@ def _from_zarr_canonical(root, chunks, decode_types):
         zarr_array = root[f"array{i}"]
 
         if chunks == "auto":
-            array_chunks = "auto"
+            # Respect cls._base_dims the same way the legacy loader below
+            # already does: dask's own "auto" heuristic doesn't know which
+            # trailing axes are an ArrayObject's base (measurement) axes, and
+            # several of abTEM's own lazy operations (e.g. interpolate_line)
+            # assume those are never split across chunks. chunks=None (the
+            # default) already avoids this by mirroring whatever to_zarr
+            # actually wrote, which itself never splits base axes -- this
+            # branch only matters if a caller explicitly opts into "auto".
+            num_ensemble_axes = zarr_array.ndim - cls._base_dims
+            array_chunks = ("auto",) * num_ensemble_axes + (-1,) * cls._base_dims
         elif chunks is None:
             array_chunks = zarr_array.chunks
         else:

--- a/abtem/array.py
+++ b/abtem/array.py
@@ -231,8 +231,28 @@ _MAX_ZARR_CHUNK_BYTES = 512 * 1024**2
 
 
 def _safe_zarr_chunks(
-    shape: tuple[int, ...], itemsize: int, max_bytes: Optional[int] = None
+    shape: tuple[int, ...],
+    itemsize: int,
+    max_bytes: Optional[int] = None,
+    n_fixed_trailing_axes: int = 0,
 ) -> tuple[int, ...]:
+    """Pick a chunk shape that stays under ``max_bytes``, preferring to
+    shrink leading (ensemble) axes and never touching the trailing
+    ``n_fixed_trailing_axes`` (an ArrayObject's ``_base_dims``) unless there
+    is no other choice.
+
+    Several of abTEM's own lazy dask operations on measurements (e.g.
+    ``interpolate_line``'s ``da.map_blocks(..., drop_axis=...)``) require
+    their base/measurement axes to be a single dask chunk -- splitting them
+    doesn't raise, it silently produces wrong results (confirmed by direct
+    reproduction: a DiffractionPatterns array whose spatial axes were split
+    this way, then reloaded lazily, gave an all-zero momentum-resolved
+    spectrum while eagerly-computed data from the same file was correct).
+    Chunking only the ensemble axes keeps a round-tripped array safe for
+    every lazy operation that already assumes whole base-axis chunks,
+    matching e.g. ``PotentialArray``'s own ``("auto",) * n + (-1,) *
+    _base_dims`` convention elsewhere in this module.
+    """
     if max_bytes is None:
         # Read fresh rather than as a default-argument value, so overriding
         # the module-level budget (e.g. in tests) takes effect.
@@ -246,6 +266,18 @@ def _safe_zarr_chunks(
             n *= c
         return n
 
+    n_fixed = min(n_fixed_trailing_axes, len(chunks))
+    splittable = list(range(len(chunks) - n_fixed))
+
+    while nbytes() > max_bytes and any(chunks[i] > 1 for i in splittable):
+        i = max(splittable, key=lambda j: chunks[j])
+        chunks[i] = max(1, chunks[i] // 2)
+
+    # Only reached if the base axes are themselves so large that shrinking
+    # every ensemble axis to 1 still isn't enough (e.g. a single very large
+    # image with little to no ensemble axis to shrink) -- fall back to
+    # splitting them too rather than failing outright; this is the one case
+    # where the lazy-op hazard described above is genuinely unavoidable.
     while nbytes() > max_bytes and any(c > 1 for c in chunks):
         i = max(range(len(chunks)), key=lambda j: chunks[j])
         chunks[i] = max(1, chunks[i] // 2)
@@ -348,6 +380,7 @@ class ComputableList(list):
 
         arrays_to_write = []
         metadata_list = []
+        base_dims_by_index = {}
 
         for i, has_array in enumerate(self):
             has_array = has_array.ensure_lazy()
@@ -365,6 +398,7 @@ class ComputableList(list):
 
             arrays_to_write.append((i, array))
             metadata_list.append({f"metadata{i}": metadata_dict})
+            base_dims_by_index[i] = has_array._base_dims
 
         if is_zip:
             # Use ZipStore for .zip files
@@ -402,6 +436,7 @@ class ComputableList(list):
                                 chunks=_safe_zarr_chunks(
                                     computed_array.shape,
                                     computed_array.dtype.itemsize,
+                                    n_fixed_trailing_axes=base_dims_by_index[i],
                                 ),
                                 overwrite=True,
                                 compressors=compressors,
@@ -454,6 +489,7 @@ class ComputableList(list):
                             chunks=_safe_zarr_chunks(
                                 computed_array.shape,
                                 computed_array.dtype.itemsize,
+                                n_fixed_trailing_axes=base_dims_by_index[i],
                             ),
                             overwrite=True,
                         )

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -1075,8 +1075,21 @@ class _BaseMeasurement2D(BaseMeasurements):
             # raise NotImplementedError("Lazy interpolation not implemented.")
             # TDOO: Implement lazy interpolation
 
-            base_axes = tuple(range(len(self.base_shape)))
-            chunks = self.array.chunks[:-2] + (positions.shape[0],)
+            # The base (spatial) axes are the *last* len(self.base_shape) axes
+            # of self.array -- any ensemble axes come first. da.map_blocks's
+            # drop_axis must name their actual positions; previously this used
+            # range(len(self.base_shape)) == (0, 1), i.e. the *first* two axes,
+            # which is only correct for a bare 2D array with no ensemble axes.
+            # With any ensemble axis present this silently mismatches dask's
+            # block bookkeeping: it doesn't raise, but produces wrong output
+            # (extra, duplicated blocks) the moment an ensemble axis has more
+            # than one chunk, or wrong values once BOTH base axes have more
+            # than one chunk each (confirmed by direct reproduction -- e.g. a
+            # DiffractionPatterns array whose spatial axes were chunked by a
+            # sufficiently large zarr save/reload).
+            n_base = len(self.base_shape)
+            base_axes = tuple(range(self.array.ndim - n_base, self.array.ndim))
+            chunks = self.array.chunks[:-n_base] + (positions.shape[0],)
             new_axis = (base_axes[0],)
 
             if width:

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -354,6 +354,28 @@ def _make_dp(n_energy, gpts, seed=0):
     return dp, array
 
 
+def test_from_zarr_auto_chunks_never_splits_base_axes(tmp_path):
+    """from_zarr(url, chunks="auto") must not let dask's own auto-chunking
+    heuristic split an ArrayObject's base (measurement) axes -- several of
+    abTEM's own lazy operations (e.g. interpolate_line) assume those are
+    never chunked. chunks=None (the default) already avoids this by
+    mirroring whatever to_zarr actually wrote (which itself never splits
+    base axes); explicitly requesting "auto" used to bypass that protection
+    since dask's own heuristic doesn't know which axes are which."""
+    import dask
+
+    import abtem.array as abtem_array_module
+
+    dp, _ = _make_dp(n_energy=2, gpts=64)
+    url = str(tmp_path / "dp_auto.zarr")
+    dp.to_zarr(url)
+
+    with dask.config.set({"array.chunk-size": "1KiB"}):
+        loaded = abtem_array_module.from_zarr(url, chunks="auto")
+
+    assert loaded.array.chunks[-2:] == ((64,), (64,))
+
+
 @pytest.mark.parametrize("suffix", ["", ".zip"])
 def test_to_zarr_never_chunks_base_axes(tmp_path, monkeypatch, suffix):
     """Regression: the spatial (base) axes of a DiffractionPatterns are much

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -298,6 +298,41 @@ def test_safe_zarr_chunks_no_op_when_already_small():
     assert _safe_zarr_chunks(shape, itemsize=8) == shape
 
 
+def test_safe_zarr_chunks_never_splits_trailing_axes_when_avoidable():
+    """Splitting an ArrayObject's base (measurement) axes -- e.g. a
+    DiffractionPatterns' 2D image plane -- doesn't just change chunk
+    granularity: several of abTEM's own lazy dask operations assume those
+    axes are never chunked and silently compute wrong results if they are
+    (see test_measure.py's interpolate_line regression). n_fixed_trailing_axes
+    must be respected whenever shrinking the leading (ensemble) axis alone is
+    enough to fit the budget."""
+    from abtem.array import _safe_zarr_chunks
+
+    shape = (1024, 256, 256)
+    chunks = _safe_zarr_chunks(
+        shape, itemsize=8, max_bytes=1_000_000, n_fixed_trailing_axes=2
+    )
+    assert chunks[-2:] == shape[-2:]
+    assert chunks[0] < shape[0]
+
+
+def test_safe_zarr_chunks_falls_back_to_trailing_axes_if_unavoidable():
+    """If even a single element along every leading axis still exceeds the
+    budget, there is no choice but to also split the trailing axes -- this
+    must not raise or loop forever."""
+    from abtem.array import _safe_zarr_chunks
+
+    shape = (1, 2048, 2048)
+    chunks = _safe_zarr_chunks(
+        shape, itemsize=8, max_bytes=1_000_000, n_fixed_trailing_axes=2
+    )
+    nbytes = 8
+    for c in chunks:
+        nbytes *= c
+    assert nbytes <= 1_000_000
+    assert chunks[-2:] != shape[-2:]
+
+
 def _make_dp(n_energy, gpts, seed=0):
     import dask.array as da
     import numpy as np
@@ -317,6 +352,37 @@ def _make_dp(n_energy, gpts, seed=0):
         ],
     )
     return dp, array
+
+
+@pytest.mark.parametrize("suffix", ["", ".zip"])
+def test_to_zarr_never_chunks_base_axes(tmp_path, monkeypatch, suffix):
+    """Regression: the spatial (base) axes of a DiffractionPatterns are much
+    larger than its ensemble (energy) axis here, so a naive "always shrink
+    the largest axis" policy would chunk the spatial plane first -- which
+    several lazy dask operations (e.g. interpolate_line) silently compute
+    wrong results against. to_zarr must chunk only the ensemble axis."""
+    import zarr
+
+    import abtem.array as abtem_array_module
+
+    monkeypatch.setattr(abtem_array_module, "_MAX_ZARR_CHUNK_BYTES", 1_000_000)
+
+    dp, _ = _make_dp(n_energy=8, gpts=256)
+    url = str(tmp_path / f"dp_base{suffix}")
+    dp.to_zarr(url)
+
+    if suffix == ".zip":
+        store = zarr.storage.ZipStore(url, mode="r")
+        root = zarr.open(store=store, mode="r")
+    else:
+        root = zarr.open(url, mode="r")
+
+    zarr_array = root["array0"]
+    assert zarr_array.chunks[-2:] == zarr_array.shape[-2:]
+    assert zarr_array.chunks[0] < zarr_array.shape[0]
+
+    if suffix == ".zip":
+        store.close()
 
 
 @pytest.mark.parametrize("suffix", ["", ".zip"])

--- a/test/test_measure.py
+++ b/test/test_measure.py
@@ -438,11 +438,12 @@ def test_pseudo_voigtian_filter_lazy():
 @pytest.mark.parametrize("device", ["cpu", gpu])
 def test_images_interpolate_line(data, lazy, device):
     wave = Probe(energy=100e3, semiangle_cutoff=30, extent=20, gpts=256, device=device)
-    image = wave.build((0, 0), lazy=False).intensity()
+    image = wave.build((0, 0), lazy=lazy).intensity()
 
     line = image.interpolate_line(start=(0, 0), end=(0, wave.extent[1]), width=0.0)
     assert np.allclose(
-        image.to_cpu().array[0], line.to_cpu().array, rtol=1e-6, atol=1e-6
+        image.to_cpu().compute().array[0], line.to_cpu().compute().array,
+        rtol=1e-6, atol=1e-6,
     )
 
     coordinate = st.floats(min_value=0, max_value=wave.extent[0])
@@ -451,15 +452,66 @@ def test_images_interpolate_line(data, lazy, device):
     angle2 = data.draw(st.floats(min_value=0, max_value=360.0))
     width = data.draw(st.floats(min_value=0, max_value=2.0))
 
-    image = wave.build(center, lazy=False).intensity()
+    image = wave.build(center, lazy=lazy).intensity()
     line1 = image.interpolate_line_at_position(
         center=center, angle=angle1, extent=wave.extent[0] / 2, width=width, gpts=128
-    ).to_cpu()
+    ).to_cpu().compute()
     line2 = image.interpolate_line_at_position(
         center=center, angle=angle2, extent=wave.extent[0] / 2, width=width, gpts=128
-    ).to_cpu()
+    ).to_cpu().compute()
 
     assert np.allclose(line1.array, line2.array, rtol=1e-6, atol=10)
+
+
+def test_interpolate_line_lazy_matches_eager_with_ensemble_axis():
+    """Regression: interpolate_line's lazy path computed drop_axis/new_axis
+    as if the base (spatial) axes were the *first* axes of the array
+    (range(len(base_shape))), rather than the actual trailing axes after any
+    ensemble axis. This never raised -- it silently produced wrong output
+    (extra, duplicated blocks) once an ensemble axis had more than one dask
+    chunk, and silently wrong values once *both* base axes had more than one
+    chunk each (reproduced via a DiffractionPatterns array whose spatial
+    axes were split by a large zarr save/reload -- an all-zero
+    momentum-resolved spectrum from the lazy load vs. a correct one from the
+    eagerly-computed data)."""
+    import dask.array as da
+
+    from abtem.core.axes import EnergyLossAxis, ReciprocalSpaceAxis
+    from abtem.measurements import DiffractionPatterns
+
+    n_energy, gpts = 6, 64
+    rng = np.random.default_rng(0)
+    array = rng.random((n_energy, gpts, gpts))
+    energies = tuple(float(e) for e in np.linspace(0.01, 0.1, n_energy))
+
+    def make_dp(chunks):
+        lazy = da.from_array(array, chunks=chunks)
+        return DiffractionPatterns.from_array_and_metadata(
+            lazy,
+            axes_metadata=[
+                EnergyLossAxis(values=energies),
+                ReciprocalSpaceAxis(sampling=0.02, label="x", units="1/A"),
+                ReciprocalSpaceAxis(sampling=0.02, label="y", units="1/A"),
+            ],
+            metadata={"energy": 100e3},
+        )
+
+    truth = make_dp((n_energy, gpts, gpts)).interpolate_line(
+        start=(0.0, 0.0), end=(0.0, gpts * 0.02), gpts=20, width=0.3, order=1,
+        endpoint=True,
+    ).compute().array
+
+    for name, chunks in [
+        ("multi_chunk_ensemble_axis", (1, gpts, gpts)),
+        ("both_base_axes_chunked", (n_energy, gpts // 2, gpts // 2)),
+    ]:
+        dp = make_dp(chunks)
+        line = dp.interpolate_line(
+            start=(0.0, 0.0), end=(0.0, gpts * 0.02), gpts=20, width=0.3, order=1,
+            endpoint=True,
+        ).compute()
+        assert line.array.shape == truth.shape, name
+        np.testing.assert_allclose(line.array, truth, err_msg=name)
 
 
 @given(


### PR DESCRIPTION
## Summary

Follow-up to #363, reported by @TomaSusi: after that fix landed, large `EnergyResolvedAtomsEnsemble` TDS results saved to a `.zarr` directory store (~5 GB) still gave an all-zero `momentum_resolved_spectrum(loaded_dp, SpectralSlitDetector(...))` when `loaded_dp` was kept lazy -- but the *correct* spectrum when `loaded_dp.compute()` was called first. The corruption scaled with potential size, and only showed up for `SpectralSlitDetector`, not `SpectralAnnularDetector`.

## Root cause

`DiffractionPatterns.interpolate_line`'s lazy path (used internally by `momentum_resolved_spectrum`'s `SpectralSlitDetector` branch) computed `drop_axis`/`new_axis` for `da.map_blocks` as:

```python
base_axes = tuple(range(len(self.base_shape)))  # e.g. (0, 1)
```

i.e. it treated the base (spatial) axes as if they were the **first** axes of the array. They're actually the **last** `len(base_shape)` axes -- any ensemble axis (energy, in this case) comes first. This never raised; it just silently fed `dask.map_blocks` the wrong axis positions.

With a single dask chunk everywhere -- the case for every freshly-computed measurement, since nothing in abTEM itself ever chunks base axes -- the mismatch never mattered: there's nothing to reconcile across chunks with only one chunk. It broke the moment either condition held (both confirmed by direct, isolated reproduction against `interpolate_line` alone):
- an ensemble axis had more than one dask chunk → wrong **shape** (a `(6, 64, 64)` array chunked `(1, 64, 64)` along energy produced a `(36, 20)` line profile instead of `(6, 20)`)
- **both** base axes had more than one chunk each → right shape, silently wrong **values**

This was unreachable in practice until #363's zarr chunking started splitting a large array's axes to fit under the codec's buffer limit, picking the largest axis first -- which for a diffraction-pattern-shaped array (few energies, large `gpts`) is a spatial axis. Reproduced end-to-end at the reported scale: a 5 GB array whose zarr chunks came out as `(300, 362, 362)` (both spatial axes split into a 4x4 grid) gave `lazy vs truth match: False`, `lazy sum: 0.0` -- matching the report exactly.

## Fix

1. **Root cause** (`abtem/measurements.py`): compute `base_axes` from the array's actual trailing dimensions (`self.array.ndim - n_base .. self.array.ndim`) instead of `(0 .. n_base)`. Also fixed `test_images_interpolate_line`, which parametrized over `lazy=[True, False]` but always built its `Images` with `lazy=False` regardless -- so it never exercised the broken path despite looking like it covered both.
2. **Defense in depth on write** (`abtem/array.py`): `_safe_zarr_chunks` now takes `n_fixed_trailing_axes` (an `ArrayObject`'s `_base_dims`) and never splits those axes while a leading (ensemble) axis alone can still meet the byte budget -- several of abTEM's own lazy operations assume whole base-axis chunks, matching the same convention already used elsewhere in the module (e.g. `PotentialArray`'s `("auto",) * n + (-1,) * _base_dims` chunking). Falls back to splitting base axes too only if that's genuinely unavoidable (e.g. a single very large image with almost no ensemble axis to shrink instead).
3. **Defense in depth on read** (`abtem/array.py`): `from_zarr`'s canonical loader had the same gap on the *read* side -- `chunks=None` (the default) already mirrors whatever `to_zarr` wrote (safe after fix 2), but an explicit `from_zarr(url, chunks="auto")` bypassed that by handing `"auto"` straight to dask for the whole array, and dask's own auto-chunking heuristic doesn't know which axes are base dims (confirmed: a 2-energy, 4096x4096 array split into ragged `(4095, 1)` spatial chunks under `chunks="auto"`). The legacy loader already got this right; the canonical one now mirrors it.

With all three fixes, the 5 GB repro's zarr chunks come out as `(18, 1448, 1448)` (only the energy axis split) and the lazy path matches the eager/ground-truth result exactly, including under an explicit `chunks="auto"` reload.

## Broader audit

Asked whether this bug class could bite elsewhere and had it checked systematically: every other `drop_axis`/`new_axis` call site in the codebase (`abtem/array.py`'s `multi_output_blockwise`, six occurrences in `abtem/prism/s_matrix.py`, two in `abtem/bloch/dynamical.py`). Findings:
- All of them already use the correct trailing-axis-position arithmetic -- `interpolate_line` was an isolated inconsistency, not a systemic pattern.
- `array.py`'s `multi_output_blockwise` already asserts a dropped axis is single-chunk and raises `RuntimeError` otherwise -- fails loudly instead of silently corrupting.
- The other call sites have no such guard, but every one of them is currently protected by construction (an explicit `rechunk(-1)` immediately before the call) *except* two: `SMatrixArray._no_chunks_reduce` and Bloch's `calculate_structure_matrix`, both of which assume a single chunk with no guarantee of it. Both were only reachable via an explicit zarr round-trip with `chunks="auto"` -- which fix 3 above closes generically for every `ArrayObject` subclass (it's keyed on `cls._base_dims`, not anything DiffractionPatterns-specific).
- Also found two pieces of dead code in `s_matrix.py` while at it (`_multiple_rechunk_reduce`/`_single_rechunk_reduce`, unreachable since the branch selecting them is commented out; and a vestigial if/elif/else at line ~405 unconditionally overwritten one line later) -- unrelated to this bug, flagged separately rather than touched here.

## Test plan
- [x] New `test_interpolate_line_lazy_matches_eager_with_ensemble_axis` (`test/test_measure.py`) -- both failure modes (multi-chunk ensemble axis, both base axes chunked) now match an eager/whole-chunk reference
- [x] Fixed `test_images_interpolate_line`'s vestigial `lazy=False` hardcoding so its `lazy` parametrization actually exercises the lazy path
- [x] New `test_safe_zarr_chunks_never_splits_trailing_axes_when_avoidable`, `test_safe_zarr_chunks_falls_back_to_trailing_axes_if_unavoidable`, `test_to_zarr_never_chunks_base_axes`, `test_from_zarr_auto_chunks_never_splits_base_axes` (`test/test_array.py`)
- [x] Manual reproduction at the reported scale (5 GB, `EnergyResolvedAtomsEnsemble`-shaped array, `.zarr` directory store): confirmed broken before, confirmed `lazy vs truth match: True` after, including under `from_zarr(url, chunks="auto")`
- [x] Checked every other `drop_axis`/`base_axes` computation in `measurements.py`, `array.py`, `prism/s_matrix.py`, `bloch/dynamical.py` -- see audit section above
- [x] Full test suite: 1358 passed, 853 skipped, 0 failures (3 deselected -- pre-existing, unrelated hangs in `test_multigpu_logic.py` spinning up real multi-process dask clusters that never complete in this sandbox, tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
