### PR TITLE
Add logscale option to MomentumResolvedSpectrum.show()

### DIFF
--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -5952,6 +5952,7 @@ class MomentumResolvedSpectrum(BaseMeasurements):
         vmin: Optional[float] = None,
         vmax: Optional[float] = None,
         power: float = 1.0,
+        logscale: bool = False,
         explode: bool | Sequence[int] = (),
         figsize: Optional[tuple[int, int]] = None,
         title: bool | str = True,
@@ -5980,7 +5981,11 @@ class MomentumResolvedSpectrum(BaseMeasurements):
             from the global min/max across all panels so the shared colorbar is
             meaningful.
         power : float
-            Display on a power scale.
+            Display on a power scale. Cannot be used together with ``logscale``.
+        logscale : bool
+            If True, show the spectrum on a logarithmic intensity scale. Cannot
+            be used together with ``power != 1.0``. Non-positive values are
+            masked (log scale is undefined there).
         explode : bool or sequence of int
             If True, explode all ensemble axes into a panel grid. If a sequence
             of ints, explode only those ensemble-axis indices (the remaining
@@ -6004,7 +6009,8 @@ class MomentumResolvedSpectrum(BaseMeasurements):
         import warnings
 
         import matplotlib.pyplot as plt
-        from matplotlib.colors import PowerNorm
+
+        from abtem.visualize.artists import _get_norm
 
         array = self.array
         if hasattr(array, "compute"):
@@ -6088,7 +6094,7 @@ class MomentumResolvedSpectrum(BaseMeasurements):
             panels = [panel_data(idx).T for idx in indices]
             _vmin = min(float(p.min()) for p in panels) if vmin is None else vmin
             _vmax = max(float(p.max()) for p in panels) if vmax is None else vmax
-            norm = PowerNorm(gamma=power, vmin=_vmin, vmax=_vmax)
+            norm = _get_norm(vmin=_vmin, vmax=_vmax, power=power, logscale=logscale)
 
             im = None
             for k, (idx, data_t) in enumerate(zip(indices, panels)):
@@ -6150,7 +6156,7 @@ class MomentumResolvedSpectrum(BaseMeasurements):
         else:
             fig = ax.get_figure()
 
-        norm = PowerNorm(gamma=power, vmin=vmin, vmax=vmax)
+        norm = _get_norm(vmin=vmin, vmax=vmax, power=power, logscale=logscale)
         im = ax.pcolormesh(
             q, e, data.T, shading="nearest", cmap=cmap, norm=norm, **kwargs
         )

--- a/test/test_spectral_detectors.py
+++ b/test/test_spectral_detectors.py
@@ -478,6 +478,50 @@ def test_cropped_spectrum_shows_without_error():
     assert ax.get_xlim()[1] < spec.q_values[-1]
 
 
+# ---- MomentumResolvedSpectrum.show(logscale=...) -----------------------------
+
+
+def test_show_logscale_uses_lognorm():
+    import matplotlib
+    from matplotlib.colors import LogNorm
+
+    matplotlib.use("Agg")
+    spec, _ = _make_simple_spectrum()
+    fig, ax = spec.show(logscale=True)
+    assert isinstance(ax.collections[0].norm, LogNorm)
+
+
+def test_show_logscale_exploded_uses_lognorm():
+    import matplotlib
+    from matplotlib.colors import LogNorm
+
+    matplotlib.use("Agg")
+    spec, _ = _make_multiaxis_spectrum()
+    fig, axes = spec.show(explode=True, logscale=True)
+    assert isinstance(axes.flatten()[0].collections[0].norm, LogNorm)
+
+
+def test_show_logscale_and_power_raises():
+    import matplotlib
+
+    matplotlib.use("Agg")
+    spec, _ = _make_simple_spectrum()
+    with pytest.raises(ValueError, match="logscale"):
+        spec.show(logscale=True, power=2.0)
+
+
+def test_show_logscale_masks_nonpositive_values_without_error():
+    """Phonon-loss TDS intensities can include zero (or, from numerical
+    noise, tiny negative) values; log scale must mask rather than raise."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    spec, array = _make_simple_spectrum()
+    array[0, 0] = 0.0
+    fig, ax = spec.show(logscale=True)
+    assert ax.collections[0].norm.vmin is None or ax.collections[0].norm.vmin > 0
+
+
 # ---- momentum_resolved_spectrum with a lazy (dask-backed) input -------------
 
 


### PR DESCRIPTION
## Summary

Reported by @TomaSusi: `MomentumResolvedSpectrum.show(logscale=True)` raised:

```
AttributeError: QuadMesh.set() got an unexpected keyword argument 'logscale'
```

## Root cause

`Images`/`DiffractionPatterns`/`PolarMeasurements.show()` all support a `logscale` option via the shared `Visualization` machinery. `MomentumResolvedSpectrum.show()` plots directly with matplotlib instead (its q/energy axes are non-linear, so the shared imshow-based `Visualization` class doesn't apply) and never picked up the same option -- `logscale=True` fell straight through `**kwargs` into `Axes.pcolormesh(...)`, which forwards unrecognized kwargs to the underlying `QuadMesh` artist and raises when it doesn't recognize the name.

## Fix

Added the same `logscale: bool = False` parameter as the other `show()` methods, and reused the existing `abtem.visualize.artists._get_norm()` helper (the same one those methods already call) instead of hand-rolling a second copy of the `Normalize`/`PowerNorm`/`LogNorm` dispatch logic. That helper already handles:
- the `power` + `logscale` mutual-exclusivity check (raises `ValueError` with a clear message)
- masking non-positive values for `LogNorm` (`vmin <= 0` → `None`) -- relevant here since phonon-loss TDS intensities can be exactly zero, or (from numerical noise) tiny negative values

## Test plan
- [x] New tests in `test/test_spectral_detectors.py`: `logscale=True` produces a `LogNorm` (single panel and exploded grid), `logscale=True, power=2.0` raises the expected `ValueError`, and a spectrum containing a zero value shows without error under `logscale=True`
- [x] Full test suite: 1356 passed, 853 skipped, 0 failures (3 deselected -- pre-existing, unrelated hangs in `test_multigpu_logic.py`, tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
