### PR TITLE
Color zero/negative-intensity pixels instead of leaving them blank on logscale (follow-up to #370)

### DIFF
--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -6062,12 +6062,14 @@ class MomentumResolvedSpectrum(BaseMeasurements):
             # white background shows through, easy to mistake for missing
             # data. These pixels are real, valid, just-below-the-log-floor
             # intensity, not missing data, so colour them as the darkest end
-            # of the scale instead of leaving a blank gap. Resolve cmap to an
-            # actual (copied, so this never mutates a shared registered
-            # colormap) Colormap object here rather than in pcolormesh itself
-            # so this applies uniformly to every panel below.
-            cmap = plt.get_cmap(cmap).copy()
-            cmap.set_bad(cmap(0.0))
+            # of the scale instead of leaving a blank gap. with_extremes()
+            # returns a new Colormap rather than mutating in place (set_bad()
+            # does the latter and is being deprecated), so this can never
+            # affect the shared, globally registered colormap. Resolved here
+            # rather than in pcolormesh itself so it applies uniformly to
+            # every panel below.
+            resolved_cmap = plt.get_cmap(cmap)
+            cmap = resolved_cmap.with_extremes(bad=resolved_cmap(0.0))
 
         def panel_data(grid_index: tuple[int, ...]) -> np.ndarray:
             # Exploded axes take their grid value; other ensemble axes collapse

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -6053,6 +6053,22 @@ class MomentumResolvedSpectrum(BaseMeasurements):
             f"{self.metadata.get('label', '')} [{self.metadata.get('units', '')}]"
         )
 
+        if logscale:
+            # LogNorm masks values <= 0 (log is undefined there) rather than
+            # raising -- phonon-loss TDS intensity (incoherent - coherent) is
+            # routinely exactly zero, or, from floating-point noise, a tiny
+            # negative value. Masked entries render with the colormap's "bad"
+            # colour, which defaults to fully transparent -- i.e. the figure's
+            # white background shows through, easy to mistake for missing
+            # data. These pixels are real, valid, just-below-the-log-floor
+            # intensity, not missing data, so colour them as the darkest end
+            # of the scale instead of leaving a blank gap. Resolve cmap to an
+            # actual (copied, so this never mutates a shared registered
+            # colormap) Colormap object here rather than in pcolormesh itself
+            # so this applies uniformly to every panel below.
+            cmap = plt.get_cmap(cmap).copy()
+            cmap.set_bad(cmap(0.0))
+
         def panel_data(grid_index: tuple[int, ...]) -> np.ndarray:
             # Exploded axes take their grid value; other ensemble axes collapse
             # to their first element. grid_index is positional in explode_axes

--- a/test/test_spectral_detectors.py
+++ b/test/test_spectral_detectors.py
@@ -522,6 +522,30 @@ def test_show_logscale_masks_nonpositive_values_without_error():
     assert ax.collections[0].norm.vmin is None or ax.collections[0].norm.vmin > 0
 
 
+def test_show_logscale_colors_nonpositive_values_instead_of_leaving_them_blank():
+    """LogNorm masks values <= 0 rather than raising, and a masked pixel is
+    drawn with the colormap's "bad" colour -- which defaults to fully
+    transparent, showing the figure's white background through it and
+    looking exactly like missing data. These pixels are real, valid,
+    just-below-the-log-floor intensity (routine for TDS: incoherent -
+    coherent is often exactly zero), so they must be coloured as the bottom
+    of the colour scale instead of left blank."""
+    import matplotlib
+    import matplotlib.pyplot as plt
+
+    matplotlib.use("Agg")
+    spec, array = _make_simple_spectrum()
+    array[0, 0] = 0.0
+
+    fig, ax = spec.show(logscale=True)
+    cmap = ax.collections[0].cmap
+    assert tuple(cmap.get_bad()) == tuple(cmap(0.0))
+    assert cmap.get_bad()[-1] == 1.0  # fully opaque, not the default transparent
+
+    # Must not have mutated the globally registered colormap.
+    assert tuple(plt.get_cmap("viridis").get_bad()) == (0.0, 0.0, 0.0, 0.0)
+
+
 # ---- momentum_resolved_spectrum with a lazy (dask-backed) input -------------
 
 


### PR DESCRIPTION
## Summary

Follow-up to #370. Reported by @TomaSusi: after adding `logscale` support to `MomentumResolvedSpectrum.show()`, some pixels render as white in the log-scale plot -- and they aren't NaN.

## Root cause

`matplotlib.colors.LogNorm` masks any value `<= 0` rather than raising (log is undefined there). A masked pixel is drawn using the colormap's "bad" colour, which defaults to fully transparent (`[0, 0, 0, 0]`) -- so the figure's white background shows straight through it, indistinguishable at a glance from missing/NaN data.

Phonon-loss TDS intensity (`I_incoherent - I_coherent`) is routinely exactly zero in bins where the variance across frozen-phonon configurations happens to vanish, or a tiny negative value from floating-point subtraction noise. These are real, valid, physically-meaningful "no measurable signal here" values -- not missing data -- so masking them and rendering as transparent white was misleading.

## Fix

When `logscale=True`, resolve `cmap` to an actual `Colormap` object (via `plt.get_cmap(cmap).copy()` -- `.copy()` so the globally registered colormap is never mutated) and set its "bad" colour to `cmap(0.0)`, the bottom of the colour scale. Zero/negative pixels now render as the darkest colour in the scale (visually "very low/negligible signal") instead of a blank gap.

## Test plan
- [x] New `test_show_logscale_colors_nonpositive_values_instead_of_leaving_them_blank`: bad colour matches `cmap(0.0)`, is fully opaque (not the default transparent), and the globally registered `"viridis"` colormap is confirmed untouched
- [x] Full test suite: 1363 passed, 854 skipped, 0 failures (3 deselected -- pre-existing, unrelated hangs in `test_multigpu_logic.py`, tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
