### PR TITLE
GPU ROCm portability

### DIFF
--- a/abtem/core/backend.py
+++ b/abtem/core/backend.py
@@ -43,6 +43,18 @@ except ImportError:
     cupyx_ndimage = None
 
 
+try:
+    # cupyx.scipy exposes submodules lazily; signal must be imported explicitly
+    # before ``get_scipy_module(...).signal`` can resolve it (the import emits a
+    # FutureWarning about the experimental cupyx.jit interface it uses
+    # internally)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        import cupyx.scipy.signal  # type: ignore  # noqa: F401
+except ImportError:
+    assert cupyx is None
+
+
 ArrayModule = Union[ModuleType, str]
 
 logger = logging.getLogger(__name__)

--- a/abtem/finite_difference.py
+++ b/abtem/finite_difference.py
@@ -5,10 +5,10 @@ from typing import TYPE_CHECKING, Callable, Sequence
 
 import numpy as np
 import scipy.ndimage  # type: ignore
-from numba import cuda, njit  # type: ignore
+from numba import njit  # type: ignore
 
 from abtem.antialias import AntialiasAperture
-from abtem.core.backend import get_array_module
+from abtem.core.backend import check_cupy_is_installed, cp, get_array_module
 from abtem.core.energy import energy2sigma, energy2wavelength
 from abtem.core.utils import get_dtype
 
@@ -191,6 +191,68 @@ def _laplace_stencil_array(accuracy):
     return stencil
 
 
+_LAPLACE_STENCIL_KERNEL = r"""
+#include <cupy/complex.cuh>
+
+// Batched 2-D Laplacian finite-difference stencil: for each batch element m,
+// out[m, i, j] = sum_k c[k + n] * (a[m, i + k, j] + a[m, i, j + k]) over
+// k in [-n, n], evaluated on the interior i, j in [n, H - n) x [n, W - n).
+// The boundary is left zero; the caller handles it via wrap padding.
+//
+// Grid: x covers W (fastest axis, coalesced), y covers H, z strides over the
+// batch so any batch size is supported.
+//
+// Template parameter T is the complex floating-point type.
+template<typename T>
+__device__ __forceinline__ void laplace_stencil_impl(
+    T* __restrict__ out,
+    const T* __restrict__ a,
+    const T* __restrict__ c,
+    const int n,
+    const int M, const int H, const int W
+) {
+    const int j = blockIdx.x * blockDim.x + threadIdx.x;
+    const int i = blockIdx.y * blockDim.y + threadIdx.y;
+    if (i < n || i >= H - n || j < n || j >= W - n) return;
+
+    for (int m = blockIdx.z; m < M; m += gridDim.z) {
+        const T* am = a + (long long)m * H * W;
+        T cumul = T(0);
+        for (int k = -n; k <= n; k++) {
+            cumul += c[k + n] * (am[(long long)(i + k) * W + j]
+                                 + am[(long long)i * W + (j + k)]);
+        }
+        out[(long long)m * H * W + (long long)i * W + j] = cumul;
+    }
+}
+
+extern "C" __global__ void laplace_stencil_c64(
+    complex<float>* out, const complex<float>* a, const complex<float>* c,
+    int n, int M, int H, int W
+) {
+    laplace_stencil_impl<complex<float> >(out, a, c, n, M, H, W);
+}
+
+extern "C" __global__ void laplace_stencil_c128(
+    complex<double>* out, const complex<double>* a, const complex<double>* c,
+    int n, int M, int H, int W
+) {
+    laplace_stencil_impl<complex<double> >(out, a, c, n, M, H, W);
+}
+"""
+
+_laplace_stencil_c64 = None
+_laplace_stencil_c128 = None
+
+
+def _init_laplace_stencil_kernels():
+    global _laplace_stencil_c64, _laplace_stencil_c128
+    if _laplace_stencil_c64 is None:
+        mod = cp.RawModule(code=_LAPLACE_STENCIL_KERNEL, options=("--std=c++14",))
+        _laplace_stencil_c64 = mod.get_function("laplace_stencil_c64")
+        _laplace_stencil_c128 = mod.get_function("laplace_stencil_c128")
+
+
 def _laplace_operator_stencil(
     accuracy, prefactor, mode: str = "wrap", dtype=None, device: str = "cpu"
 ):
@@ -219,35 +281,46 @@ def _laplace_operator_stencil(
                     out[m, i, j] = cumul
         return out
 
-    @cuda.jit
-    def stencil_func_gpu_batch(a, out):
-        m, i, j = cuda.grid(3)
-        M, H, W = a.shape
-        if m < M and n <= i < H - n and n <= j < W - n:
-            cumul = dtype(0.0)
-            for k in range(-n, n + 1):
-                cumul += c[k] * a[m, i + k, j] + c[k] * a[m, i, j + k]
-            out[m, i, j] = cumul
+    if device == "gpu":
+        check_cupy_is_installed()
+        # the kernel indexes the coefficients in natural order (index k + n for
+        # offset k), so undo the roll applied for the CPU stencil above
+        c_gpu = cp.asarray(np.roll(c, n))
 
     def _laplace_stencil_gpu(a):
         xp = get_array_module(a)
+        a = xp.ascontiguousarray(a)
         out = xp.zeros_like(a)
 
         M, H, W = a.shape
 
-        threads_x = 8
-        threads_y = 8
+        _init_laplace_stencil_kernels()
+        if a.dtype == xp.complex128:
+            kernel = _laplace_stencil_c128
+        else:
+            kernel = _laplace_stencil_c64
 
-        target_threads = 256
-        threads_m = max(1, target_threads // (threads_x * threads_y))
-
-        threadsperblock = (threads_m, threads_x, threads_y)
-
-        blockspergrid_m = math.ceil(a.shape[0] / threadsperblock[0])
-        blockspergrid_x = math.ceil(a.shape[1] / threadsperblock[1])
-        blockspergrid_y = math.ceil(a.shape[2] / threadsperblock[2])
-        blockspergrid = (blockspergrid_m, blockspergrid_x, blockspergrid_y)
-        stencil_func_gpu_batch[blockspergrid, threadsperblock](a, out)
+        threads_x = 16
+        threads_y = 16
+        block = (threads_x, threads_y, 1)
+        grid = (
+            math.ceil(W / threads_x),
+            math.ceil(H / threads_y),
+            min(M, 65535),
+        )
+        kernel(
+            grid,
+            block,
+            (
+                out,
+                a,
+                c_gpu.astype(a.dtype, copy=False),
+                np.int32(n),
+                np.int32(M),
+                np.int32(H),
+                np.int32(W),
+            ),
+        )
 
         return out
 

--- a/abtem/finite_difference.py
+++ b/abtem/finite_difference.py
@@ -249,8 +249,12 @@ def _init_laplace_stencil_kernels():
     global _laplace_stencil_c64, _laplace_stencil_c128
     if _laplace_stencil_c64 is None:
         mod = cp.RawModule(code=_LAPLACE_STENCIL_KERNEL, options=("--std=c++14",))
-        _laplace_stencil_c64 = mod.get_function("laplace_stencil_c64")
+        # _laplace_stencil_c64 doubles as the initialized-guard, so it is
+        # assigned last: a concurrent thread that observes it non-None is then
+        # guaranteed to also observe _laplace_stencil_c128 (redundant module
+        # compilation from two racing threads is harmless — CuPy caches it)
         _laplace_stencil_c128 = mod.get_function("laplace_stencil_c128")
+        _laplace_stencil_c64 = mod.get_function("laplace_stencil_c64")
 
 
 def _laplace_operator_stencil(
@@ -297,8 +301,13 @@ def _laplace_operator_stencil(
         _init_laplace_stencil_kernels()
         if a.dtype == xp.complex128:
             kernel = _laplace_stencil_c128
-        else:
+        elif a.dtype == xp.complex64:
             kernel = _laplace_stencil_c64
+        else:
+            raise TypeError(
+                "the GPU Laplacian stencil requires a complex64 or complex128 "
+                f"array, got {a.dtype}"
+            )
 
         threads_x = 16
         threads_y = 16

--- a/abtem/prism/s_matrix.py
+++ b/abtem/prism/s_matrix.py
@@ -24,7 +24,13 @@ from abtem.core.axes import (
     UnknownAxis,
     WaveVectorAxis,
 )
-from abtem.core.backend import copy_to_device, cp, get_array_module, validate_device
+from abtem.core.backend import (
+    asnumpy,
+    copy_to_device,
+    cp,
+    get_array_module,
+    validate_device,
+)
 from abtem.core.chunks import Chunks, chunk_ranges, equal_sized_chunks, validate_chunks
 from abtem.core.complex import complex_exponential
 from abtem.core.diagnostics import TqdmWrapper
@@ -4634,9 +4640,14 @@ class SMatrix(BaseSMatrix, Ensemble, CopyMixin, EqualityMixin):
         w = xp.concatenate([lattice_basis, extra_basis], axis=0)
 
         # order the retained modes by how much of the expansion they carry, so
-        # that a rank cap keeps the largest and the reported spectrum descends
+        # that a rank cap keeps the largest and the reported spectrum descends;
+        # the argsort runs on the host: the vector holds one entry per retained
+        # mode, and CuPy's Thrust-backed sort is unavailable on some HIP/ROCm
+        # builds
         amplitudes = xp.ascontiguousarray((projected @ w.conj().T).T)
-        order = xp.argsort(xp.linalg.norm(amplitudes, axis=1))[::-1]
+        order = xp.asarray(
+            np.argsort(asnumpy(xp.linalg.norm(amplitudes, axis=1)))[::-1]
+        )
         if self._max_rank is not None:
             order = order[: max(1, self._max_rank)]
         w, amplitudes = w[order], xp.ascontiguousarray(amplitudes[order])

--- a/test/test_realspace_multislice.py
+++ b/test/test_realspace_multislice.py
@@ -595,11 +595,13 @@ class TestComplexWorkflows:
 
 
 class TestStencilNumericalAccuracy:
-    """Verify the numba stencil matches the scipy reference implementation."""
+    """Verify the fast stencils match the scipy reference implementation."""
 
+    @pytest.mark.parametrize("device", ["cpu", gpu])
     @pytest.mark.parametrize("accuracy", [2, 4, 6, 8])
-    def test_laplace_stencil_matches_scipy_reference(self, accuracy):
-        """Compare the numba Laplacian stencil against scipy.ndimage.convolve."""
+    def test_laplace_stencil_matches_scipy_reference(self, accuracy, device):
+        """Compare the fast Laplacian stencils against scipy.ndimage.convolve."""
+        from abtem.core.backend import get_array_module
         from abtem.finite_difference import (
             _laplace_operator_func_slow,
             _laplace_operator_stencil,
@@ -618,14 +620,29 @@ class TestStencilNumericalAccuracy:
                 for m in range(a.shape[0])
             ]
         )
+        xp = get_array_module(device)
         result = _laplace_operator_stencil(
-            accuracy, prefactor, mode="wrap", dtype=np.complex64, device="cpu"
-        )(a)
+            accuracy, prefactor, mode="wrap", dtype=np.complex64, device=device
+        )(xp.asarray(a))
 
         np.testing.assert_allclose(
-            result,
+            to_numpy(result),
             ref,
             rtol=1e-5,
             atol=1e-5,
-            err_msg=f"Stencil mismatch at accuracy={accuracy}",
+            err_msg=f"Stencil mismatch at accuracy={accuracy} on {device}",
         )
+
+    @pytest.mark.parametrize("device", [gpu])
+    def test_gpu_stencil_rejects_non_complex_dtype(self, device):
+        """The raw GPU kernel only ships complex specializations; a real array
+        must raise instead of silently reinterpreting the buffer."""
+        import cupy as cp
+
+        from abtem.finite_difference import _laplace_operator_stencil
+
+        stencil = _laplace_operator_stencil(
+            4, 1.0, mode="wrap", dtype=np.complex64, device="gpu"
+        )
+        with pytest.raises(TypeError, match="complex64 or complex128"):
+            stencil(cp.ones((8, 8), dtype=cp.float32))


### PR DESCRIPTION
Hi Toma,

Running the full GPU test suite on a ROCm machine (Strix Halo gfx1151, ROCm 7.2.0, amd-cupy 13.5.1) surfaced three independent defects in the GPU code path. Two affect every CuPy-HIP platform and one affects CUDA as well. Each gets its own commit; 532 GPU-parameterized tests now pass on that box, up from two hard failure classes plus an interpreter-killing segfault. The branch is rebased on current dev (a626b5a3).

**1. `cupyx.scipy.signal` was never importable through `get_scipy_module` (all platforms, CUDA included).** `cupyx.scipy` exposes its submodules lazily, so `get_scipy_module(array).signal` in the Lorentzian/Voigtian image filters raised `AttributeError` unless something else had already imported `cupyx.scipy.signal`. The fix registers the submodule in `abtem.core.backend` next to the existing `cupyx.scipy.ndimage` import, with the `FutureWarning` that import emits (about the experimental `cupyx.jit` interface it uses internally) suppressed. Fixes `test_lorentzian_filter_images[gpu-*]` and `test_voigtian_filter_images[gpu-*]`.

**2. The real-space multislice Laplacian was abTEM's only `numba.cuda` dependency, and `numba.cuda` cannot initialize on non-CUDA platforms.** The `@cuda.jit` stencil in `abtem/finite_difference.py` is replaced with a `cp.RawModule` kernel following the pattern of `abtem/core/_cuda.py`; CuPy compiles it via NVRTC on CUDA and hipRTC on ROCm alike, so the module no longer imports `numba.cuda` at all. The kernel reproduces the previous stencil to machine precision (checked against the untouched CPU `numba.njit` stencil for complex64/complex128, accuracy orders 2–16, and 2-D through 4-D batch shapes; relative error ≤3e-7 single, ≤6e-16 double). It also switches the launch layout so the fast image axis maps to `threadIdx.x` (coalesced access; the numba kernel had the batch index on x) and strides the grid over the batch so any batch size is supported. Fixes all 8 `test_realspace_multislice` GPU failures on ROCm.

**3. PRISM S-matrix compression segfaulted the interpreter on HIP via `xp.argsort`.** CuPy's sort family (`sort`, `argsort`, `lexsort`, `unique`) is backed by precompiled Thrust device code, which the amd-cupy wheels ship only for MI-series and a subset of RDNA architectures — on an unsupported device the call segfaults at kernel launch inside `libamdhip64` rather than raising, taking pytest down with it. The argsort in `_compress` orders one scalar norm per retained mode, so it now runs on the host: cost is negligible at that size, and it removes the only Thrust dependency in the GPU path. Un-crashes `test_prism_upsample` (78 tests) on ROCm.

**Testing.** On the ROCm box, after the rebase onto a626b5a3: suite-wide `-k gpu -m "not multigpu"` → 532 passed, 152 skipped (`--runslow` gating), 0 failed; full runs of `test_realspace_multislice.py`, `test_measure.py`, and `test_prism_upsample.py` (368 tests, CPU + GPU) all green. A CPU-only environment was simulated by blocking `cupy`/`cupyx` imports: abTEM imports cleanly and the CPU stencil is unaffected. I don't have a CUDA card in this machine, so the RawModule kernel has only run under hipRTC here — the machine-precision equivalence check is dtype- and layout-exhaustive, but a CI or maintainer run on CUDA would be a welcome double-check.

No API or dependency changes; `numba` remains required for the CPU stencil.

Best,
Paul


🤖 Written by [Claude Code](https://claude.com/claude-code) on Paul's behalf