### PR TITLE
Remove unreachable return left behind in _apply_convolve_2d_on_axes

### DIFF
--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -2695,7 +2695,6 @@ def _apply_convolve_2d_on_axes(array, kernel_2d, axes, mode, cval=0.0):
     # filter stops matching and the GPU tests catch the change.
     result = scipy_signal.fftconvolve(padded, kernel_nd, mode="valid")
     return result.astype(array.dtype, copy=False)
-    return array
 
 
 def _lorentzian_source_size(


### PR DESCRIPTION

Hi Toma,

This PR removes the trailing `return array` after the `fftconvolve` return in `_apply_convolve_2d_on_axes` — unreachable since the function was introduced in #270. No behavior change; the Lorentzian/Voigtian/source-size filter tests pass unchanged.

Best,
Paul

🤖 Written by [Claude Code](https://claude.com/claude-code) on Paul's behalf.