### PR TITLE
Cache per-chunk GPU work: cuFFT plan entries and polar detector-bin geometry

### DIFF
--- a/abtem/core/abtem.yaml
+++ b/abtem/core/abtem.yaml
@@ -42,6 +42,10 @@ cupy:
   #          which on Bluestein-fallback grid sizes can reach tens of GB).
   # null  — same as -1 (no bound).
   fft-cache-size: auto
+  # Number of cuFFT plans kept. CuPy's own default is 16, which thrashes for
+  # workloads with many distinct transform shapes (e.g. core-loss scattering,
+  # whose batch dimension follows the number of contributing sites).
+  fft-cache-entries: 64
 mkl:
   # The number of threads to use for mkl
   threads: 2

--- a/abtem/core/abtem.yaml
+++ b/abtem/core/abtem.yaml
@@ -42,9 +42,12 @@ cupy:
   #          which on Bluestein-fallback grid sizes can reach tens of GB).
   # null  — same as -1 (no bound).
   fft-cache-size: auto
-  # Number of cuFFT plans kept. CuPy's own default is 16, which thrashes for
-  # workloads with many distinct transform shapes (e.g. core-loss scattering,
-  # whose batch dimension follows the number of contributing sites).
+  # Minimum number of cuFFT plans kept. CuPy's own default is 16, which
+  # thrashes for workloads with many distinct transform shapes (e.g. core-loss
+  # scattering, whose batch dimension follows the number of contributing
+  # sites). The count is raised to this value, never lowered — a cache tuned
+  # larger through CuPy's own API is left alone. null or a non-positive value
+  # leaves the entry count untouched entirely.
   fft-cache-entries: 64
 mkl:
   # The number of threads to use for mkl

--- a/abtem/core/fft.py
+++ b/abtem/core/fft.py
@@ -366,8 +366,36 @@ U = TypeVar("U", np.ndarray, da.core.Array)
 
 # Cache the parsed cuFFT cache limit + the config value it was derived from.
 # Revalidated on every GPU FFT dispatch without reparsing when the config is
-# unchanged (the common case in a hot loop).
-_CUFFT_CACHE_STATE: tuple[object, int] | None = None
+# unchanged (the common case in a hot loop). CuPy's plan cache is per thread
+# (and per device), so the applied state must be thread-local as well: a
+# process-global slot would configure only the first dispatching thread and
+# leave every other dask worker thread's cache at CuPy's defaults.
+_CUFFT_CACHE_STATE = threading.local()
+
+
+def _reset_cufft_cache_state():
+    """Forget the applied plan-cache state for the calling thread (tests)."""
+    for attr in ("token", "limit"):
+        try:
+            delattr(_CUFFT_CACHE_STATE, attr)
+        except AttributeError:
+            pass
+
+
+def _parse_cufft_cache_entries() -> int:
+    """The configured plan-cache entry count, or 0 to leave the count alone.
+
+    Invalid values must not raise: this runs ahead of every GPU FFT, and an
+    exception here (e.g. ``int(None)``) would fail every dispatch. null and
+    non-positive values mean "do not touch the entry count", mirroring how a
+    user opts out of the sibling ``fft-cache-size`` bound.
+    """
+    raw = config.get("cupy.fft-cache-entries", 64)
+    try:
+        entries = int(raw)
+    except (TypeError, ValueError):
+        return 0
+    return entries if entries > 0 else 0
 
 
 def _configure_cufft_cache():
@@ -397,18 +425,14 @@ def _configure_cufft_cache():
     of successive computations. The limit is a ceiling, not a reservation —
     unused headroom costs no memory.
     """
-    global _CUFFT_CACHE_STATE
     raw = config.get("cupy.fft-cache-size", "auto")
 
     # The plan cache and the resolved "auto" limit are per device, so the
     # applied state is keyed on the current device as well as the raw value.
     device = cp.cuda.Device()
-    entries = int(config.get("cupy.fft-cache-entries", 64))
-    if _CUFFT_CACHE_STATE is not None and _CUFFT_CACHE_STATE[0] == (
-        raw,
-        entries,
-        device.id,
-    ):
+    entries = _parse_cufft_cache_entries()
+    applied = getattr(_CUFFT_CACHE_STATE, "token", None)
+    if applied is not None and applied == (raw, entries, device.id):
         return
 
     if raw is None:
@@ -431,8 +455,15 @@ def _configure_cufft_cache():
         # batches follow the number of sites passing the threshold, put 30 %
         # of the runtime in _get_cufft_plan_nd, and raising the limit made
         # the same scan 18 % faster with identical results.
-        if cache.get_size() != entries:
+        #
+        # Raise, never lower: a cache someone tuned larger through CuPy's own
+        # API keeps its size (the old code likewise never overrode a live
+        # cache, only re-enabled a disabled one). This also re-enables a
+        # disabled cache, whose size is 0.
+        if entries and cache.get_size() < entries:
             cache.set_size(entries)
+        elif not entries and cache.get_size() == 0:
+            cache.set_size(16)  # re-enable a previously disabled cache
         if limit > 0:
             cache.set_memsize(limit)
         else:
@@ -441,7 +472,8 @@ def _configure_cufft_cache():
             # oversized-plan warning recommends exactly this.
             cache.set_memsize(-1)
 
-    _CUFFT_CACHE_STATE = ((raw, entries, device.id), limit)
+    _CUFFT_CACHE_STATE.token = (raw, entries, device.id)
+    _CUFFT_CACHE_STATE.limit = limit
 
 
 _warned_plan_cache_bypass = False

--- a/abtem/core/fft.py
+++ b/abtem/core/fft.py
@@ -403,7 +403,12 @@ def _configure_cufft_cache():
     # The plan cache and the resolved "auto" limit are per device, so the
     # applied state is keyed on the current device as well as the raw value.
     device = cp.cuda.Device()
-    if _CUFFT_CACHE_STATE is not None and _CUFFT_CACHE_STATE[0] == (raw, device.id):
+    entries = int(config.get("cupy.fft-cache-entries", 64))
+    if _CUFFT_CACHE_STATE is not None and _CUFFT_CACHE_STATE[0] == (
+        raw,
+        entries,
+        device.id,
+    ):
         return
 
     if raw is None:
@@ -419,19 +424,24 @@ def _configure_cufft_cache():
     cache = cp.fft.config.get_plan_cache()
     if limit == 0:
         cache.set_size(0)       # disable caching entirely
-    elif limit > 0:
-        if cache.get_size() == 0:
-            cache.set_size(16)  # re-enable a previously disabled cache
-        cache.set_memsize(limit)
     else:
-        # Explicitly restore "unlimited": an earlier bound (e.g. from the
-        # "auto" default) must be undoable at runtime -- the oversized-plan
-        # warning recommends exactly this.
-        if cache.get_size() == 0:
-            cache.set_size(16)
-        cache.set_memsize(-1)
+        # CuPy keeps at most 16 plans by default. Workloads whose batch
+        # dimension varies pass that within a few chunks and then rebuild
+        # plans continuously: profiling a core-loss scan, whose scattering
+        # batches follow the number of sites passing the threshold, put 30 %
+        # of the runtime in _get_cufft_plan_nd, and raising the limit made
+        # the same scan 18 % faster with identical results.
+        if cache.get_size() != entries:
+            cache.set_size(entries)
+        if limit > 0:
+            cache.set_memsize(limit)
+        else:
+            # Explicitly restore "unlimited": an earlier bound (e.g. from the
+            # "auto" default) must be undoable at runtime -- the
+            # oversized-plan warning recommends exactly this.
+            cache.set_memsize(-1)
 
-    _CUFFT_CACHE_STATE = ((raw, device.id), limit)
+    _CUFFT_CACHE_STATE = ((raw, entries, device.id), limit)
 
 
 _warned_plan_cache_bypass = False

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -7,7 +7,7 @@ import functools
 import itertools
 import warnings
 from abc import ABCMeta, abstractmethod
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from numbers import Number
 from types import ModuleType
 from typing import (
@@ -324,13 +324,6 @@ def _polar_bins_key(
     )
 
 
-# Real LRU: a hit refreshes the entry, an insert beyond the bound evicts only
-# the least recently used one. The bound caps device-memory retention at a few
-# full-grid int64 arrays per device.
-_RADIAL_BINNING_DEVICE_CACHE: OrderedDict = OrderedDict()
-_RADIAL_BINNING_DEVICE_CACHE_MAX = 8
-
-
 def _radial_binning_device_arrays(
     array,
     sampling,
@@ -353,7 +346,6 @@ def _radial_binning_device_arrays(
     key (a free lookup when the lru-cached geometry is warm), so there is no
     key/data consistency contract for callers to uphold.
     """
-    xp = get_array_module(array)
     key = _polar_bins_key(
         array.shape[-2:],
         sampling,
@@ -367,7 +359,7 @@ def _radial_binning_device_arrays(
         True,
     )
 
-    if xp is np:
+    if get_array_module(array) is np:
         device_key = "cpu"
     else:
         # Key on the device the array actually lives on -- read off the array
@@ -375,32 +367,32 @@ def _radial_binning_device_arrays(
         # under multi-GPU use.
         device_key = ("gpu", int(array.device.id))
 
-    cache_key = key + (device_key,)
-    cached = _RADIAL_BINNING_DEVICE_CACHE.get(cache_key)
-    if cached is not None:
-        _RADIAL_BINNING_DEVICE_CACHE.move_to_end(cache_key)
-        return cached
+    return _radial_binning_device_arrays_cached(key, device_key)
 
+
+@functools.lru_cache(maxsize=8)
+def _radial_binning_device_arrays_cached(key, device_key):
+    """The device-resident arrays behind ``_radial_binning_device_arrays``.
+
+    ``lru_cache`` supplies the locking and least-recently-used eviction (a
+    hand-rolled dict here raced under the threaded scheduler). The bound is a
+    single cap shared across all devices -- in the supported multi-GPU layout
+    (one process per GPU) each process only ever sees one device anyway.
+    """
     indices = _polar_detector_bins_cached(*key)
-    flat_host = np.concatenate(indices)
-    separators_host = np.concatenate(([0], np.cumsum([len(i) for i in indices])))
+    flat_indices = np.concatenate(indices)
+    separators = np.concatenate(([0], np.cumsum([len(i) for i in indices])))
 
-    if xp is np:
-        flat_indices, separators = flat_host, separators_host
+    if device_key == "cpu":
         # Shared between callers, like the lru-cached geometry.
         flat_indices.flags.writeable = False
         separators.flags.writeable = False
-    else:
-        # Allocate on the array's device, whatever device is current.
-        # (CuPy arrays cannot be flagged read-only; shared by convention.)
-        with array.device:
-            flat_indices = xp.asarray(flat_host)
-            separators = xp.asarray(separators_host)
+        return flat_indices, separators
 
-    while len(_RADIAL_BINNING_DEVICE_CACHE) >= _RADIAL_BINNING_DEVICE_CACHE_MAX:
-        _RADIAL_BINNING_DEVICE_CACHE.popitem(last=False)
-    _RADIAL_BINNING_DEVICE_CACHE[cache_key] = (flat_indices, separators)
-    return flat_indices, separators
+    # Allocate on the keyed device, whatever device is current.
+    # (CuPy arrays cannot be flagged read-only; shared by convention.)
+    with cp.cuda.Device(device_key[1]):
+        return cp.asarray(flat_indices), cp.asarray(separators)
 
 
 @functools.lru_cache(maxsize=8)

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -7,7 +7,7 @@ import functools
 import itertools
 import warnings
 from abc import ABCMeta, abstractmethod
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from numbers import Number
 from types import ModuleType
 from typing import (
@@ -23,8 +23,6 @@ from typing import (
 )
 
 import dask.array as da
-from functools import lru_cache
-
 import numpy as np
 from ase import Atom
 from ase.cell import Cell
@@ -295,43 +293,117 @@ def _annular_detector_mask(
     return bins
 
 
-_RADIAL_BINNING_DEVICE_CACHE: dict = {}
+def _polar_bins_key(
+    gpts,
+    sampling,
+    inner,
+    outer,
+    nbins_radial,
+    nbins_azimuthal,
+    rotation,
+    offset,
+    fftshift,
+    return_indices,
+) -> tuple:
+    """The canonical, hashable geometry key.
+
+    The single definition used by every cache in this module, so a parameter
+    added to the geometry cannot silently be left out of one cache's key.
+    """
+    return (
+        tuple(int(n) for n in gpts),
+        tuple(float(d) for d in sampling),
+        float(inner),
+        float(outer),
+        int(nbins_radial),
+        int(nbins_azimuthal),
+        float(rotation),
+        tuple(float(o) for o in offset),
+        bool(fftshift),
+        bool(return_indices),
+    )
+
+
+# Real LRU: a hit refreshes the entry, an insert beyond the bound evicts only
+# the least recently used one. The bound caps device-memory retention at a few
+# full-grid int64 arrays per device.
+_RADIAL_BINNING_DEVICE_CACHE: OrderedDict = OrderedDict()
 _RADIAL_BINNING_DEVICE_CACHE_MAX = 8
 
 
-def _radial_binning_device_arrays(xp, key, indices):
-    """Flat bin indices and separators, resident on the array's device.
+def _radial_binning_device_arrays(
+    array,
+    sampling,
+    inner,
+    outer,
+    nbins_radial,
+    nbins_azimuthal,
+    rotation,
+    offset,
+    fftshift,
+):
+    """Flat bin indices and separators, resident on ``array``'s device.
 
     Indexing a device array with a host index array transfers that array every
     call; for a detector applied once per wave-function chunk this dominated a
     core-loss scan's runtime. Both arrays depend only on the detector geometry
-    and the grid, so they are cached per device.
+    and the grid, so they are cached per (geometry, device).
+
+    The host-side indices are derived internally from the canonical geometry
+    key (a free lookup when the lru-cached geometry is warm), so there is no
+    key/data consistency contract for callers to uphold.
     """
+    xp = get_array_module(array)
+    key = _polar_bins_key(
+        array.shape[-2:],
+        sampling,
+        inner,
+        outer,
+        nbins_radial,
+        nbins_azimuthal,
+        rotation,
+        offset,
+        fftshift,
+        True,
+    )
+
     if xp is np:
         device_key = "cpu"
     else:
-        try:
-            device_key = ("gpu", int(xp.cuda.Device().id))
-        except Exception:  # noqa: BLE001 -- fall back to a single gpu bucket
-            device_key = "gpu"
+        # Key on the device the array actually lives on -- read off the array
+        # itself, not the current-device context, which can differ from it
+        # under multi-GPU use.
+        device_key = ("gpu", int(array.device.id))
 
     cache_key = key + (device_key,)
     cached = _RADIAL_BINNING_DEVICE_CACHE.get(cache_key)
     if cached is not None:
+        _RADIAL_BINNING_DEVICE_CACHE.move_to_end(cache_key)
         return cached
 
-    flat_indices = xp.asarray(np.concatenate(indices))
-    separators = xp.concatenate(
-        (xp.array([0]), xp.cumsum(xp.array([len(i) for i in indices])))
-    )
+    indices = _polar_detector_bins_cached(*key)
+    flat_host = np.concatenate(indices)
+    separators_host = np.concatenate(([0], np.cumsum([len(i) for i in indices])))
 
-    if len(_RADIAL_BINNING_DEVICE_CACHE) >= _RADIAL_BINNING_DEVICE_CACHE_MAX:
-        _RADIAL_BINNING_DEVICE_CACHE.clear()
+    if xp is np:
+        flat_indices, separators = flat_host, separators_host
+        # Shared between callers, like the lru-cached geometry.
+        flat_indices.flags.writeable = False
+        separators.flags.writeable = False
+    else:
+        # Allocate on the array's device, whatever device is current.
+        # (CuPy arrays cannot be flagged read-only; shared by convention.)
+        with array.device:
+            flat_indices = xp.asarray(flat_host)
+            separators = xp.asarray(separators_host)
+
+    while len(_RADIAL_BINNING_DEVICE_CACHE) >= _RADIAL_BINNING_DEVICE_CACHE_MAX:
+        _RADIAL_BINNING_DEVICE_CACHE.popitem(last=False)
     _RADIAL_BINNING_DEVICE_CACHE[cache_key] = (flat_indices, separators)
     return flat_indices, separators
 
 
-@lru_cache(maxsize=32)
+@functools.lru_cache(maxsize=8)
 def _polar_detector_bins_cached(
     gpts: tuple[int, int],
     sampling: tuple[float, float],
@@ -352,7 +424,12 @@ def _polar_detector_bins_cached(
     coordinates on the host and shipping the indices to the device. Profiling
     such a scan put ~48 % of the runtime here.
 
-    Returned arrays are shared between callers and marked read-only.
+    Entries are full-grid arrays, so the bound is deliberately small: typical
+    workflows touch a handful of geometries, and 8 entries already cap the
+    retention at a few hundred MB for large grids.
+
+    Returned containers are immutable and their arrays read-only: they are
+    shared between all callers.
     """
     result = _polar_detector_bins_uncached(
         gpts=gpts,
@@ -366,11 +443,11 @@ def _polar_detector_bins_cached(
         fftshift=fftshift,
         return_indices=return_indices,
     )
-    if isinstance(result, list):
+    if return_indices:
         for array in result:
             array.flags.writeable = False
-    else:
-        result.flags.writeable = False
+        return tuple(result)
+    result.flags.writeable = False
     return result
 
 
@@ -385,20 +462,21 @@ def _polar_detector_bins(
     offset: tuple[float, float] = (0.0, 0.0),
     fftshift: bool = False,
     return_indices: bool = False,
-) -> np.ndarray | list[np.ndarray]:
+) -> np.ndarray | tuple[np.ndarray, ...]:
     """Bin geometry for a polar detector, cached on its arguments."""
-    return _polar_detector_bins_cached(
-        gpts=tuple(int(n) for n in gpts),
-        sampling=tuple(float(d) for d in sampling),
-        inner=float(inner),
-        outer=float(outer),
-        nbins_radial=int(nbins_radial),
-        nbins_azimuthal=int(nbins_azimuthal),
-        rotation=float(rotation),
-        offset=tuple(float(o) for o in offset),
-        fftshift=bool(fftshift),
-        return_indices=bool(return_indices),
+    key = _polar_bins_key(
+        gpts,
+        sampling,
+        inner,
+        outer,
+        nbins_radial,
+        nbins_azimuthal,
+        rotation,
+        offset,
+        fftshift,
+        return_indices,
     )
+    return _polar_detector_bins_cached(*key)
 
 
 def _polar_detector_bins_uncached(
@@ -3821,37 +3899,21 @@ class DiffractionPatterns(_BaseMeasurement2D):
     ):
         xp = get_array_module(array)
 
-        indices = _polar_detector_bins(
-            gpts=array.shape[-2:],
+        # The flat index array and the separators are functions of the
+        # detector geometry alone, but indexing a device array with a host
+        # index array copies it every call -- up to one int64 per grid point.
+        flat_indices, separators = _radial_binning_device_arrays(
+            array,
             sampling=sampling,
             inner=inner,
             outer=outer,
             nbins_radial=nbins_radial,
             nbins_azimuthal=nbins_azimuthal,
-            fftshift=fftshift,
             rotation=rotation,
             offset=offset,
-            return_indices=True,
+            fftshift=fftshift,
         )
-
-        # The flat index array and the separators are functions of the
-        # detector geometry alone, but indexing a device array with a host
-        # index array copies it every call -- up to one int64 per grid point.
-        flat_indices, separators = _radial_binning_device_arrays(
-            xp,
-            (
-                tuple(int(n) for n in array.shape[-2:]),
-                tuple(float(d) for d in sampling),
-                float(inner),
-                float(outer),
-                int(nbins_radial),
-                int(nbins_azimuthal),
-                float(rotation),
-                tuple(float(o) for o in offset),
-                bool(fftshift),
-            ),
-            indices,
-        )
+        n_bins = int(len(separators)) - 1
 
         new_shape = array.shape[:-2] + (nbins_radial, nbins_azimuthal)
 
@@ -3869,7 +3931,7 @@ class DiffractionPatterns(_BaseMeasurement2D):
         result = xp.zeros(
             (
                 array.shape[0],
-                len(indices),
+                n_bins,
             ),
             dtype=fp_dtype,
         )

--- a/abtem/measurements.py
+++ b/abtem/measurements.py
@@ -23,6 +23,8 @@ from typing import (
 )
 
 import dask.array as da
+from functools import lru_cache
+
 import numpy as np
 from ase import Atom
 from ase.cell import Cell
@@ -293,7 +295,113 @@ def _annular_detector_mask(
     return bins
 
 
+_RADIAL_BINNING_DEVICE_CACHE: dict = {}
+_RADIAL_BINNING_DEVICE_CACHE_MAX = 8
+
+
+def _radial_binning_device_arrays(xp, key, indices):
+    """Flat bin indices and separators, resident on the array's device.
+
+    Indexing a device array with a host index array transfers that array every
+    call; for a detector applied once per wave-function chunk this dominated a
+    core-loss scan's runtime. Both arrays depend only on the detector geometry
+    and the grid, so they are cached per device.
+    """
+    if xp is np:
+        device_key = "cpu"
+    else:
+        try:
+            device_key = ("gpu", int(xp.cuda.Device().id))
+        except Exception:  # noqa: BLE001 -- fall back to a single gpu bucket
+            device_key = "gpu"
+
+    cache_key = key + (device_key,)
+    cached = _RADIAL_BINNING_DEVICE_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    flat_indices = xp.asarray(np.concatenate(indices))
+    separators = xp.concatenate(
+        (xp.array([0]), xp.cumsum(xp.array([len(i) for i in indices])))
+    )
+
+    if len(_RADIAL_BINNING_DEVICE_CACHE) >= _RADIAL_BINNING_DEVICE_CACHE_MAX:
+        _RADIAL_BINNING_DEVICE_CACHE.clear()
+    _RADIAL_BINNING_DEVICE_CACHE[cache_key] = (flat_indices, separators)
+    return flat_indices, separators
+
+
+@lru_cache(maxsize=32)
+def _polar_detector_bins_cached(
+    gpts: tuple[int, int],
+    sampling: tuple[float, float],
+    inner: float,
+    outer: float,
+    nbins_radial: int,
+    nbins_azimuthal: int,
+    rotation: float,
+    offset: tuple[float, float],
+    fftshift: bool,
+    return_indices: bool,
+):
+    """Cached bin geometry; see ``_polar_detector_bins``.
+
+    The result depends only on the detector geometry and the grid, but a
+    detector is applied once per wave-function chunk -- for a core-loss scan
+    that is hundreds of times per task, each one rebuilding full-grid polar
+    coordinates on the host and shipping the indices to the device. Profiling
+    such a scan put ~48 % of the runtime here.
+
+    Returned arrays are shared between callers and marked read-only.
+    """
+    result = _polar_detector_bins_uncached(
+        gpts=gpts,
+        sampling=sampling,
+        inner=inner,
+        outer=outer,
+        nbins_radial=nbins_radial,
+        nbins_azimuthal=nbins_azimuthal,
+        rotation=rotation,
+        offset=offset,
+        fftshift=fftshift,
+        return_indices=return_indices,
+    )
+    if isinstance(result, list):
+        for array in result:
+            array.flags.writeable = False
+    else:
+        result.flags.writeable = False
+    return result
+
+
 def _polar_detector_bins(
+    gpts: tuple[int, int],
+    sampling: tuple[float, float],
+    inner: float,
+    outer: float,
+    nbins_radial: int,
+    nbins_azimuthal: int,
+    rotation: float = 0.0,
+    offset: tuple[float, float] = (0.0, 0.0),
+    fftshift: bool = False,
+    return_indices: bool = False,
+) -> np.ndarray | list[np.ndarray]:
+    """Bin geometry for a polar detector, cached on its arguments."""
+    return _polar_detector_bins_cached(
+        gpts=tuple(int(n) for n in gpts),
+        sampling=tuple(float(d) for d in sampling),
+        inner=float(inner),
+        outer=float(outer),
+        nbins_radial=int(nbins_radial),
+        nbins_azimuthal=int(nbins_azimuthal),
+        rotation=float(rotation),
+        offset=tuple(float(o) for o in offset),
+        fftshift=bool(fftshift),
+        return_indices=bool(return_indices),
+    )
+
+
+def _polar_detector_bins_uncached(
     gpts: tuple[int, int],
     sampling: tuple[float, float],
     inner: float,
@@ -3726,8 +3834,23 @@ class DiffractionPatterns(_BaseMeasurement2D):
             return_indices=True,
         )
 
-        separators = xp.concatenate(
-            (xp.array([0]), xp.cumsum(xp.array([len(i) for i in indices])))
+        # The flat index array and the separators are functions of the
+        # detector geometry alone, but indexing a device array with a host
+        # index array copies it every call -- up to one int64 per grid point.
+        flat_indices, separators = _radial_binning_device_arrays(
+            xp,
+            (
+                tuple(int(n) for n in array.shape[-2:]),
+                tuple(float(d) for d in sampling),
+                float(inner),
+                float(outer),
+                int(nbins_radial),
+                int(nbins_azimuthal),
+                float(rotation),
+                tuple(float(o) for o in offset),
+                bool(fftshift),
+            ),
+            indices,
         )
 
         new_shape = array.shape[:-2] + (nbins_radial, nbins_azimuthal)
@@ -3737,7 +3860,7 @@ class DiffractionPatterns(_BaseMeasurement2D):
                 -1,
                 array.shape[-2] * array.shape[-1],
             )
-        )[..., np.concatenate(indices)]
+        )[..., flat_indices]
 
         # Use the configured floating-point precision, not a hardcoded float32.
         # _AbstractRadialDetector._out_dtype returns get_dtype(complex=False), so

--- a/test/test_detector_bin_cache.py
+++ b/test/test_detector_bin_cache.py
@@ -1,0 +1,90 @@
+"""Detector bin geometry is cached rather than rebuilt per detect call."""
+
+import numpy as np
+import pytest
+
+import abtem
+import abtem.measurements as M
+
+
+BINS_KWARGS = dict(
+    gpts=(128, 128),
+    sampling=(0.05, 0.05),
+    inner=0.0,
+    outer=50.0,
+    nbins_radial=10,
+    nbins_azimuthal=1,
+)
+
+
+def test_polar_detector_bins_are_cached():
+    M._polar_detector_bins_cached.cache_clear()
+
+    first = M._polar_detector_bins(**BINS_KWARGS)
+    second = M._polar_detector_bins(**BINS_KWARGS)
+
+    assert first is second
+    info = M._polar_detector_bins_cached.cache_info()
+    assert info.hits == 1 and info.misses == 1
+
+
+def test_cached_bins_are_read_only():
+    """Callers share the cached arrays, so they must not be mutable."""
+    bins = M._polar_detector_bins(**BINS_KWARGS)
+    with pytest.raises(ValueError):
+        bins[0, 0] = 123
+
+
+def test_cached_bins_match_the_uncached_computation():
+    M._polar_detector_bins_cached.cache_clear()
+
+    cached = M._polar_detector_bins(**BINS_KWARGS)
+    uncached = M._polar_detector_bins_uncached(**BINS_KWARGS)
+
+    assert np.array_equal(cached, uncached)
+
+
+def test_differing_geometry_is_not_confused():
+    a = M._polar_detector_bins(**BINS_KWARGS)
+    b = M._polar_detector_bins(**{**BINS_KWARGS, "outer": 30.0})
+    c = M._polar_detector_bins(**{**BINS_KWARGS, "nbins_radial": 5})
+
+    assert a is not b and a is not c
+    assert not np.array_equal(a, b)
+
+
+def test_device_index_arrays_are_cached_per_device():
+    indices = M._polar_detector_bins(**{**BINS_KWARGS, "return_indices": True})
+    key = ((128, 128), (0.05, 0.05), 0.0, 50.0, 10, 1, 0.0, (0.0, 0.0), False)
+
+    M._RADIAL_BINNING_DEVICE_CACHE.clear()
+    flat_a, sep_a = M._radial_binning_device_arrays(np, key, indices)
+    flat_b, sep_b = M._radial_binning_device_arrays(np, key, indices)
+
+    assert flat_a is flat_b and sep_a is sep_b
+    assert np.array_equal(flat_a, np.concatenate(indices))
+    assert int(sep_a[-1]) == sum(len(i) for i in indices)
+
+
+def test_radial_detectors_give_unchanged_results():
+    """The cache must not change what a detector produces."""
+    from abtem.core import config
+
+    with config.set({"device": "cpu"}):
+        probe = abtem.Probe(
+            energy=100e3, semiangle_cutoff=20, gpts=(64, 64), extent=(10.0, 10.0)
+        )
+        waves = probe.build(lazy=False)
+
+        for detector in (
+            abtem.FlexibleAnnularDetector(),
+            abtem.SegmentedDetector(
+                inner=20, outer=60, nbins_radial=2, nbins_azimuthal=4
+            ),
+        ):
+            M._polar_detector_bins_cached.cache_clear()
+            M._RADIAL_BINNING_DEVICE_CACHE.clear()
+            first = np.asarray(detector.detect(waves).array)
+            second = np.asarray(detector.detect(waves).array)  # served from cache
+            assert np.allclose(first, second, rtol=0, atol=0)
+            assert M._polar_detector_bins_cached.cache_info().hits >= 1

--- a/test/test_detector_bin_cache.py
+++ b/test/test_detector_bin_cache.py
@@ -53,17 +53,48 @@ def test_differing_geometry_is_not_confused():
     assert not np.array_equal(a, b)
 
 
+_GEOMETRY_KWARGS = dict(
+    {k: v for k, v in BINS_KWARGS.items() if k != "gpts"},
+    rotation=0.0,
+    offset=(0.0, 0.0),
+    fftshift=False,
+)
+
+
 def test_device_index_arrays_are_cached_per_device():
-    indices = M._polar_detector_bins(**{**BINS_KWARGS, "return_indices": True})
-    key = ((128, 128), (0.05, 0.05), 0.0, 50.0, 10, 1, 0.0, (0.0, 0.0), False)
+    array = np.zeros((2, *BINS_KWARGS["gpts"]))
 
     M._RADIAL_BINNING_DEVICE_CACHE.clear()
-    flat_a, sep_a = M._radial_binning_device_arrays(np, key, indices)
-    flat_b, sep_b = M._radial_binning_device_arrays(np, key, indices)
+    flat_a, sep_a = M._radial_binning_device_arrays(array, **_GEOMETRY_KWARGS)
+    flat_b, sep_b = M._radial_binning_device_arrays(array, **_GEOMETRY_KWARGS)
 
     assert flat_a is flat_b and sep_a is sep_b
+    indices = M._polar_detector_bins(**{**BINS_KWARGS, "return_indices": True})
     assert np.array_equal(flat_a, np.concatenate(indices))
     assert int(sep_a[-1]) == sum(len(i) for i in indices)
+    # Shared between callers, so they must not be mutable (cpu arrays only;
+    # cupy arrays cannot be flagged).
+    assert not flat_a.flags.writeable and not sep_a.flags.writeable
+
+
+def test_device_cache_evicts_least_recently_used():
+    """A hot entry survives inserts beyond the bound; the stalest is evicted."""
+    array = np.zeros((1, *BINS_KWARGS["gpts"]))
+
+    M._RADIAL_BINNING_DEVICE_CACHE.clear()
+    hot, _ = M._radial_binning_device_arrays(array, **_GEOMETRY_KWARGS)
+
+    for i in range(M._RADIAL_BINNING_DEVICE_CACHE_MAX + 3):
+        M._radial_binning_device_arrays(
+            array, **{**_GEOMETRY_KWARGS, "outer": 30.0 + i}
+        )
+        M._radial_binning_device_arrays(array, **_GEOMETRY_KWARGS)
+
+    again, _ = M._radial_binning_device_arrays(array, **_GEOMETRY_KWARGS)
+    assert again is hot
+    assert (
+        len(M._RADIAL_BINNING_DEVICE_CACHE) <= M._RADIAL_BINNING_DEVICE_CACHE_MAX
+    )
 
 
 def test_radial_detectors_give_unchanged_results():
@@ -87,4 +118,7 @@ def test_radial_detectors_give_unchanged_results():
             first = np.asarray(detector.detect(waves).array)
             second = np.asarray(detector.detect(waves).array)  # served from cache
             assert np.allclose(first, second, rtol=0, atol=0)
-            assert M._polar_detector_bins_cached.cache_info().hits >= 1
+            # The repeat call is served from the device cache without even
+            # touching the host-side geometry cache again.
+            info = M._polar_detector_bins_cached.cache_info()
+            assert info.misses == 1 and len(M._RADIAL_BINNING_DEVICE_CACHE) == 1

--- a/test/test_detector_bin_cache.py
+++ b/test/test_detector_bin_cache.py
@@ -64,7 +64,7 @@ _GEOMETRY_KWARGS = dict(
 def test_device_index_arrays_are_cached_per_device():
     array = np.zeros((2, *BINS_KWARGS["gpts"]))
 
-    M._RADIAL_BINNING_DEVICE_CACHE.clear()
+    M._radial_binning_device_arrays_cached.cache_clear()
     flat_a, sep_a = M._radial_binning_device_arrays(array, **_GEOMETRY_KWARGS)
     flat_b, sep_b = M._radial_binning_device_arrays(array, **_GEOMETRY_KWARGS)
 
@@ -81,10 +81,11 @@ def test_device_cache_evicts_least_recently_used():
     """A hot entry survives inserts beyond the bound; the stalest is evicted."""
     array = np.zeros((1, *BINS_KWARGS["gpts"]))
 
-    M._RADIAL_BINNING_DEVICE_CACHE.clear()
+    M._radial_binning_device_arrays_cached.cache_clear()
     hot, _ = M._radial_binning_device_arrays(array, **_GEOMETRY_KWARGS)
 
-    for i in range(M._RADIAL_BINNING_DEVICE_CACHE_MAX + 3):
+    maxsize = M._radial_binning_device_arrays_cached.cache_info().maxsize
+    for i in range(maxsize + 3):
         M._radial_binning_device_arrays(
             array, **{**_GEOMETRY_KWARGS, "outer": 30.0 + i}
         )
@@ -92,9 +93,8 @@ def test_device_cache_evicts_least_recently_used():
 
     again, _ = M._radial_binning_device_arrays(array, **_GEOMETRY_KWARGS)
     assert again is hot
-    assert (
-        len(M._RADIAL_BINNING_DEVICE_CACHE) <= M._RADIAL_BINNING_DEVICE_CACHE_MAX
-    )
+    info = M._radial_binning_device_arrays_cached.cache_info()
+    assert info.currsize <= info.maxsize
 
 
 def test_radial_detectors_give_unchanged_results():
@@ -114,11 +114,34 @@ def test_radial_detectors_give_unchanged_results():
             ),
         ):
             M._polar_detector_bins_cached.cache_clear()
-            M._RADIAL_BINNING_DEVICE_CACHE.clear()
+            M._radial_binning_device_arrays_cached.cache_clear()
             first = np.asarray(detector.detect(waves).array)
             second = np.asarray(detector.detect(waves).array)  # served from cache
             assert np.allclose(first, second, rtol=0, atol=0)
             # The repeat call is served from the device cache without even
             # touching the host-side geometry cache again.
             info = M._polar_detector_bins_cached.cache_info()
-            assert info.misses == 1 and len(M._RADIAL_BINNING_DEVICE_CACHE) == 1
+            device_info = M._radial_binning_device_arrays_cached.cache_info()
+            assert info.misses == 1 and device_info.currsize == 1
+
+
+def test_device_cache_is_thread_safe_under_churn():
+    """Concurrent misses beyond the bound must not race the eviction (the
+    hand-rolled predecessor could KeyError under the threaded scheduler)."""
+    import concurrent.futures
+
+    array = np.zeros((1, *BINS_KWARGS["gpts"]))
+    M._radial_binning_device_arrays_cached.cache_clear()
+
+    def hammer(worker):
+        for j in range(30):
+            outer = 20.0 + (worker * 30 + j) % 12  # > maxsize distinct keys
+            M._radial_binning_device_arrays(
+                array, **{**_GEOMETRY_KWARGS, "outer": outer}
+            )
+
+    with concurrent.futures.ThreadPoolExecutor(8) as pool:
+        list(pool.map(hammer, range(8)))
+
+    info = M._radial_binning_device_arrays_cached.cache_info()
+    assert info.currsize <= info.maxsize

--- a/test/test_fft.py
+++ b/test/test_fft.py
@@ -298,3 +298,36 @@ def test_cufft_cache_config_edge_values():
     # Restore the shipped default for subsequent tests.
     abtem_fft._CUFFT_CACHE_STATE = None
     abtem_fft._configure_cufft_cache()
+
+
+def test_plan_cache_entry_limit_is_raised():
+    cp = pytest.importorskip("cupy")
+    try:
+        if cp.cuda.runtime.getDeviceCount() < 1:
+            pytest.skip("no GPU available")
+    except Exception:
+        pytest.skip("no usable CUDA/HIP runtime")
+
+    from abtem.core import config
+    from abtem.core import fft as abtem_fft
+
+    cache = cp.fft.config.get_plan_cache()
+
+    # CuPy's own default of 16 thrashes for varying batch shapes.
+    abtem_fft._CUFFT_CACHE_STATE = None
+    abtem_fft._configure_cufft_cache()
+    assert cache.get_size() == 64
+
+    abtem_fft._CUFFT_CACHE_STATE = None
+    with config.set({"cupy.fft-cache-entries": 128}):
+        abtem_fft._configure_cufft_cache()
+        assert cache.get_size() == 128
+
+    # Disabling the cache still wins over the entry count.
+    abtem_fft._CUFFT_CACHE_STATE = None
+    with config.set({"cupy.fft-cache-size": "0 MB"}):
+        abtem_fft._configure_cufft_cache()
+        assert cache.get_size() == 0
+
+    abtem_fft._CUFFT_CACHE_STATE = None
+    abtem_fft._configure_cufft_cache()

--- a/test/test_fft.py
+++ b/test/test_fft.py
@@ -205,18 +205,18 @@ def test_cufft_cache_auto_resolves_device_relative():
 
     expected = cp.cuda.Device().mem_info[1] // 4
 
-    abtem_fft._CUFFT_CACHE_STATE = None
+    abtem_fft._reset_cufft_cache_state()
     with config.set({"cupy.fft-cache-size": "auto"}):
         abtem_fft._configure_cufft_cache()
-        assert abtem_fft._CUFFT_CACHE_STATE is not None
-        assert abtem_fft._CUFFT_CACHE_STATE[1] == expected
+        assert getattr(abtem_fft._CUFFT_CACHE_STATE, "token", None) is not None
+        assert abtem_fft._CUFFT_CACHE_STATE.limit == expected
         assert cp.fft.config.get_plan_cache().get_memsize() == expected
 
     # -1 must still mean unlimited (no memsize bound applied).
-    abtem_fft._CUFFT_CACHE_STATE = None
+    abtem_fft._reset_cufft_cache_state()
     with config.set({"cupy.fft-cache-size": -1}):
         abtem_fft._configure_cufft_cache()
-        assert abtem_fft._CUFFT_CACHE_STATE[1] == -1
+        assert abtem_fft._CUFFT_CACHE_STATE.limit == -1
 
 
 def test_oversized_plan_bypasses_cache():
@@ -269,38 +269,38 @@ def test_cufft_cache_config_edge_values():
     cache = cp.fft.config.get_plan_cache()
 
     # -1 must undo an earlier bound (the oversized-plan warning recommends it).
-    abtem_fft._CUFFT_CACHE_STATE = None
+    abtem_fft._reset_cufft_cache_state()
     with config.set({"cupy.fft-cache-size": "auto"}):
         abtem_fft._configure_cufft_cache()
         assert cache.get_memsize() > 0
-    abtem_fft._CUFFT_CACHE_STATE = None
+    abtem_fft._reset_cufft_cache_state()
     with config.set({"cupy.fft-cache-size": -1}):
         abtem_fft._configure_cufft_cache()
         assert cache.get_memsize() == -1
 
     # null means "no bound" rather than crashing.
-    abtem_fft._CUFFT_CACHE_STATE = None
+    abtem_fft._reset_cufft_cache_state()
     with config.set({"cupy.fft-cache-size": None}):
         abtem_fft._configure_cufft_cache()
         assert cache.get_memsize() == -1
 
     # A positive bound re-enables a previously disabled cache.
-    abtem_fft._CUFFT_CACHE_STATE = None
+    abtem_fft._reset_cufft_cache_state()
     with config.set({"cupy.fft-cache-size": "0 MB"}):
         abtem_fft._configure_cufft_cache()
         assert cache.get_size() == 0
-    abtem_fft._CUFFT_CACHE_STATE = None
+    abtem_fft._reset_cufft_cache_state()
     with config.set({"cupy.fft-cache-size": "1 GB"}):
         abtem_fft._configure_cufft_cache()
         assert cache.get_size() > 0
         assert cache.get_memsize() == 10**9
 
     # Restore the shipped default for subsequent tests.
-    abtem_fft._CUFFT_CACHE_STATE = None
+    abtem_fft._reset_cufft_cache_state()
     abtem_fft._configure_cufft_cache()
 
 
-def test_plan_cache_entry_limit_is_raised():
+def test_plan_cache_entry_limit():
     cp = pytest.importorskip("cupy")
     try:
         if cp.cuda.runtime.getDeviceCount() < 1:
@@ -313,21 +313,38 @@ def test_plan_cache_entry_limit_is_raised():
 
     cache = cp.fft.config.get_plan_cache()
 
-    # CuPy's own default of 16 thrashes for varying batch shapes.
-    abtem_fft._CUFFT_CACHE_STATE = None
-    abtem_fft._configure_cufft_cache()
-    assert cache.get_size() == 64
+    try:
+        # CuPy's own default of 16 thrashes for varying batch shapes.
+        cache.set_size(16)
+        abtem_fft._reset_cufft_cache_state()
+        with config.set({"cupy.fft-cache-entries": 64}):
+            abtem_fft._configure_cufft_cache()
+            assert cache.get_size() == 64
 
-    abtem_fft._CUFFT_CACHE_STATE = None
-    with config.set({"cupy.fft-cache-entries": 128}):
+        # Raised, never lowered: an externally tuned larger cache is kept.
+        cache.set_size(256)
+        abtem_fft._reset_cufft_cache_state()
+        with config.set({"cupy.fft-cache-entries": 64}):
+            abtem_fft._configure_cufft_cache()
+            assert cache.get_size() == 256
+
+        # Invalid or opt-out values leave the entry count alone; they must
+        # never raise, as this runs ahead of every GPU FFT dispatch.
+        for bad in (None, -1, "not-a-number"):
+            cache.set_size(32)
+            abtem_fft._reset_cufft_cache_state()
+            with config.set({"cupy.fft-cache-entries": bad}):
+                abtem_fft._configure_cufft_cache()
+                assert cache.get_size() == 32, f"entries={bad!r}"
+
+        # Disabling the cache still wins over the entry count.
+        abtem_fft._reset_cufft_cache_state()
+        with config.set(
+            {"cupy.fft-cache-size": "0 MB", "cupy.fft-cache-entries": 64}
+        ):
+            abtem_fft._configure_cufft_cache()
+            assert cache.get_size() == 0
+    finally:
+        # Reapply the process configuration whatever happened above.
+        abtem_fft._reset_cufft_cache_state()
         abtem_fft._configure_cufft_cache()
-        assert cache.get_size() == 128
-
-    # Disabling the cache still wins over the entry count.
-    abtem_fft._CUFFT_CACHE_STATE = None
-    with config.set({"cupy.fft-cache-size": "0 MB"}):
-        abtem_fft._configure_cufft_cache()
-        assert cache.get_size() == 0
-
-    abtem_fft._CUFFT_CACHE_STATE = None
-    abtem_fft._configure_cufft_cache()


### PR DESCRIPTION

Hi Toma!

Second installment of the core-loss profiling series (after #375): two caches for work that is identical for every wave-function chunk but was rebuilt on each one. Both surfaced profiling core-loss scans but pay off for any chunked STEM workload — plain HAADF included.

## 1. cuFFT plan-cache entry limit (`cupy.fft-cache-entries`, default 64)

CuPy's plan cache keeps at most 16 plans. Workloads whose FFT batch dimension varies — a core-loss scan's scattering batches follow the number of sites passing the threshold — cycle through more than 16 distinct transform shapes within a few chunks and then rebuild plans continuously: profiling put ~30 % of a production scan's runtime in `_get_cufft_plan_nd`, and raising the limit made the same scan 18 % faster with identical results. The limit is now a config key applied alongside the existing `fft-cache-size` bound in `_configure_cufft_cache`: the entry count and the (#346) memsize bound compose, `0 MB` still disables the cache outright, and the applied-state token includes the entry count so runtime config changes take effect. The count is **raised, never lowered** — a cache someone tuned larger through CuPy's own API keeps its size, and `null` or a non-positive value opts out of touching the count entirely (invalid values never raise; this runs ahead of every GPU FFT dispatch). The applied-state token is thread-local, because CuPy's plan cache is per thread: the previous process-global token (from #346) configured only the first dispatching thread and left every other dask worker thread at CuPy's defaults — so this also makes the existing memsize bound actually apply on all threads. Frozen-phonon ensembles hit the same thrashing from ensemble batching, so plain imaging benefits too. (Known limitation, deliberate: the entry count treats the symptom — the root cause is that scattering batch sizes are data-dependent; bucketing them to repeating values, as `estimate_scan_batch_size` already does elsewhere, would bound the distinct shapes and is left as a follow-up.)

## 2. Polar detector-bin geometry cached instead of rebuilt per call

`_polar_detector_bins` builds full-grid polar coordinates on the host and, in `DiffractionPatterns._batch_integrate`, ships the resulting index arrays to the device — once per wave-function chunk, though the result depends only on the detector geometry and the grid. For a core-loss scan applying a `FlexibleAnnularDetector` per chunk, profiling put ~48 % of the runtime here. Two layers of caching fix it: the host-side geometry is `lru_cache`d (8 entries — they hold full-grid arrays, so the bound is deliberately small; returned containers are immutable tuples of read-only arrays), and the flat bin indices + separators are kept resident per (geometry, device) in a real LRU (8 entries, least-recently-used eviction), so the host-to-device copy happens once per geometry instead of once per chunk. Both caches key through one canonical `_polar_bins_key` helper, so the keys cannot drift apart, and the device cache keys on the device the diffraction array actually lives on (`array.device`), not the current-device context — safe under multi-GPU use.

One heads-up for the skewed-grids work (#282/#352): those branches add a `cell` argument to `_polar_detector_bins`, and an `ase.Cell` is not hashable, so the `lru_cache` key will need the cell flattened to a tuple when they rebase — happy to coordinate.

## Adversarial review

The branch went through the same adversarial review round as #375; the hardening commit addresses what it caught: `null`/`-1` for the new config key would have crashed every GPU FFT dispatch; the entry count clobbered externally tuned cache sizes; the state token being process-global left other threads unconfigured (a pre-existing #346 gap this branch now fixes); the device cache trusted callers to pass a matching key/indices pair, keyed on the current device instead of the array's, cleared wholesale at its bound, and retained more host memory than needed.

## Testing

New `test/test_fft.py` test: the entry limit follows the config (explicit values, grow-only, opt-out and invalid values, `0 MB` still wins), with try/finally restoration. New `test/test_detector_bin_cache.py`: cached geometry is identical to a fresh build and distinct geometries are not confused; repeat detects are served from the device cache; LRU eviction keeps hot entries; detector results are unchanged. Full local runs of the fft, measure, detect and ionization suites pass; an A/B benchmark on identical workloads gives bit-identical checksums with the caches on and off.

Best,
Paul

🤖 Written by [Claude Code](https://claude.com/claude-code) on Paul's behalf