### PR TITLE
Fixing consistency between Bloch and multislice for 3DED

### DIFF
--- a/abtem/bloch/dynamical.py
+++ b/abtem/bloch/dynamical.py
@@ -1815,6 +1815,12 @@ class BlochWaves:
         else:
             array = calculate_wave_functions(values, g_vec, extent, gpts, thicknesses)
 
+            if thicknesses.ndim == 0:
+                # a scalar thickness has no ensemble (thickness) axis; drop the spurious
+                # leading size-1 axis so the array matches the empty axis metadata (the
+                # lazy path already returns a 2D array in this case).
+                array = array[0]
+
         ensemble_axes_metadata: list[AxisMetadata] = []
 
         if isinstance(thicknesses, np.ndarray) and thicknesses.ndim > 0:

--- a/abtem/bloch/dynamical.py
+++ b/abtem/bloch/dynamical.py
@@ -225,7 +225,7 @@ def calculate_structure_factors(
 
     struct_factors = (
         xp.sum(
-            f_e * xp.exp(-2.0j * np.pi * positions @ hkl),
+            f_e * xp.exp(2.0j * np.pi * positions @ hkl),
             axis=0,
         )
         / atoms.cell.volume
@@ -282,14 +282,21 @@ def structure_factor_to_potential(
     """
     xp = get_array_module(structure_factor)
     structure_factor = structure_factor_1d_to_3d(structure_factor, hkl, gpts)
-    # Deliberately xp.fft rather than abtem.core.fft.ifftn: the FFTW backend
+    # Deliberately xp.fft rather than abtem.core.fft.fftn: the FFTW backend
     # behind that wrapper only ever transforms the trailing two axes, so it
     # would silently turn this 3D transform into a 2D one on CPU. The slow-FFT
     # diagnostic is requested explicitly instead -- this grid follows from
     # g_max and the cell, so it is essentially never a fast length.
-    warn_if_slow_gpu_fft(structure_factor, "ifftn")
-    potential = xp.fft.ifftn(structure_factor)
-    potential = potential * np.prod(potential.shape) / kappa
+    #
+    # calculate_structure_factors uses the standard crystallographic convention
+    # F(g) = sum_j f_j exp(+2pi i g.r_j), i.e. V(r) = sum_g F(g) exp(-2pi i g.r)
+    # is the correct Fourier synthesis -- exactly numpy's forward transform
+    # (fftn), not the inverse. Unlike ifftn, fftn carries no built-in 1/N
+    # normalization, so (unlike the previous ifftn-based version) the result
+    # must not be rescaled by the number of grid points.
+    warn_if_slow_gpu_fft(structure_factor, "fftn")
+    potential = xp.fft.fftn(structure_factor)
+    potential = potential / kappa
     potential -= potential.min()
     return potential.real
 

--- a/abtem/bloch/utils.py
+++ b/abtem/bloch/utils.py
@@ -123,12 +123,17 @@ def reciprocal_space_gpts(
     cell: np.ndarray | Cell,
     g_max: float,
 ) -> tuple[int, int, int]:
-    dk = 1 / cell_bounds(cell)
+    # The largest Miller index along axis i over the ellipsoid {hkl : |hkl @ B| <= g_max}
+    # is g_max * sqrt((B B^T)^-1)_ii = g_max * |a_i| (the lattice-vector length). Using the
+    # Cartesian bounding box instead under-sizes the grid for a non-orthogonal cell (the
+    # box can be smaller than |a_i| along some axis), dropping reflection differences from
+    # the dynamical matrix. For an orthogonal cell |a_i| equals the bounding box.
+    lengths = np.linalg.norm(np.array(cell, dtype=float), axis=1)
 
     gpts = (
-        int(np.ceil(g_max / dk[0])) * 2 + 1,
-        int(np.ceil(g_max / dk[1])) * 2 + 1,
-        int(np.ceil(g_max / dk[2])) * 2 + 1,
+        int(np.ceil(g_max * lengths[0])) * 2 + 1,
+        int(np.ceil(g_max * lengths[1])) * 2 + 1,
+        int(np.ceil(g_max * lengths[2])) * 2 + 1,
     )
     return gpts
 

--- a/abtem/bloch/utils.py
+++ b/abtem/bloch/utils.py
@@ -123,11 +123,12 @@ def reciprocal_space_gpts(
     cell: np.ndarray | Cell,
     g_max: float,
 ) -> tuple[int, int, int]:
-    # The largest Miller index along axis i over the ellipsoid {hkl : |hkl @ B| <= g_max}
-    # is g_max * sqrt((B B^T)^-1)_ii = g_max * |a_i| (the lattice-vector length). Using the
-    # Cartesian bounding box instead under-sizes the grid for a non-orthogonal cell (the
-    # box can be smaller than |a_i| along some axis), dropping reflection differences from
-    # the dynamical matrix. For an orthogonal cell |a_i| equals the bounding box.
+    # The largest Miller index along axis i over the ellipsoid {hkl : |hkl @ B| <=
+    # g_max} is g_max * sqrt((B B^T)^-1)_ii = g_max * |a_i| (the lattice-vector
+    # length). Using the Cartesian bounding box instead under-sizes the grid for a
+    # non-orthogonal cell (the box can be smaller than |a_i| along some axis),
+    # dropping reflection differences from the dynamical matrix. For an orthogonal
+    # cell |a_i| equals the bounding box.
     lengths = np.linalg.norm(np.array(cell, dtype=float), axis=1)
 
     gpts = (

--- a/test/test_bloch_waves.py
+++ b/test/test_bloch_waves.py
@@ -2,15 +2,20 @@ import numpy as np
 import pytest
 import strategies as abtem_st
 from ase import Atoms
+from ase.build import bulk
 from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 
 import abtem
+from abtem.atoms import orthogonalize_cell
+from abtem.bloch import BlochWaves, StructureFactor
+from abtem.bloch.dynamical import calculate_structure_factors
 from abtem.bloch.utils import (
     auto_detect_centering,
     relative_positions_for_centering,
     wrapped_is_close,
 )
+from abtem.parametrizations import LobatoParametrization
 
 
 @st.composite
@@ -134,3 +139,116 @@ def test_structure_factor_potential_requests_the_slow_fft_diagnostic():
 
     assert warner.call_count == 1
     assert potential.shape == (4, 4, 4)
+
+
+def test_structure_factor_matches_standard_crystallographic_sign_convention():
+    # calculate_structure_factors must compute F(g) = sum_j f_j(g) * exp(+2pi i
+    # g . r_j) / V, the standard International-Tables convention. abTEM previously
+    # computed the complex conjugate (exp(-2pi i ...)), which structure_factor_to_
+    # potential's ifftn happened to cancel when reconstructing a real-space potential
+    # (see test_potential_from_structure_factor), but calculate_structure_matrix
+    # consumes F(g) directly with no such cancellation -- so the wrong sign there
+    # gave Bloch-wave results inconsistent with multislice for non-centrosymmetric
+    # structures (reported from the 3DED project's independent cross-check against
+    # multislice). Verified here against a fully independent hand computation on an
+    # asymmetric, low-symmetry two-atom cell, where the two sign conventions give
+    # very different (not just complex-conjugate-equal) answers at general hkl.
+    atoms = Atoms(
+        "CO",
+        positions=[[0.3, 0.1, 0.0], [1.1, 0.4, 0.2]],
+        cell=[3.0, 3.5, 4.0],
+        pbc=True,
+    )
+    hkl = np.array([[1, 0, 0], [0, 1, 0], [1, 1, 0], [2, -1, 1]])
+
+    F_code = calculate_structure_factors(
+        hkl,
+        atoms,
+        parametrization="lobato",
+        g_max=3.0,
+        thermal_sigma=0.0,
+        occupancy=1.0,
+        device="cpu",
+    )
+
+    parametrization = LobatoParametrization()
+    reciprocal_cell = np.linalg.inv(np.asarray(atoms.cell)).T
+    g_vec = hkl @ reciprocal_cell
+    g_length_sq = (g_vec**2).sum(-1)
+
+    F_hand = np.zeros(len(hkl), dtype=complex)
+    for number, position in zip(atoms.numbers, atoms.positions):
+        f = parametrization.scattering_factor(int(number))(g_length_sq)
+        F_hand += f * np.exp(2.0j * np.pi * (g_vec @ position))
+    F_hand /= atoms.cell.volume
+
+    np.testing.assert_allclose(F_code, F_hand, atol=1e-7)
+
+    # the wrong (conjugate) sign would disagree by far more than float noise
+    F_hand_wrong_sign = np.zeros(len(hkl), dtype=complex)
+    for number, position in zip(atoms.numbers, atoms.positions):
+        f = parametrization.scattering_factor(int(number))(g_length_sq)
+        F_hand_wrong_sign += f * np.exp(-2.0j * np.pi * (g_vec @ position))
+    F_hand_wrong_sign /= atoms.cell.volume
+    assert np.max(np.abs(F_code - F_hand_wrong_sign)) > 1e-3
+
+
+def test_bloch_waves_on_skewed_cell_at_tilt_matches_orthogonalized_supercell():
+    # Regression test for a crash (ValueError: invalid entry in coordinates array,
+    # from np.ravel_multi_index in abtem.bloch.utils.ravel_hkl) that occurred
+    # reliably for non-orthogonal cells (hexagonal/rhombohedral angles near 120
+    # degrees are the worst case) once the tilt/beam selection was wide enough
+    # that calculate_structure_matrix needed structure-factor values at reflection
+    # differences outside the array bounds reciprocal_space_gpts sized for.
+    # Reported from the 3DED project's Bloch-wave cross-checks against multislice.
+    #
+    # Beyond "does it crash", this checks the fix is quantitatively correct: the
+    # hexagonal primitive cell's diffraction pattern, at a general (non-zone-axis)
+    # tilt, must match an orthogonalized supercell of the exact same crystal.
+    hex_atoms = bulk("Mg", "hcp", a=3.21, c=5.21)
+    hex_atoms.set_cell(
+        [hex_atoms.cell[0], hex_atoms.cell[1], [0.0, 0.0, 7.5]], scale_atoms=True
+    )
+    ortho_atoms = orthogonalize_cell(hex_atoms, max_repetitions=6)
+
+    orientation_matrix, _ = np.linalg.qr(
+        np.array([[0.95, 0.05, 0.1], [-0.05, 0.98, 0.15], [-0.1, -0.15, 0.97]])
+    )
+
+    def diffraction_pattern(atoms):
+        structure_factor = StructureFactor(
+            atoms, g_max=6.0, parametrization="lobato", thermal_sigma=0.0
+        )
+        bloch_waves = BlochWaves(
+            structure_factor=structure_factor,
+            energy=200e3,
+            sg_max=0.15,
+            orientation_matrix=orientation_matrix,
+            use_wave_eq=True,
+        )
+        return (
+            bloch_waves.calculate_diffraction_patterns(thicknesses=[50.0])
+            .to_cpu()
+            .compute()
+        )
+
+    dp_hex = diffraction_pattern(hex_atoms)
+    dp_ortho = diffraction_pattern(ortho_atoms)
+
+    g_hex = np.asarray(dp_hex.positions)[0]
+    g_ortho = np.asarray(dp_ortho.positions)[0]
+    intensity_hex = np.asarray(dp_hex.array)[0]
+    intensity_ortho = np.asarray(dp_ortho.array)[0]
+
+    # match each primitive-cell reflection to its supercell counterpart by
+    # physical reciprocal-space position (the two cells don't share hkl labels)
+    distances = np.linalg.norm(g_hex[:, None, :] - g_ortho[None, :, :], axis=-1)
+    nearest = distances.argmin(axis=1)
+    matched = distances[np.arange(len(g_hex)), nearest] < 1e-4
+    assert matched.mean() > 0.95  # nearly every primitive-cell reflection matches
+
+    a = intensity_hex[matched]
+    b = intensity_ortho[nearest[matched]]
+    keep = (a > 1e-9) | (b > 1e-9)
+    r1 = np.abs(a[keep] - b[keep]).sum() / b[keep].sum()
+    assert r1 < 1e-4


### PR DESCRIPTION
## Summary

Fixes two confirmed Bloch-wave/multislice consistency bugs surfaced by the
[py3DED project](https://github.com/3DED/py3DED)'s independent cross-checks
between the two simulation engines.

1. **Structure-factor sign convention** (`abtem/bloch/dynamical.py`).
   `calculate_structure_factors` computed the complex conjugate of the
   standard crystallographic convention (`exp(-2pi i g.r)` instead of
   `exp(+2pi i g.r)`). This was invisible to the existing potential
   round-trip test because `structure_factor_to_potential`'s `ifftn` happened
   to cancel the wrong sign when reconstructing a real-space potential — but
   `calculate_structure_matrix` consumes `F(g)` directly, with no such
   cancellation, so Bloch-wave diffraction was inconsistent with multislice.
   Fixed the sign and switched the paired transform from `ifftn` to `fftn`
   (dropping the now-unneeded `1/N` un-normalization) so potential
   reconstruction stays correct.

2. **Non-orthogonal-cell crash** (`abtem/bloch/utils.py`, cherry-picked from
   `da8a3220` on the unmerged `skewpixels` branch — same diagnosis, already
   fixed there). `calculate_structure_matrix` needs structure-factor values
   at *pairwise differences* of the selected beam set, but the array
   `reciprocal_space_gpts` sizes for them only (just barely) covered single
   reflections, using a Cartesian-bounding-box heuristic that ignores the
   reciprocal metric tensor. Non-orthogonal cells — hexagonal/rhombohedral
   angles near 120° are the worst case — hit this reliably:
   `ValueError: invalid entry in coordinates array` from `ravel_hkl`. Fixed
   by sizing the grid from the true per-axis bound, `g_max * |a_i|`.

## Tests

Two new regression tests in `test/test_bloch_waves.py`:

- `test_structure_factor_matches_standard_crystallographic_sign_convention`
  — checks `calculate_structure_factors` against an independent hand
  computation on an asymmetric two-atom cell (the wrong sign disagrees by
  far more than float noise, so this fails loudly on regression).
- `test_bloch_waves_on_skewed_cell_at_tilt_matches_orthogonalized_supercell`
  — reproduces the crash on a hexagonal cell at a general tilt, and checks
  the result quantitatively matches (R1 < 1e-4) an orthogonalized supercell
  of the same crystal.

All existing `test_bloch_waves.py` / `test_bloch_indexing.py` tests still
pass, including `test_potential_from_structure_factor` (confirms the
`ifftn`→`fftn` pairing still reconstructs the potential correctly).

## Note on a third, related report

The same 3DED cross-check also reported a thermal-sigma (Debye–Waller)
disagreement between the two engines. That turned out to already be fixed by
#271 (anisotropic DWF support), merged before this branch — no action needed
here. A fourth reported issue (rotation-axis orientation) was investigated at
length and could not be reproduced as a code-level bug; every
orientation/rotation-matrix convention shared between the two engines was
traced and found mutually consistent.

Thanks to @pbklar for reporting these!

🤖 Generated with [Claude Code](https://claude.com/claude-code)
