### PR TITLE
Fix cupyx signal import guard

### DIFF
--- a/abtem/core/_cuda.py
+++ b/abtem/core/_cuda.py
@@ -60,7 +60,7 @@ _sum_rle_f64 = None
 def _init_sum_rle_kernels():
     global _sum_rle_f32, _sum_rle_f64
     if _sum_rle_f32 is None:
-        mod = cp.RawModule(code=_SUM_RLE_KERNEL, options=("--std=c++14",))
+        mod = cp.RawModule(code=_SUM_RLE_KERNEL, options=("--std=c++17",))
         _sum_rle_f32 = mod.get_function("sum_rle_f32")
         _sum_rle_f64 = mod.get_function("sum_rle_f64")
 
@@ -227,7 +227,7 @@ _interpolate_radial_f64 = None
 def _init_interpolate_radial_kernels():
     global _interpolate_radial_f32, _interpolate_radial_f64
     if _interpolate_radial_f32 is None:
-        mod = cp.RawModule(code=_INTERPOLATE_RADIAL_KERNEL, options=("--std=c++14",))
+        mod = cp.RawModule(code=_INTERPOLATE_RADIAL_KERNEL, options=("--std=c++17",))
         _interpolate_radial_f32 = mod.get_function("interpolate_radial_f32")
         _interpolate_radial_f64 = mod.get_function("interpolate_radial_f64")
 

--- a/abtem/core/_cuda.py
+++ b/abtem/core/_cuda.py
@@ -60,7 +60,9 @@ _sum_rle_f64 = None
 def _init_sum_rle_kernels():
     global _sum_rle_f32, _sum_rle_f64
     if _sum_rle_f32 is None:
-        mod = cp.RawModule(code=_SUM_RLE_KERNEL, options=("--std=c++17",))
+        # no --std option: rely on each backend's default dialect, which tracks
+        # CuPy's bundled headers (see finite_difference._init_laplace_stencil_kernels)
+        mod = cp.RawModule(code=_SUM_RLE_KERNEL)
         _sum_rle_f32 = mod.get_function("sum_rle_f32")
         _sum_rle_f64 = mod.get_function("sum_rle_f64")
 
@@ -227,7 +229,7 @@ _interpolate_radial_f64 = None
 def _init_interpolate_radial_kernels():
     global _interpolate_radial_f32, _interpolate_radial_f64
     if _interpolate_radial_f32 is None:
-        mod = cp.RawModule(code=_INTERPOLATE_RADIAL_KERNEL, options=("--std=c++17",))
+        mod = cp.RawModule(code=_INTERPOLATE_RADIAL_KERNEL)
         _interpolate_radial_f32 = mod.get_function("interpolate_radial_f32")
         _interpolate_radial_f64 = mod.get_function("interpolate_radial_f64")
 

--- a/abtem/core/backend.py
+++ b/abtem/core/backend.py
@@ -52,7 +52,11 @@ try:
         warnings.simplefilter("ignore", FutureWarning)
         import cupyx.scipy.signal  # type: ignore  # noqa: F401
 except ImportError:
-    assert cupyx is None
+    # this can fail even though cupyx itself imported: cupyx.scipy.signal
+    # eagerly imports cuBLAS-backed submodules, so an environment without the
+    # CUDA/ROCm libraries on the loader path fails here. GPU filters that need
+    # scipy.signal then fail at use time instead of blocking the abtem import.
+    pass
 
 
 ArrayModule = Union[ModuleType, str]

--- a/abtem/core/backend.py
+++ b/abtem/core/backend.py
@@ -39,7 +39,10 @@ except ImportError:
 try:
     import cupyx.scipy.ndimage as cupyx_ndimage  # type: ignore
 except ImportError:
-    assert cupyx is None
+    # same reasoning as the cupyx.scipy.signal guard below: this can fail even
+    # though cupyx itself imported, if the CUDA/ROCm libraries it eagerly
+    # pulls in aren't on the loader path. GPU code that needs cupyx_ndimage
+    # then fails at use time instead of blocking the abtem import.
     cupyx_ndimage = None
 
 

--- a/abtem/finite_difference.py
+++ b/abtem/finite_difference.py
@@ -248,7 +248,11 @@ _laplace_stencil_c128 = None
 def _init_laplace_stencil_kernels():
     global _laplace_stencil_c64, _laplace_stencil_c128
     if _laplace_stencil_c64 is None:
-        mod = cp.RawModule(code=_LAPLACE_STENCIL_KERNEL, options=("--std=c++17",))
+        # no --std option: the dialect requirement comes from CuPy's bundled
+        # headers, and each backend's default tracks them (CuPy itself pins no
+        # dialect); pinning one broke NVRTC when CuPy 14's complex.cuh started
+        # requiring C++17 via CCCL
+        mod = cp.RawModule(code=_LAPLACE_STENCIL_KERNEL)
         # _laplace_stencil_c64 doubles as the initialized-guard, so it is
         # assigned last: a concurrent thread that observes it non-None is then
         # guaranteed to also observe _laplace_stencil_c128 (redundant module

--- a/abtem/finite_difference.py
+++ b/abtem/finite_difference.py
@@ -401,6 +401,11 @@ class LaplaceOperator:
         """
         Centered finite-difference laplacian operator.
 
+        Operates on complex wave arrays: the stencil coefficients are cast to
+        the configured complex dtype, so the stencils are specialized for
+        complex64/complex128 input even though the Laplacian itself is a real
+        operator.
+
         Parameters
         ----------
         accuracy: int

--- a/abtem/finite_difference.py
+++ b/abtem/finite_difference.py
@@ -248,7 +248,7 @@ _laplace_stencil_c128 = None
 def _init_laplace_stencil_kernels():
     global _laplace_stencil_c64, _laplace_stencil_c128
     if _laplace_stencil_c64 is None:
-        mod = cp.RawModule(code=_LAPLACE_STENCIL_KERNEL, options=("--std=c++14",))
+        mod = cp.RawModule(code=_LAPLACE_STENCIL_KERNEL, options=("--std=c++17",))
         # _laplace_stencil_c64 doubles as the initialized-guard, so it is
         # assigned last: a concurrent thread that observes it non-None is then
         # guaranteed to also observe _laplace_stencil_c128 (redundant module


### PR DESCRIPTION
Follow-up to #376 with two fixes: one commit that missed the merge window, and a portability bug that CUDA validation on Perlmutter caught after the merge.

**1. Don't block the abtem import when `cupyx.scipy.signal` fails to load** (47abc7b3, cherry-picked from the #376 branch — it landed there minutes after the merge). The guarded import asserted that an ImportError implies cupyx itself is missing, but `cupyx.scipy.signal` eagerly imports cuBLAS-backed submodules, so it can fail in an environment where cupy imports fine and the CUDA/ROCm libraries are simply not on the loader path (observed on Perlmutter with `cupy-cuda12x` and no cudatoolkit module loaded: `libcublas.so.12` not found → the assert killed every `import abtem`, including CPU-only use). Failure now degrades gracefully: GPU filters needing `scipy.signal` raise at use time, as before #376.

**2. Stop pinning a C++ dialect in the RawModule kernels** (2dc3f4e7 + 6b7e9542). Validating #376 on an A100 (Perlmutter, CuPy 14.2.0, CUDA 12.9) caught this — and confirms the concern raised in review about the hardcoded compiler options: CuPy 14 routes `cupy/complex.cuh` through its bundled CCCL headers, which reject anything below C++17, so the Laplacian stencil failed to compile under NVRTC with `--std=c++14` ("Thrust requires at least C++17"); the amd-cupy 13.5.1 ROCm build doesn't chain `complex.cuh` into CCCL, which is why hipRTC accepted it during development. Rather than repinning (first commit bumps to C++17, second removes the pin), the kernels now pass no `--std` at all: their own source needs nothing beyond C++11, the dialect requirement comes from CuPy's bundled headers, and each backend's default tracks those headers — CuPy pins no dialect for its own kernels either, so this matches the configuration CuPy tests everywhere. The two kernels in `core/_cuda.py` are unpinned as well (they compiled on CuPy 14 only because they avoid `complex.cuh`).

A final commit adds a docstring note that `LaplaceOperator` is specialized for complex input (the Laplacian itself is a real operator; the restriction comes from the stencil coefficients being cast to the configured complex dtype).

**Validation.** ROCm 7.2.0/hipRTC (gfx1151): all three RawModule kernels compile and run without a pinned dialect; the stencil matches the CPU reference to machine precision for both complex dtypes; 156 kernel-consumer tests green. CUDA (Perlmutter A100, CuPy 14.2.0, CUDA 12.9, at 6b7e9542): stencil reference tests `9 passed`; full GPU sweep (`-k gpu -m "not multigpu"`) `537 passed, 152 skipped, 0 failed` in 6:07. The #376 GPU stencil tests are what caught (2) on first contact with real CUDA.

🤖 Written by [Claude Code](https://claude.com/claude-code) — Paul reviewed and posted it