### PR TITLE
Raise a clear error before OOM in Bloch-wave eigendecomposition

### DIFF
--- a/abtem/bloch/dynamical.py
+++ b/abtem/bloch/dynamical.py
@@ -917,7 +917,18 @@ def calculate_structure_matrix(
 
     Mii = xp.asarray(Mii)
 
-    A = A * prefactor * Mii[None] * Mii[:, None]
+    # `A = A * prefactor * Mii[None] * Mii[:, None]` would keep the old A
+    # alive (still bound to the name) through all three multiplications,
+    # needing 2x A's footprint at once for the whole chain -- for a ~13GB
+    # structure matrix that is the difference between fitting on a 24GB GPU
+    # and not. The first multiplication can't be done in place (A may be
+    # read-only here, e.g. from the pandas round-trip in
+    # retrieve_structure_factor_values) but it produces a fresh, writable
+    # array as a side effect, so the old A is freed right after this line
+    # instead of being held through the rest of the chain.
+    A = A * prefactor
+    A *= Mii[None]
+    A *= Mii[:, None]
 
     sg = xp.asarray(excitation_errors(g, energy, use_wave_eq=use_wave_eq))
     diag = 2 * 1 / energy2wavelength(energy) * sg

--- a/abtem/bloch/dynamical.py
+++ b/abtem/bloch/dynamical.py
@@ -933,6 +933,52 @@ def plane_wave_coefficients(hkl: np.ndarray, xp) -> np.ndarray:
     return array
 
 
+def check_eigh_memory(structure_matrix: np.ndarray, safety_factor: float = 2.5) -> None:
+    """Raise a clear error if the Hermitian eigendecomposition of
+    `structure_matrix` is unlikely to fit in the memory currently available,
+    instead of letting a raw CUDA/numpy allocation failure propagate.
+
+    A dense `eigh` needs the input matrix, the output eigenvector matrix, and
+    solver workspace live at once, roughly 2-2.5x the size of the matrix
+    itself; `safety_factor` bundles all three into one multiple.
+
+    Parameters
+    ----------
+    structure_matrix : numpy.ndarray
+        The (N, N) structure matrix about to be passed to `eigh`.
+    safety_factor : float
+        Multiple of the structure matrix's own byte size budgeted for the
+        eigenvector output and solver workspace held simultaneously.
+    """
+    n = structure_matrix.shape[-1]
+    itemsize = structure_matrix.dtype.itemsize
+    required_bytes = int(n**2 * itemsize * safety_factor)
+
+    xp = get_array_module(structure_matrix)
+
+    if xp is cp:
+        free_bytes, _ = cp.cuda.Device().mem_info
+        available_bytes = free_bytes + cp.get_default_memory_pool().free_bytes()
+        device_str = "GPU"
+    else:
+        try:
+            import psutil
+
+            available_bytes = psutil.virtual_memory().available
+        except ImportError:
+            return
+        device_str = "CPU"
+
+    if required_bytes > available_bytes:
+        raise MemoryError(
+            f"eigendecomposition of the {n}x{n} structure matrix ({n} Bloch "
+            f"beams) needs an estimated {required_bytes / 1e9:.1f} GB, but only "
+            f"{available_bytes / 1e9:.1f} GB is available on the {device_str}. "
+            "Reduce `g_max` and/or `sg_max` to select fewer beams, or run on a "
+            "device with more memory."
+        )
+
+
 def calculate_dynamical_scattering(
     structure_matrix: np.ndarray,
     hkl: np.ndarray,
@@ -967,6 +1013,8 @@ def calculate_dynamical_scattering(
     thicknesses = np.asarray(thicknesses)
 
     Mii = xp.asarray(calculate_M_matrix(hkl, cell, energy))
+
+    check_eigh_memory(structure_matrix)
 
     v, C = xp.linalg.eigh(structure_matrix)
     # v, C = scipy.linalg.eigh(structure_matrix)

--- a/abtem/bloch/dynamical.py
+++ b/abtem/bloch/dynamical.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import gc
 import itertools
 import warnings
 from abc import ABCMeta, abstractmethod
@@ -958,14 +957,6 @@ def check_eigh_memory(structure_matrix: np.ndarray, safety_factor: float = 2.5) 
     xp = get_array_module(structure_matrix)
 
     if xp is cp:
-        # A structure matrix from a prior, crashed call to this same function
-        # can stay reachable through its own exception traceback (every frame
-        # between the `raise` and the caller's `except` keeps its locals
-        # alive) until the cycle collector runs, so cupy's pool never sees it
-        # freed and mem_info() undercounts what is genuinely available.
-        # Collecting first, before reading memory state, avoids repeatedly
-        # tripping this check on a retry loop.
-        gc.collect()
         free_bytes, _ = cp.cuda.Device().mem_info
         available_bytes = free_bytes + cp.get_default_memory_pool().free_bytes()
         device_str = "GPU"
@@ -1025,24 +1016,7 @@ def calculate_dynamical_scattering(
 
     check_eigh_memory(structure_matrix)
 
-    try:
-        v, C = xp.linalg.eigh(structure_matrix)
-    except Exception as exc:
-        # The pre-flight check above estimates from a fixed safety factor and
-        # a point-in-time memory reading; it can't account for allocator
-        # fragmentation (a same-total-bytes-but-no-single-large-enough-block
-        # situation) or memory another task grabs between the check and this
-        # call. Catch the actual failure too, so it still surfaces as the
-        # same actionable message rather than a raw CUDA/numpy error.
-        if xp is cp and isinstance(exc, cp.cuda.memory.OutOfMemoryError):
-            n = structure_matrix.shape[-1]
-            raise MemoryError(
-                f"eigendecomposition of the {n}x{n} structure matrix ({n} "
-                f"Bloch beams) ran out of GPU memory during allocation. "
-                "Reduce `g_max` and/or `sg_max` to select fewer beams, or "
-                "run on a device with more memory."
-            ) from exc
-        raise
+    v, C = xp.linalg.eigh(structure_matrix)
     # v, C = scipy.linalg.eigh(structure_matrix)
 
     gamma = v * energy2wavelength(energy) / 2.0

--- a/abtem/bloch/dynamical.py
+++ b/abtem/bloch/dynamical.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gc
 import itertools
 import warnings
 from abc import ABCMeta, abstractmethod
@@ -957,6 +958,14 @@ def check_eigh_memory(structure_matrix: np.ndarray, safety_factor: float = 2.5) 
     xp = get_array_module(structure_matrix)
 
     if xp is cp:
+        # A structure matrix from a prior, crashed call to this same function
+        # can stay reachable through its own exception traceback (every frame
+        # between the `raise` and the caller's `except` keeps its locals
+        # alive) until the cycle collector runs, so cupy's pool never sees it
+        # freed and mem_info() undercounts what is genuinely available.
+        # Collecting first, before reading memory state, avoids repeatedly
+        # tripping this check on a retry loop.
+        gc.collect()
         free_bytes, _ = cp.cuda.Device().mem_info
         available_bytes = free_bytes + cp.get_default_memory_pool().free_bytes()
         device_str = "GPU"
@@ -1016,7 +1025,24 @@ def calculate_dynamical_scattering(
 
     check_eigh_memory(structure_matrix)
 
-    v, C = xp.linalg.eigh(structure_matrix)
+    try:
+        v, C = xp.linalg.eigh(structure_matrix)
+    except Exception as exc:
+        # The pre-flight check above estimates from a fixed safety factor and
+        # a point-in-time memory reading; it can't account for allocator
+        # fragmentation (a same-total-bytes-but-no-single-large-enough-block
+        # situation) or memory another task grabs between the check and this
+        # call. Catch the actual failure too, so it still surfaces as the
+        # same actionable message rather than a raw CUDA/numpy error.
+        if xp is cp and isinstance(exc, cp.cuda.memory.OutOfMemoryError):
+            n = structure_matrix.shape[-1]
+            raise MemoryError(
+                f"eigendecomposition of the {n}x{n} structure matrix ({n} "
+                f"Bloch beams) ran out of GPU memory during allocation. "
+                "Reduce `g_max` and/or `sg_max` to select fewer beams, or "
+                "run on a device with more memory."
+            ) from exc
+        raise
     # v, C = scipy.linalg.eigh(structure_matrix)
 
     gamma = v * energy2wavelength(energy) / 2.0


### PR DESCRIPTION
## Summary
- Large unit cells at high `g_max` (e.g. triclinic structures like kyanite) can select tens of thousands of beams, making the dense structure matrix passed to `eigh()` in `calculate_dynamical_scattering` too large for available VRAM/RAM — this previously surfaced as a raw, confusing CUDA/numpy `OutOfMemoryError` deep inside the solver.
- Adds `check_eigh_memory()` in `abtem/bloch/dynamical.py`, called just before `eigh`. It estimates peak bytes needed (matrix + eigenvectors + solver workspace, ~2.5x the matrix size) from the beam count and dtype, and compares against live free memory (`cp.cuda.Device().mem_info()` on GPU, `psutil.virtual_memory().available` on CPU, softly skipped if `psutil` isn't installed).
- On insufficient memory, raises `MemoryError` naming the beam count and suggesting a lower `g_max`/`sg_max`, instead of letting the raw allocation failure propagate.

Found while cross-validating PR #379 against real production-scale 3DED simulations (py3DED project): a kyanite (Al2SiO5, triclinic) structure at `g_max=8.0`, `sg_max=1.0` selected 28,898 beams and crashed with a 13.36GB CUDA allocation failure inside `eigh` — matching `N**2 * 16 bytes` for `N=28898`. This is a real scaling wall for large unit cells / high `g_max`, not a correctness bug; this PR turns the crash into an actionable error.

## Test plan
- [x] `test/test_bloch_waves.py` (11 tests) passes unmodified on top of this change
- [x] Manually verified `check_eigh_memory` raises `MemoryError` when available memory is mocked low, and stays silent for normal-sized matrices with real available memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)
