### PR TITLE
Add the GPU test runner and define GPU validation (tools/gpu)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ dist
 # uv (no lock file: abTEM is a library, CI resolves fresh)
 uv.lock
 .venv/
+
+# tools/gpu/run_gpu_tests.sh in-place mode logs
+.gpu-test-logs/

--- a/tools/gpu/README.md
+++ b/tools/gpu/README.md
@@ -1,0 +1,61 @@
+# GPU testing
+
+GitHub CI has no GPU runner, so the GPU code paths — CuPy raw kernels and their runtime compilation (NVRTC on CUDA, hipRTC on ROCm), `cupyx` submodules, device-specific numerics — are exercised only on real hardware. Two bugs shipped in 2026-09 exactly this way: a kernel whose compiler options NVRTC rejected (invisible on the ROCm box it was developed on, [#376](https://github.com/abTEM/abTEM/pull/376) follow-up) and Thrust-backed sorts that segfault on some HIP builds. This directory holds the runner that would have caught both.
+
+## What "GPU-validated" means
+
+Two invocations, both green:
+
+```bash
+export OMP_NUM_THREADS=1
+python -m pytest test/test_realspace_multislice.py -q -k "StencilNumericalAccuracy or rejects"
+python -m pytest test/ -q -k gpu -m "not multigpu"
+```
+
+The first force-compiles the raw GPU kernels and compares them against the scipy reference — it fails fast on compiler/toolchain problems. The second runs every GPU-parameterized test (~540 as of 2026-09; the `--runslow`-gated ones stay skipped). Passing on one platform does not imply the other: CUDA/NVRTC and ROCm/hipRTC have caught disjoint bugs, so changes to GPU code should be validated on whichever platforms are available, ideally both.
+
+## Running
+
+`run_gpu_tests.sh` wraps both invocations with logging, a `status.tsv` history, and optional failure email.
+
+**Developer, testing the current checkout** (installs nothing, never touches git state; uses the active environment):
+
+```bash
+tools/gpu/run_gpu_tests.sh
+```
+
+The test dependencies come from the `test` dependency group (`uv pip install -e . --group test` or `pip install --group test .` with pip ≥ 25.1) plus a cupy matching your platform (`cupy-cuda12x`, or a ROCm build).
+
+**Unattended / cron** (`ABTEM_CI_ROOT` enables managed mode: the script maintains its own clone and venv there, hard-tracking `origin/dev`, and self-heals if a scratch purge deletes them):
+
+```bash
+ABTEM_CI_ROOT=$SCRATCH/abtem-gpu-ci \
+ABTEM_CI_MODULES="cudatoolkit/12.9" \
+ABTEM_CI_MAILTO=you@example.org \
+tools/gpu/run_gpu_tests.sh
+```
+
+Example: weekly on NERSC Perlmutter via `scrontab -e` (times are local; `-q shared --gpus 1 -c 32` charges ~¼ node):
+
+```text
+#SCRON -A <account>
+#SCRON -q shared
+#SCRON -C gpu
+#SCRON --gpus 1
+#SCRON -c 32
+#SCRON -t 00:40:00
+#SCRON -J abtem-gpu-tests
+#SCRON --mail-type=FAIL,TIMEOUT
+#SCRON --mail-user=<you@example.org>
+0 6 * * 1 ABTEM_CI_ROOT=$SCRATCH/abtem-gpu-ci ABTEM_CI_MODULES=cudatoolkit/12.9 ABTEM_CI_MAILTO=<you@example.org> $SCRATCH/abtem-gpu-ci/run_gpu_tests.sh
+```
+
+(Copy the script itself somewhere stable first — in managed mode it clones the repo, so it cannot run from inside the clone it manages. On Perlmutter, note that `/global/common` is read-only from compute nodes: keep `ABTEM_CI_ROOT` on `$SCRATCH`.)
+
+**Reusing an existing venv** (e.g. a dev machine where cupy is a custom ROCm build): `ABTEM_CI_VENV=<venv>` activates it and installs nothing; the checkout under test is put on `PYTHONPATH`, so an editable abtem install in that venv is never re-pointed.
+
+All knobs are documented in the header of `run_gpu_tests.sh`.
+
+## Toward CI integration
+
+The eventual proper solution is a GitHub Actions self-hosted runner on a GPU machine, wired into PR checks. Until such a machine is designated, this script is the bridge: scheduled runs on maintainers' hardware (a weekly Perlmutter A100 run and a weekly local ROCm run exist as of 2026-09), plus manual runs before merging GPU-touching changes.

--- a/tools/gpu/README.md
+++ b/tools/gpu/README.md
@@ -54,6 +54,8 @@ Example: weekly on NERSC Perlmutter via `scrontab -e` (times are local; `-q shar
 
 **Reusing an existing venv** (e.g. a dev machine where cupy is a custom ROCm build): `ABTEM_CI_VENV=<venv>` activates it and installs nothing; the checkout under test is put on `PYTHONPATH`, so an editable abtem install in that venv is never re-pointed.
 
+**Multi-GPU:** `ABTEM_CI_MULTIGPU=1` adds a third invocation running the `multigpu`-marked tests. They require ≥ 2 visible GPUs plus `dask-cuda` (and skip themselves otherwise), so on a cluster this means requesting at least a 2-GPU allocation (e.g. `--gpus 2` instead of `--gpus 1` in the scrontab resources).
+
 All knobs are documented in the header of `run_gpu_tests.sh`.
 
 ## Toward CI integration

--- a/tools/gpu/README.md
+++ b/tools/gpu/README.md
@@ -50,7 +50,7 @@ Example: weekly on NERSC Perlmutter via `scrontab -e` (times are local; `-q shar
 0 6 * * 1 ABTEM_CI_ROOT=$SCRATCH/abtem-gpu-ci ABTEM_CI_MODULES=cudatoolkit/12.9 ABTEM_CI_MAILTO=<you@example.org> $SCRATCH/abtem-gpu-ci/run_gpu_tests.sh
 ```
 
-(Copy the script itself somewhere stable first — in managed mode it clones the repo, so it cannot run from inside the clone it manages. On Perlmutter, note that `/global/common` is read-only from compute nodes: keep `ABTEM_CI_ROOT` on `$SCRATCH`.)
+(Copy the script itself somewhere stable first — in managed mode it clones the repo, so it cannot run from inside the clone it manages. Managed mode clones anonymously over HTTPS by default, since compute nodes often cannot use the SSH key that works on login nodes; set `ABTEM_CI_REPO_URL` for a private fork. On Perlmutter, note that `/global/common` is read-only from compute nodes: keep `ABTEM_CI_ROOT` on `$SCRATCH`.)
 
 **Reusing an existing venv** (e.g. a dev machine where cupy is a custom ROCm build): `ABTEM_CI_VENV=<venv>` activates it and installs nothing; the checkout under test is put on `PYTHONPATH`, so an editable abtem install in that venv is never re-pointed.
 

--- a/tools/gpu/run_gpu_tests.sh
+++ b/tools/gpu/run_gpu_tests.sh
@@ -37,6 +37,9 @@
 #                      "cudatoolkit/12.9" on NERSC Perlmutter (default: none)
 #   ABTEM_CI_MAILTO    address to email on failure; requires a working
 #                      mail/mailx/sendmail on the node (default: no mail)
+#   ABTEM_CI_MULTIGPU  set non-empty to also run the multigpu-marked tests;
+#                      they need >= 2 visible GPUs and dask-cuda and skip
+#                      themselves otherwise (default: off)
 #
 # Exit status is non-zero when either test invocation fails. Each run appends
 # one line to status.tsv in the log directory:
@@ -155,13 +158,25 @@ echo "== full GPU sweep =="
 python -m pytest test/ -q -p no:cacheprovider -k gpu -m "not multigpu"
 SWEEP_RC=$?
 
+MULTI_RC=0
+if [ -n "${ABTEM_CI_MULTIGPU:-}" ]; then
+    # the multigpu-marked tests skip themselves unless >= 2 GPUs and dask-cuda
+    # are present, so this invocation is safe on any machine; exit code 5
+    # (nothing collected) is treated as success
+    echo "== multi-GPU tests =="
+    python -m pytest test/ -q -p no:cacheprovider -m multigpu
+    MULTI_RC=$?
+    [ "${MULTI_RC}" -eq 5 ] && MULTI_RC=0
+fi
+
 SUMMARY="$(grep -E '[0-9]+ (passed|failed)' "${LOG}" | tail -1)"
-if [ "${STENCIL_RC}" -eq 0 ] && [ "${SWEEP_RC}" -eq 0 ]; then
+RCS="stencil_rc=${STENCIL_RC} sweep_rc=${SWEEP_RC} multigpu_rc=${MULTI_RC}"
+if [ "${STENCIL_RC}" -eq 0 ] && [ "${SWEEP_RC}" -eq 0 ] && [ "${MULTI_RC}" -eq 0 ]; then
     record PASS "${SUMMARY}"
     echo "== all green =="
 else
-    record FAIL "stencil_rc=${STENCIL_RC} sweep_rc=${SWEEP_RC}; ${SUMMARY}"
-    send_failure_mail "stencil_rc=${STENCIL_RC} sweep_rc=${SWEEP_RC}; ${SUMMARY}"
+    record FAIL "${RCS}; ${SUMMARY}"
+    send_failure_mail "${RCS}; ${SUMMARY}"
     echo "== FAILURES — see ${LOG} =="
     exit 1
 fi

--- a/tools/gpu/run_gpu_tests.sh
+++ b/tools/gpu/run_gpu_tests.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+# GPU test runner for abTEM.
+#
+# GitHub CI has no GPU runner, so the GPU code paths (CuPy kernels, their
+# NVRTC/hipRTC compilation, cupyx submodules) are validated by running this
+# script on a machine with a GPU. It performs the two invocations that define
+# "GPU-validated":
+#
+#   1. the Laplacian-stencil reference tests, which force-compile the raw GPU
+#      kernels and compare them against the scipy reference
+#   2. the full GPU-parameterized suite (excluding multi-GPU tests)
+#
+# Modes
+# -----
+# in-place (default):
+#     Tests the checkout this script lives in, using the active Python
+#     environment (or ABTEM_CI_VENV). Installs nothing, never touches git
+#     state. For developers: run it before merging changes to GPU code.
+#
+# managed (ABTEM_CI_ROOT set):
+#     Maintains its own clone and venv under ABTEM_CI_ROOT and hard-tracks
+#     origin/ABTEM_CI_BRANCH; refreshes dependencies on every run. For
+#     unattended use (cron / scrontab); self-heals if the clone or venv is
+#     deleted (e.g. by a scratch purge).
+#
+# Environment knobs
+# -----------------
+#   ABTEM_CI_ROOT      enable managed mode; working dir for clone/venv/logs
+#   ABTEM_CI_BRANCH    branch to test in managed mode (default: dev)
+#   ABTEM_CI_VENV      existing venv to activate; in managed mode this skips
+#                      venv creation and all installs and runs the clone via
+#                      PYTHONPATH (an editable install in that venv is never
+#                      re-pointed)
+#   ABTEM_CI_CUPY_PKG  cupy package for the managed venv (default: cupy-cuda12x;
+#                      irrelevant when ABTEM_CI_VENV is set)
+#   ABTEM_CI_MODULES   space-separated environment modules to load, e.g.
+#                      "cudatoolkit/12.9" on NERSC Perlmutter (default: none)
+#   ABTEM_CI_MAILTO    address to email on failure; requires a working
+#                      mail/mailx/sendmail on the node (default: no mail)
+#
+# Exit status is non-zero when either test invocation fails. Each run appends
+# one line to status.tsv in the log directory:
+#   date <tab> mode/branch <tab> commit <tab> PASS|FAIL <tab> summary <tab> log
+
+set -uo pipefail
+
+BRANCH="${ABTEM_CI_BRANCH:-dev}"
+STAMP="$(date -u +%Y-%m-%d_%H%M)"
+export OMP_NUM_THREADS=1
+
+if [ -n "${ABTEM_CI_ROOT:-}" ]; then
+    MODE="managed/${BRANCH}"
+    CI_ROOT="${ABTEM_CI_ROOT}"
+    REPO="${CI_ROOT}/abTEM"
+    LOGS="${CI_ROOT}/logs"
+else
+    MODE="in-place"
+    REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+    LOGS="${REPO}/.gpu-test-logs"
+fi
+STATUS="${LOGS}/status.tsv"
+mkdir -p "${LOGS}"
+LOG="${LOGS}/${STAMP}.log"
+exec > >(tee "${LOG}") 2>&1
+
+record() {
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "${STAMP}" "${MODE}" "${SHA:-unknown}" "$1" "$2" "${LOG}" >> "${STATUS}"
+}
+
+send_failure_mail() {
+    [ -n "${ABTEM_CI_MAILTO:-}" ] || return 0
+    local reason="$1"
+    local report="${LOGS}/${STAMP}.report.txt"
+    {
+        echo "abTEM GPU tests FAILED on $(hostname) (job ${SLURM_JOB_ID:-none})"
+        echo "date:    ${STAMP} (UTC)"
+        echo "mode:    ${MODE} @ ${SHA:-unknown}"
+        echo "reason:  ${reason}"
+        echo "log:     ${LOG}"
+        echo
+        echo "==== pytest short test summary (if any) ===="
+        sed -n '/short test summary info/,$p' "${LOG}" | head -60
+        echo
+        echo "==== last 150 log lines ===="
+        tail -150 "${LOG}"
+    } > "${report}"
+    local subject="[abtem-gpu-tests] FAIL ${MODE}@${SHA:-unknown} ${STAMP}"
+    if command -v mail >/dev/null 2>&1; then
+        mail -s "${subject}" "${ABTEM_CI_MAILTO}" < "${report}"
+    elif command -v mailx >/dev/null 2>&1; then
+        mailx -s "${subject}" "${ABTEM_CI_MAILTO}" < "${report}"
+    elif command -v sendmail >/dev/null 2>&1; then
+        { echo "To: ${ABTEM_CI_MAILTO}"; echo "Subject: ${subject}"; echo; cat "${report}"; } \
+            | sendmail -t
+    else
+        echo "WARNING: ABTEM_CI_MAILTO set but no mailer found; report at ${report}" >&2
+    fi
+}
+
+fail() { record FAIL "$1"; send_failure_mail "$1"; echo "FAILED: $1"; exit 1; }
+
+for m in ${ABTEM_CI_MODULES:-}; do
+    module load "$m" || fail "module load $m failed"
+done
+
+# --- repo --------------------------------------------------------------------
+if [ "${MODE}" != "in-place" ]; then
+    if [ ! -d "${REPO}/.git" ]; then
+        git clone --branch "${BRANCH}" git@github.com:abTEM/abTEM.git "${REPO}" \
+            || fail "git clone failed"
+    fi
+    cd "${REPO}"
+    git fetch origin "${BRANCH}" || fail "git fetch failed"
+    git checkout -q "${BRANCH}" && git reset --hard -q "origin/${BRANCH}" \
+        || fail "git checkout failed"
+else
+    cd "${REPO}"
+fi
+SHA="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+echo "== abTEM ${MODE} @ ${SHA} on $(hostname) =="
+
+# --- python environment ------------------------------------------------------
+if [ -n "${ABTEM_CI_VENV:-}" ]; then
+    [ -x "${ABTEM_CI_VENV}/bin/python" ] || fail "ABTEM_CI_VENV has no python"
+    source "${ABTEM_CI_VENV}/bin/activate"
+    export PYTHONPATH="${REPO}${PYTHONPATH:+:${PYTHONPATH}}"
+elif [ "${MODE}" != "in-place" ]; then
+    VENV="${CI_ROOT}/venv"
+    if [ ! -x "${VENV}/bin/python" ]; then
+        uv venv "${VENV}" || fail "uv venv failed"
+    fi
+    source "${VENV}/bin/activate"
+    uv pip install -e . --group test "${ABTEM_CI_CUPY_PKG:-cupy-cuda12x}" \
+        || fail "dependency install failed"
+fi
+# in-place without ABTEM_CI_VENV: use whatever python is active, but make sure
+# this checkout wins over any installed abtem
+[ "${MODE}" = "in-place" ] && export PYTHONPATH="${REPO}${PYTHONPATH:+:${PYTHONPATH}}"
+
+python - <<'EOF' || fail "sanity import failed"
+import abtem, cupy
+props = cupy.cuda.runtime.getDeviceProperties(0)
+print("abtem:", abtem.__file__)
+print("cupy:", cupy.__version__, "device:", props["name"].decode())
+EOF
+
+# --- the two runs ------------------------------------------------------------
+echo "== stencil reference tests =="
+python -m pytest test/test_realspace_multislice.py -q -p no:cacheprovider \
+    -k "StencilNumericalAccuracy or rejects"
+STENCIL_RC=$?
+
+echo "== full GPU sweep =="
+python -m pytest test/ -q -p no:cacheprovider -k gpu -m "not multigpu"
+SWEEP_RC=$?
+
+SUMMARY="$(grep -E '[0-9]+ (passed|failed)' "${LOG}" | tail -1)"
+if [ "${STENCIL_RC}" -eq 0 ] && [ "${SWEEP_RC}" -eq 0 ]; then
+    record PASS "${SUMMARY}"
+    echo "== all green =="
+else
+    record FAIL "stencil_rc=${STENCIL_RC} sweep_rc=${SWEEP_RC}; ${SUMMARY}"
+    send_failure_mail "stencil_rc=${STENCIL_RC} sweep_rc=${SWEEP_RC}; ${SUMMARY}"
+    echo "== FAILURES — see ${LOG} =="
+    exit 1
+fi

--- a/tools/gpu/run_gpu_tests.sh
+++ b/tools/gpu/run_gpu_tests.sh
@@ -40,6 +40,10 @@
 #   ABTEM_CI_MULTIGPU  set non-empty to also run the multigpu-marked tests;
 #                      they need >= 2 visible GPUs and dask-cuda and skip
 #                      themselves otherwise (default: off)
+#   ABTEM_CI_REPO_URL  clone URL for managed mode (default: anonymous HTTPS —
+#                      the runner only reads, and cluster compute nodes often
+#                      cannot use the SSH key that works on login nodes; set a
+#                      git@ URL for a private fork)
 #
 # Exit status is non-zero when either test invocation fails. Each run appends
 # one line to status.tsv in the log directory:
@@ -110,7 +114,8 @@ done
 # --- repo --------------------------------------------------------------------
 if [ "${MODE}" != "in-place" ]; then
     if [ ! -d "${REPO}/.git" ]; then
-        git clone --branch "${BRANCH}" git@github.com:abTEM/abTEM.git "${REPO}" \
+        git clone --branch "${BRANCH}" \
+            "${ABTEM_CI_REPO_URL:-https://github.com/abTEM/abTEM.git}" "${REPO}" \
             || fail "git clone failed"
     fi
     cd "${REPO}"


### PR DESCRIPTION
Adds `tools/gpu/` — a GPU test runner and a short document defining what "GPU-validated" means for abTEM.

Motivation: GitHub CI has no GPU runner, so GPU-only code paths escape it entirely. Two bugs entered the dev branch that way in September: the Thrust-backed sorts that segfault on some HIP builds (fixed in #376) and the raw-kernel compiler options that NVRTC rejects on CuPy 14 (caught by first-contact CUDA validation of #376, fixed in the follow-up). Both would have been caught by a routine GPU run of the suite — this PR turns that routine into a checked-in, documented procedure instead of tribal knowledge.

Contents:

- `tools/gpu/README.md` — defines GPU validation as two invocations (the stencil reference tests, which force-compile the raw kernels via NVRTC/hipRTC and compare against scipy; and the full `-k gpu` sweep), documents the dependency-group install, and notes that CUDA and ROCm have caught disjoint bugs so neither platform's pass implies the other's.
- `tools/gpu/run_gpu_tests.sh` — wraps both invocations with logging, a `status.tsv` history, and optional failure email. In-place mode tests the developer's current checkout with their active environment and installs nothing; managed mode (`ABTEM_CI_ROOT`) maintains its own clone and venv for unattended cron/scrontab use and self-heals after scratch purges. All site specifics (environment modules, cupy flavor, mail address, an external venv) are env-var knobs; the README includes a Perlmutter `scrontab` example.
- `.gitignore` entry for the in-place mode's log directory.

Validated by running both modes' logic on the two platforms currently doing scheduled runs: a Perlmutter A100 (CuPy 14.2.0, CUDA 12.9, managed mode via scrontab) and a ROCm 7.2 machine (amd-cupy 13.5.1, external-venv mode). Weekly scheduled runs on both have been active since 2026-09-10.

Deliberately out of scope: wiring GPU results into PR checks. The clean long-term solution is a GitHub Actions self-hosted runner on a designated GPU machine — flagging that as an open infrastructure question; this script is the bridge until then and remains useful for cluster runs after.

🤖 Written by [Claude Code](https://claude.com/claude-code) — Paul reviewed and posted it