### PR TITLE
Make wrapped_crop_2d total for any crop corner

### DIFF
--- a/abtem/prism/utils.py
+++ b/abtem/prism/utils.py
@@ -60,24 +60,72 @@ def minimum_crop(positions: np.ndarray, shape):
 
 
 def wrapped_slices(start: int, stop: int, n: int) -> Tuple[slice, slice]:
-    if start < 0:
-        if stop > n:
-            raise RuntimeError(f"start = {start} stop = {stop}, n = {n}")
+    """Two slices covering ``[start, stop)`` on a periodic axis of length ``n``.
 
-        a = slice(start % n, None)
-        b = slice(0, stop)
+    ``start`` may be any integer. Normalising it into ``[0, n)`` first leaves
+    only two cases -- the window fits, or it wraps once -- which is what two
+    slices can express.
 
-    elif stop > n:
-        if start < 0:
-            raise RuntimeError(f"start = {start} stop = {stop}, n = {n}")
+    The previous implementation assumed ``-n <= start < n`` and ``0 < stop <= 2n``
+    and split on the raw values. For a window lying entirely in negative indices
+    (``stop <= 0``) it produced ``slice(0, stop)``, which is Python's *negative
+    indexing* and selects ``n + stop`` elements rather than none, so the two
+    pieces concatenated to ``n + size`` elements instead of ``size``. The
+    mis-shaped array then surfaced as a broadcast error frames away from here.
 
-        a = slice(start, None)
-        b = slice(0, stop - n)
+    Raises
+    ------
+    RuntimeError
+        If ``stop - start > n``. Two slices cannot cover more than one period;
+        ``wrapped_crop_2d`` catches this and takes its general path.
+    """
+    size = stop - start
 
-    else:
-        a = slice(start, stop)
-        b = slice(0, 0)
-    return a, b
+    if size > n:
+        raise RuntimeError(
+            f"a window of {size} elements exceeds the period {n} and cannot be "
+            f"expressed as two slices (start = {start}, stop = {stop})"
+        )
+
+    start %= n
+    stop = start + size
+
+    if stop <= n:
+        return slice(start, stop), slice(0, 0)
+
+    return slice(start, None), slice(0, stop - n)
+
+
+def _wrapped_gather_2d(
+    array: np.ndarray, corner: Tuple[int, int], size: Tuple[int, int]
+) -> np.ndarray:
+    """``wrapped_crop_2d`` for windows wider than one period.
+
+    Gathers by modulo index, which is total for any corner and any size. It
+    copies through fancy indexing, so it is kept off the common path -- but it
+    is correct where the slice pair cannot be, and unlike the ``xp.pad(...,
+    mode="wrap")`` fallback it replaced, it does not fail for windows spanning
+    several periods.
+    """
+    xp = get_array_module(array)
+    i = (corner[0] + xp.arange(size[0])) % array.shape[-2]
+    j = (corner[1] + xp.arange(size[1])) % array.shape[-1]
+    return array[..., i[:, None], j[None, :]]
+
+
+def _check_crop_shape(cropped: np.ndarray, size: Tuple[int, int]) -> np.ndarray:
+    """Fail here rather than at a broadcast three frames downstream.
+
+    A wrongly sized crop used to reach the caller intact and only show up as an
+    operand-shape mismatch elsewhere. The check is a shape comparison, so it
+    costs nothing on the hot path, and it is a complete detector for this class
+    of defect: when the slice pair is wrong it is the shape that is wrong.
+    """
+    if cropped.shape[-2:] != tuple(size):
+        raise RuntimeError(
+            f"wrapped_crop_2d produced {cropped.shape[-2:]}, expected {tuple(size)}"
+        )
+    return cropped
 
 
 def wrapped_crop_2d(
@@ -91,17 +139,7 @@ def wrapped_crop_2d(
         a, c = wrapped_slices(corner[0], upper_corner[0], array.shape[-2])
         b, d = wrapped_slices(corner[1], upper_corner[1], array.shape[-1])
     except RuntimeError:
-        padding = tuple(
-            (abs(min(c, 0)), max(c + k - l, 0))
-            for c, l, k in zip(corner, array.shape[-2:], size)
-        )
-        slices = tuple(
-            slice(c + p[0], c + p[0] + l) for c, l, p in zip(corner, size, padding)
-        )
-        padding = ((0, 0),) * (len(array.shape) - 2) + padding
-        slices = (slice(None),) * (len(array.shape) - 2) + slices
-        array = xp.pad(array, padding, mode="wrap")[slices]
-        return array
+        return _wrapped_gather_2d(array, corner, size)
 
     A = array[..., a, b]
     B = array[..., c, b]
@@ -123,12 +161,14 @@ def wrapped_crop_2d(
         CD = xp.concatenate([C, D], axis=-2)
 
     if CD.size == 0:
-        return AB
+        return _check_crop_shape(AB, size)
 
     if AB.size == 0:
-        return CD
+        cropped = CD
+    else:
+        cropped = xp.concatenate([AB, CD], axis=-1)
 
-    return xp.concatenate([AB, CD], axis=-1)
+    return _check_crop_shape(cropped, size)
 
 
 def prism_wave_vectors(

--- a/test/test_prism.py
+++ b/test/test_prism.py
@@ -284,3 +284,86 @@ def test_prism_aberrated_ctf_matches_probe():
         np.squeeze(probe_intensity),
         atol=1e-5 * probe_intensity.max(),
     )
+
+
+class TestWrappedCrop2D:
+    """``wrapped_slices`` assumed ``-n <= start < n`` and ``0 < stop <= 2n``.
+
+    Outside that range it returned a wrongly shaped array instead of failing:
+    for a window entirely in negative indices, ``slice(0, stop)`` is Python's
+    negative indexing and selects ``n + stop`` rows rather than none. The crop
+    then reached the caller intact and surfaced as a broadcast error frames
+    away, in ``prism_transition_potential_scan``. Reachable from any model with
+    atoms far enough outside the cell.
+    """
+
+    @staticmethod
+    def _reference(array, corner, size):
+        """The crop by modulo index -- the definition of a periodic crop."""
+        i = (corner[0] + np.arange(size[0])) % array.shape[-2]
+        j = (corner[1] + np.arange(size[1])) % array.shape[-1]
+        return array[..., i[:, None], j[None, :]]
+
+    @pytest.mark.parametrize("n, size", [(192, 64), (17, 5), (8, 8)])
+    def test_every_corner_gives_the_right_shape_and_values(self, n, size):
+        from abtem.prism.utils import wrapped_crop_2d
+
+        rng = np.random.default_rng(0)
+        array = rng.standard_normal((2, n, n))
+        # Several periods either side: the old code was correct only in a
+        # narrow band around zero, and wrong by n + size rows outside it.
+        for corner in range(-3 * n, 3 * n):
+            got = wrapped_crop_2d(array, (corner, 0), (size, size))
+            assert got.shape == (2, size, size)
+            assert np.array_equal(got, self._reference(array, (corner, 0), (size, size)))
+
+    def test_both_axes_wrap_independently(self):
+        from abtem.prism.utils import wrapped_crop_2d
+
+        rng = np.random.default_rng(1)
+        array = rng.standard_normal((3, 24, 20))
+        for corner in [(-30, -25), (-5, 18), (23, -1), (47, 39), (-48, -40)]:
+            got = wrapped_crop_2d(array, corner, (7, 9))
+            assert got.shape == (3, 7, 9)
+            assert np.array_equal(got, self._reference(array, corner, (7, 9)))
+
+    @pytest.mark.parametrize("size", [16, 24, 32, 48])
+    def test_windows_wider_than_one_period(self, size):
+        """Two slices cannot express these; the general path must.
+
+        The old code was correct here only for corners in a narrow band around
+        zero -- e.g. n=16, corner=-23, size=24 came back as 8x8 -- so sweep the
+        corner rather than picking one.
+        """
+        from abtem.prism.utils import wrapped_crop_2d
+
+        n = 16
+        rng = np.random.default_rng(2)
+        array = rng.standard_normal((1, n, n))
+        for corner in range(-2 * n, 2 * n, 3):
+            got = wrapped_crop_2d(array, (corner, corner), (size, size))
+            assert got.shape == (1, size, size)
+            assert np.array_equal(
+                got, self._reference(array, (corner, corner), (size, size))
+            )
+
+    def test_wrapped_slices_refuses_more_than_one_period(self):
+        from abtem.prism.utils import wrapped_slices
+
+        with pytest.raises(RuntimeError, match="exceeds the period"):
+            wrapped_slices(0, 25, 24)
+
+    @pytest.mark.parametrize("device", ["cpu", gpu])
+    def test_matches_on_device(self, device):
+        from abtem.core.backend import copy_to_device
+        from abtem.prism.utils import wrapped_crop_2d
+
+        rng = np.random.default_rng(3)
+        array = rng.standard_normal((2, 32, 32))
+        for corner in [(-40, 7), (-9, -9), (70, -70)]:
+            got = wrapped_crop_2d(copy_to_device(array, device), corner, (11, 11))
+            assert_array_matches_device(got, device)
+            assert np.allclose(
+                np.asarray(copy_to_device(got, "cpu")),
+                self._reference(array, corner, (11, 11)),
+            )


### PR DESCRIPTION
## What

`wrapped_slices` assumed `-n <= start < n` and `0 < stop <= 2n` and split on the raw values. Outside that range it returned a wrongly shaped array rather than failing: for a window lying entirely in negative indices, `slice(0, stop)` with `stop <= 0` is Python's *negative indexing* and selects `n + stop` elements instead of none, so the two pieces concatenated to `n + size` elements.

At `n=192, size=64`, **479 of 800 consecutive corners came back with the wrong shape**:

```
contiguous bad ranges: [(-400, -257), (-192, -65), (193, 399)]
  corner -80 -> shape (1, 256, 64)   wrapped_slices(-80, -16, 192) = (slice(112, None), slice(0, -16))
```

Nothing checked the result, so the mis-shaped crop reached the caller intact and surfaced as

```
ValueError: operands could not be broadcast together with shapes (4,1,64,64) (1,51,256,64)
```

in `prism_transition_potential_scan`, three frames from the cause. Any model with atoms far enough outside the cell reaches it once the interpolation factor makes the crop window small enough — found on a 190-atom hBN model with x down to −3.64 Å.

## The fix

Normalise before splitting — `start %= n; stop = start + size` — which leaves only the two cases two slices can express: the window fits, or it wraps once. Verified against modulo indexing for **every** corner across several periods.

**Windows wider than one period.** Two slices cannot cover more than one period, so `wrapped_slices` now says so explicitly and `wrapped_crop_2d` takes a general path that gathers by modulo index. This replaces the `xp.pad(..., mode="wrap")` fallback, which was not merely opaque but **wrong**: `n=16, corner=-23, size=24` came back `8×8`, and windows spanning several periods raised a bare `ValueError`. The gather copies through fancy indexing, so it is kept off the common path — but it is correct where the slice pair cannot be, and it makes the function total for any corner and any size.

**Shape check on the way out.** Across all 800 corners there was no case of a correct shape carrying wrong values, so a shape comparison is a *complete* detector for this class of defect — and it costs nothing on the hot path. It turns a broadcast error three frames downstream into a failure at the crop.

## Tests

New `TestWrappedCrop2D` in `test/test_prism.py`: every corner across several periods gives the right shape and values for three `(n, size)` combinations; both axes wrap independently; windows wider than one period are correct across a swept corner; `wrapped_slices` refuses more than one period; CPU and GPU agree with the modulo-index reference.

All 11 fail on `dev` without the source change. Full suite: 1952 passed, 318 skipped.

A note on picking test parameters here, since it caught me out: the old code was correct in a narrow band around zero, so a single hand-picked corner can pass against it by luck. `corner=(5, -7)` does. The multi-period test sweeps the corner instead — 287 of the swept cases fail on `dev`.

## Interaction with open PRs

#338 adds four new `wrapped_crop_2d` call sites and #365 adds two; neither touches `wrapped_slices`. Both inherit the fix, and the new shape check will fail loudly at the crop rather than at a broadcast downstream.

🤖 Written by [Claude Code](https://claude.com/claude-code) — Paul reviewed and posted it